### PR TITLE
Fix delta validation, add request errors

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 import click
 from ib_insync import util
 from ib_insync.contract import ComboLeg, Contract, Option, Stock, TagValue
-from ib_insync.order import LimitOrder, Order
+from ib_insync.order import LimitOrder
 
 from thetagang.util import (
     account_summary_to_dict,
@@ -220,7 +220,7 @@ class PortfolioManager:
     def summarize_account(self):
         account_summary = self.ib.accountSummary(self.config["account"]["number"])
         click.echo()
-        click.secho(f"Account summary:", fg="green")
+        click.secho("Account summary:", fg="green")
         click.echo()
         account_summary = account_summary_to_dict(account_summary)
 
@@ -844,6 +844,7 @@ class PortfolioManager:
             return (
                 ticker.modelGreeks
                 and not util.isNan(ticker.modelGreeks.delta)
+                and ticker.modelGreeks.delta is not None
                 and abs(ticker.modelGreeks.delta)
                 <= get_target_delta(self.config, symbol, right)
             )

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -3,9 +3,8 @@
 import asyncio
 
 import click
-from ib_insync import IB, IBC, Index, Watchdog, util
-from ib_insync.contract import Contract, Stock
-from ib_insync.objects import Position
+from ib_insync import IB, IBC, Watchdog, util
+from ib_insync.contract import Contract
 
 from thetagang.config import normalize_config, validate_config
 from thetagang.util import get_strike_limit, get_target_delta
@@ -18,7 +17,7 @@ util.patchAsyncio()
 def start(config):
     import toml
 
-    import thetagang.config_defaults as config_defaults
+    import thetagang.config_defaults as config_defaults  # NOQA
 
     with open(config, "r") as f:
         config = toml.load(f)
@@ -27,10 +26,10 @@ def start(config):
 
     validate_config(config)
 
-    click.secho(f"Config:", fg="green")
+    click.secho("Config:", fg="green")
     click.echo()
 
-    click.secho(f"  Account details:", fg="green")
+    click.secho("  Account details:", fg="green")
     click.secho(
         f"    Number                   = {config['account']['number']}", fg="cyan"
     )
@@ -48,7 +47,7 @@ def start(config):
     )
     click.echo()
 
-    click.secho(f"  Roll options when either condition is true:", fg="green")
+    click.secho("  Roll options when either condition is true:", fg="green")
     click.secho(
         f"    Days to expiry          <= {config['roll_when']['dte']} and P&L >= {config['roll_when']['min_pnl']} ({config['roll_when']['min_pnl'] * 100}%)",
         fg="cyan",
@@ -59,7 +58,7 @@ def start(config):
     )
 
     click.echo()
-    click.secho(f"  When contracts are ITM:", fg="green")
+    click.secho("  When contracts are ITM:", fg="green")
     click.secho(
         f"    Roll puts               = {config['roll_when']['puts']['itm']}",
         fg="cyan",
@@ -70,7 +69,7 @@ def start(config):
     )
 
     click.echo()
-    click.secho(f"  Write options with targets of:", fg="green")
+    click.secho("  Write options with targets of:", fg="green")
     click.secho(f"    Days to expiry          >= {config['target']['dte']}", fg="cyan")
     click.secho(
         f"    Default delta           <= {config['target']['delta']}", fg="cyan"
@@ -95,7 +94,7 @@ def start(config):
     )
 
     click.echo()
-    click.secho(f"  Symbols:", fg="green")
+    click.secho("  Symbols:", fg="green")
     for s in config["symbols"].keys():
         c = config["symbols"][s]
         c_delta = f"{get_target_delta(config, s, 'C'):.2f}".rjust(4)
@@ -128,6 +127,7 @@ def start(config):
         portfolio_manager.manage()
 
     ib = IB()
+    ib.RaiseRequestErrors = True
     ib.connectedEvent += onConnected
 
     completion_future = asyncio.Future()


### PR DESCRIPTION
If thetagang gets a timeout from ib_insync when fetching portfolio
positions, it proceeds as if nothing happened. It loads the config
file, but without knowing the portfolio positions, it starts to
write puts instead of writing/rolling calls.

I also removed unused imports from the files I touched.

----

Adding more context to the commit message above. The delta validation fix is straightforward, please find the traceback below:
```
2021-08-06 06:51:09,066 eventkit.event ERROR Value () caused exception for event Event<connectedEvent, [[None, None, <function start.<locals>.onConnected at 0x10fccaf70>]]>
Traceback (most recent call last):
  File "/[redacted]/Library/Caches/pypoetry/virtualenvs/thetagang-4tNXOOtf-py3.8/lib/python3.8/site-packages/eventkit/event.py", line 186, in emit
    result = func(*args)
  File "/[redacted]/dev/thetagang/thetagang/thetagang.py", line 128, in onConnected
    portfolio_manager.manage()
  File "/[redacted]/dev/thetagang/thetagang/portfolio_manager.py", line 380, in manage
    self.check_calls(portfolio_positions)
  File "/[redacted]/dev/thetagang/thetagang/portfolio_manager.py", line 439, in check_calls
    self.roll_calls(rollable_calls, portfolio_positions)
  File "/[redacted]/dev/thetagang/thetagang/portfolio_manager.py", line 659, in roll_calls
    return self.roll_positions(calls, "C", portfolio_positions)
  File "/[redacted]/dev/thetagang/thetagang/portfolio_manager.py", line 677, in roll_positions
    sell_ticker = self.find_eligible_contracts(
  File "/[redacted]/dev/thetagang/thetagang/portfolio_manager.py", line 859, in find_eligible_contracts
    tickers = [ticker for ticker in tickers if delta_is_valid(ticker)]
  File "/[redacted]/dev/thetagang/thetagang/portfolio_manager.py", line 859, in <listcomp>
    tickers = [ticker for ticker in tickers if delta_is_valid(ticker)]
  File "/[redacted]/dev/thetagang/thetagang/portfolio_manager.py", line 847, in delta_is_valid
    and abs(ticker.modelGreeks.delta)
TypeError: bad operand type for abs(): 'NoneType'
```

The timout is more interesting, and I'm not entirely sure if the attribute I set on the instance of [IB](https://ib-insync.readthedocs.io/api.html#ib_insync.ib.IB.RaiseRequestErrors) class fixes the problem. The timeout was thrown by ib_insync when fetching my portfolio positions. All I have is this log line:
```
2021-07-29 06:46:21,313 ib_insync.ib ERROR account updates request timed out
2021-07-29 06:46:21,317 ib_insync.ib INFO Synchronization complete
```
After the timeout exception, thetagang proceeded as if nothing happened. That creates a problem: thetagang loaded the config file, but didn't know which positions I had in the portfolio, so instead of rolling/writing calls for those positions, it started to write puts.