### PR TITLE
add option to run without IBC

### DIFF
--- a/thetagang/main.py
+++ b/thetagang/main.py
@@ -22,7 +22,8 @@ CONTEXT_SETTINGS = dict(
     default="thetagang.toml",
     type=click.Path(exists=True, readable=True),
 )
-def cli(config):
+@click.option('--noibc', is_flag=True, help="Run without IBC")
+def cli(config, noibc):
     """ThetaGang is an IBKR bot for collecting money.
 
     You can configure this tool by supplying a toml configuration file.
@@ -32,4 +33,4 @@ def cli(config):
 
     from .thetagang import start
 
-    start(config)
+    start(config, noibc)

--- a/thetagang/main.py
+++ b/thetagang/main.py
@@ -22,8 +22,8 @@ CONTEXT_SETTINGS = dict(
     default="thetagang.toml",
     type=click.Path(exists=True, readable=True),
 )
-@click.option('--noibc', is_flag=True, help="Run without IBC")
-def cli(config, noibc):
+@click.option('--without-ibc', is_flag=True, help="Run without IBC")
+def cli(config, without_ibc):
     """ThetaGang is an IBKR bot for collecting money.
 
     You can configure this tool by supplying a toml configuration file.
@@ -33,4 +33,4 @@ def cli(config, noibc):
 
     from .thetagang import start
 
-    start(config, noibc)
+    start(config, without_ibc)

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -14,7 +14,7 @@ from .portfolio_manager import PortfolioManager
 util.patchAsyncio()
 
 
-def start(config, noibc=False):
+def start(config, without_ibc=False):
     import toml
 
     import thetagang.config_defaults as config_defaults  # NOQA
@@ -156,7 +156,7 @@ def start(config, noibc=False):
     if config.get("ib_insync", {}).get("logfile"):
         util.logToFile(config["ib_insync"]["logfile"])
 
-    if not noibc:
+    if not without_ibc:
         # TWS version is pinned to current stable
         ibc_config = config.get("ibc", {})
         # Remove any config params that aren't valid keywords for IBC
@@ -170,7 +170,7 @@ def start(config, noibc=False):
         portfolio_manager.manage()
 
     ib = IB()
-    if not noibc:
+    if not without_ibc:
         ib.RaiseRequestErrors = ibc_config.get("RaiseRequestErrors", False)
     ib.connectedEvent += onConnected
 
@@ -187,7 +187,7 @@ def start(config, noibc=False):
         exchange=probeContractConfig["exchange"],
     )
 
-    if not noibc:
+    if not without_ibc:
         watchdog = Watchdog(ibc,
                             ib,
                             probeContract=probeContract,
@@ -199,7 +199,7 @@ def start(config, noibc=False):
                    clientId=watchdogConfig['clientId'],
                    timeout=watchdogConfig['probeTimeout'])
     ib.run(completion_future)
-    if not noibc:
+    if not without_ibc:
         watchdog.stop()
         ibc.terminate()
     else:

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -14,7 +14,7 @@ from .portfolio_manager import PortfolioManager
 util.patchAsyncio()
 
 
-def start(config, use_ibc=True):
+def start(config, noibc=False):
     import toml
 
     import thetagang.config_defaults as config_defaults  # NOQA
@@ -156,7 +156,7 @@ def start(config, use_ibc=True):
     if config.get("ib_insync", {}).get("logfile"):
         util.logToFile(config["ib_insync"]["logfile"])
 
-    if use_ibc:
+    if not noibc:
         # TWS version is pinned to current stable
         ibc_config = config.get("ibc", {})
         # Remove any config params that aren't valid keywords for IBC
@@ -170,7 +170,7 @@ def start(config, use_ibc=True):
         portfolio_manager.manage()
 
     ib = IB()
-    if use_ibc:
+    if not noibc:
         ib.RaiseRequestErrors = ibc_config.get("RaiseRequestErrors", False)
     ib.connectedEvent += onConnected
 
@@ -187,7 +187,7 @@ def start(config, use_ibc=True):
         exchange=probeContractConfig["exchange"],
     )
 
-    if use_ibc:
+    if not noibc:
         watchdog = Watchdog(ibc,
                             ib,
                             probeContract=probeContract,
@@ -199,7 +199,7 @@ def start(config, use_ibc=True):
                    clientId=watchdogConfig['clientId'],
                    timeout=watchdogConfig['probeTimeout'])
     ib.run(completion_future)
-    if use_ibc:
+    if not noibc:
         watchdog.stop()
         ibc.terminate()
     else:


### PR DESCRIPTION
launching another TWS/gateway can be expensive if there is already an instance running. 
we need an option to use existing IBC, or TWS/gateway session. This also helps to run without thetagang docker.