### PR TITLE
Price update: adjust prices after submission

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -39,6 +39,10 @@ market_data_type = 1
 # used for fetching tickers/prices.
 exchange = "SMART"
 
+# Range of time to delay, in seconds, before resubmitting an order with updated
+# midpoint price if `symbol.<symbol>.adjust_midpoint_after_delay = true`.
+price_update_delay = [30, 60]
+
 [orders.algo]
 # By default we use adaptive orders with patient priority which gives reasonable
 # results. You can also experiment with TWAP or other options, however the
@@ -195,6 +199,15 @@ weight = 0.4
 # OR: specify in terms of parts. Must use either weight or parts, but cannot mix
 # both.
 # parts = 40
+
+# Sometimes, particularly for stocks/ETFs with limited liquidity, the spreads
+# are too wide to get an order filled at the midpoint on the first attempt. For
+# those, you can try setting this to `true`, and thetagang will wait a random
+# amount of time, then resubmit orders that haven't filled (but only for the
+# symbols with this set to true). The amount of time we'll wait is chosen
+# randomly from the range defined by `orders.price_update_delay`.
+adjust_price_after_delay = false
+
 [symbols.QQQ]
 weight = 0.3
 

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -81,8 +81,9 @@ def validate_config(config):
                 "market_data_type": And(int, lambda n: 1 <= n <= 4),
             },
             "orders": {
-                "exchange": And(str, len),
-                "algo": algo_settings,
+                Optional("exchange"): And(str, len),
+                Optional("algo"): algo_settings,
+                Optional("price_update_delay"): And([int], lambda p: len(p) == 2),
             },
             "option_chains": {
                 "expirations": And(int, lambda n: 1 <= n),
@@ -148,6 +149,7 @@ def validate_config(config):
                         Optional("write_threshold"): And(float, lambda n: 0 <= n <= 1),
                         Optional("strike_limit"): And(float, lambda n: n > 0),
                     },
+                    Optional("adjust_price_after_delay"): bool,
                 }
             },
             Optional("ib_insync"): {

--- a/thetagang/config_defaults.py
+++ b/thetagang/config_defaults.py
@@ -4,6 +4,7 @@ DEFAULT_CONFIG = {
     },
     "orders": {
         "exchange": "SMART",
+        "price_update_delay": [30, 60],
         "algo": {
             "strategy": "Adaptive",
             "params": [["adaptivePriority", "Patient"]],

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1894,8 +1894,8 @@ class PortfolioManager:
             self.ib.sleep(1)
 
         unfilled = [
-            trade
-            for trade in self.trades
+            (idx, trade)
+            for idx, trade in enumerate(self.trades)
             if trade
             and trade.contract.symbol in self.config["symbols"]
             and self.config["symbols"][trade.contract.symbol].get(
@@ -1903,7 +1903,7 @@ class PortfolioManager:
             )
             and not trade.isDone()
         ]
-        for trade in unfilled:
+        for idx, trade in unfilled:
             try:
                 (
                     contract,
@@ -1927,7 +1927,8 @@ class PortfolioManager:
                     order.algoStrategy = self.get_algo_strategy()
                     order.algoParams = self.get_algo_params()
 
-                    self.ib.placeOrder(contract, order)
+                    # put the trade back from whence it came
+                    self.trades[idx] = self.ib.placeOrder(contract, order)
             except RuntimeError:
                 console.print_exception()
 


### PR DESCRIPTION
Sometimes the spreads are too wide on certain contracts, so we don't get fills unless the price is adjusted after the order is submitted and the spreads get less wide. The simplest fix is to just reset the price to the midpoint again after submitting the order, although this 1) doesn't always guarantee the order will fill and 2) may occasionally result in less than ideal fills, but usually you still get an improvement over the bid or ask price, provided it moves in the right direction.