### PR TITLE
Add basic VIX call ladder-ing

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -312,6 +312,12 @@ delta = 0.30
 # closed. Comment out to disable.
 close_hedges_when_vix_exceeds = 50.0
 
+# Don't count any VIX positions where the DTE is <= this value. Increase this
+# value to create a call ladder. For example, if you set this to 5, thetagang
+# will ignore current VIX positions starting 5 days before expiry, and
+# potentially adding more. This allows you to create a simple call ladder.
+ignore_dte = 0
+
 # The allocations are specified as an ordered list of allocation weights
 # according to an upper/lower bound on VIXMO (the 30 day VIX). Default values
 # are the same as those described in the VXTH methodology. These are evaluated

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -308,6 +308,8 @@ symbol = 'SPY'
 enabled = false
 # Target delta for calls that are purchased
 delta = 0.30
+# Target DTE for new positions
+target_dte = 30
 # If the current spot VIX exceeds this value, long VIX call positions will be
 # closed. Comment out to disable.
 close_hedges_when_vix_exceeds = 50.0

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -192,6 +192,7 @@ def validate_config(config):
             Optional("vix_call_hedge"): {
                 "enabled": bool,
                 Optional("delta"): And(float, lambda n: 0 <= n <= 1),
+                Optional("target_dte"): And(int, lambda n: n > 0),
                 Optional("close_hedges_when_vix_exceeds"): float,
                 Optional("ignore_dte"): And(int, lambda n: n >= 0),
                 Optional("allocation"): [

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -193,6 +193,7 @@ def validate_config(config):
                 "enabled": bool,
                 Optional("delta"): And(float, lambda n: 0 <= n <= 1),
                 Optional("close_hedges_when_vix_exceeds"): float,
+                Optional("ignore_dte"): And(int, lambda n: n >= 0),
                 Optional("allocation"): [
                     {
                         Optional("lower_bound"): float,

--- a/thetagang/config_defaults.py
+++ b/thetagang/config_defaults.py
@@ -30,6 +30,7 @@ DEFAULT_CONFIG = {
     "vix_call_hedge": {
         "enabled": False,
         "delta": 0.3,
+        "target_dte": 30,
         "ignore_dte": 0,
         "allocation": [
             {"upper_bound": 15.0, "weight": 0.0},

--- a/thetagang/config_defaults.py
+++ b/thetagang/config_defaults.py
@@ -30,6 +30,7 @@ DEFAULT_CONFIG = {
     "vix_call_hedge": {
         "enabled": False,
         "delta": 0.3,
+        "ignore_dte": 0,
         "allocation": [
             {"upper_bound": 15.0, "weight": 0.0},
             {"lower_bound": 15.0, "upper_bound": 30.0, "weight": 0.01},

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1564,15 +1564,18 @@ class PortfolioManager:
                     return (False, vix_ticker, close_hedges_when_vix_exceeds)
                 return (False, None, None)
 
+            ignore_dte = self.config["vix_call_hedge"]["ignore_dte"]
+
             with console.status(
                 "[bold blue_violet]Checking on our VIX call hedge..."
             ) as status:
                 net_vix_call_count = net_option_positions(
-                    "VIX", portfolio_positions, "C", ignore_zero_dte=True
+                    "VIX", portfolio_positions, "C", ignore_dte=ignore_dte
                 )
                 if net_vix_call_count > 0:
                     status.update(
-                        f"[bold blue_violet]net_vix_call_count={net_vix_call_count} (0dte contracts ignored), "
+                        f"[bold blue_violet]net_vix_call_count={net_vix_call_count} "
+                        f"(DTE <= {ignore_dte} contracts ignored), "
                         "checking if we need to close positions...",
                     )
                     (
@@ -1625,10 +1628,10 @@ class PortfolioManager:
                         f"[cyan1]net_vix_call_count={net_vix_call_count}, no action is needed at this time",
                     )
                     return
-                else:
-                    status.update(
-                        f"[bold blue_violet]net_vix_call_count={net_vix_call_count}, checking if we should open new positions...",
-                    )
+
+                status.update(
+                    f"[bold blue_violet]net_vix_call_count={net_vix_call_count}, checking if we should open new positions...",
+                )
 
                 (
                     close_vix_calls,

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1681,10 +1681,12 @@ class PortfolioManager:
                             float(account_summary["NetLiquidation"].value) * weight
                         )
                         delta = self.config["vix_call_hedge"]["delta"]
+                        target_dte = self.config["vix_call_hedge"]["target_dte"]
                         if weight > 0:
                             to_print.append(
                                 f"[green]Current VIXMO spot price prescribes an allocation of up to "
-                                f"${allocation_amount:.2f} for purchasing VIX calls, at or above delta={delta} with a DTE >= 30",
+                                f"${allocation_amount:.2f} for purchasing VIX calls, "
+                                f"at or above delta={delta} with a DTE >= {target_dte}",
                             )
                         else:
                             to_print.append(
@@ -1701,7 +1703,11 @@ class PortfolioManager:
 
                         status.stop()
                         buy_ticker = self.find_eligible_contracts(
-                            vix_contract, "C", 0, target_delta=delta, target_dte=30
+                            vix_contract,
+                            "C",
+                            0,
+                            target_delta=delta,
+                            target_dte=target_dte,
                         )
                         status.start()
                         price = round(get_lower_price(buy_ticker), 2)

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -62,7 +62,7 @@ def count_long_option_positions(symbol, portfolio_positions, right):
     return 0
 
 
-def net_option_positions(symbol, portfolio_positions, right, ignore_zero_dte=False):
+def net_option_positions(symbol, portfolio_positions, right, ignore_dte=None):
     if symbol in portfolio_positions:
         return math.floor(
             sum(
@@ -73,8 +73,9 @@ def net_option_positions(symbol, portfolio_positions, right, ignore_zero_dte=Fal
                     and p.contract.right.upper().startswith(right.upper())
                     and option_dte(p.contract.lastTradeDateOrContractMonth) >= 0
                     and (
-                        not ignore_zero_dte
-                        or option_dte(p.contract.lastTradeDateOrContractMonth) > 0
+                        not ignore_dte
+                        or option_dte(p.contract.lastTradeDateOrContractMonth)
+                        > ignore_dte
                     )
                 ]
             )


### PR DESCRIPTION
If you set `vix_call_hedge.ignore_dte` to a value > 0, you can construct a basic call ladder by ignoring open positions as they approach expiry.