### PR TITLE
Better handling for ITM rolling with credit_only

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -613,6 +613,17 @@ files = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "9.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "more-itertools-9.1.0.tar.gz", hash = "sha256:cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d"},
+    {file = "more_itertools-9.1.0-py3-none-any.whl", hash = "sha256:d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3"},
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1041,4 +1052,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "fc4b5eceff58990bf76a4ece67717e35600ae4d91efdeceb12b4ad5568dab5e7"
+content-hash = "cfb7b13b73480ebdfa737797c736f41e27692e3dc7936fee8aba0021a27d2d8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ pytimeparse = "^1.1.8"
 schema = "^0.7.5"
 toml = "^0.10.2"
 rich = "^13.3.5"
+more-itertools = "^9.1.0"
 
 [tool.poetry.group.dev.dependencies]
 autoflake = "^2.0"

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -102,7 +102,10 @@ min_pnl = 0.0
 itm = true
 
 # Only roll when there's a suitable contract available that will result in a
-# credit.
+# credit. Enabling this may result in the target delta value being ignored in
+# circumstances where we can't find a contract that will result in both a
+# credit _and_ satisfying the target delta (i.e., having a credit takes
+# precedence).
 credit_only = false
 
 # If set to false, calls will not be rolled if there are any number of calls in
@@ -115,7 +118,10 @@ has_excess = true
 itm = false
 
 # Only roll when there's a suitable contract available that will result in a
-# credit.
+# credit. Enabling this may result in the target delta value being ignored in
+# circumstances where we can't find a contract that will result in both a
+# credit _and_ satisfying the target delta (i.e., having a credit takes
+# precedence).
 credit_only = false
 
 # If set to false, puts will not be rolled if there are any number of puts in


### PR DESCRIPTION
When `credit_only = true`, we sometimes do a poor job of selecting a reasonable contract because we can't satisfy the requirement for both a credit and the target delta.

This relaxes the target delta limitation in such cases.