### PR TITLE
Threshold config: constant defaults

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -40,6 +40,20 @@ market_data_type = 1
 # Valid values include "30 D", "60 D", "6 M", "1 Y", etc.
 daily_stddev_window = "30 D"
 
+# Optionally, specify a write threshold either as percent, or sigma, either for
+# all contracts, or separately for puts/calls. Refer to the comments for
+# `write_threshold` and `write_threshold_sigma` under `symbols` for details.
+#
+# # Applies to both puts and calls
+# write_threshold = 0.01 # 1%
+# write_threshold_sigma = 1.0 # 1𝜎
+# [puts] # Applies only to puts
+# write_threshold = 0.01 # 1%
+# write_threshold_sigma = 1.0 # 1𝜎
+# [calls] # Applies only to calls
+# write_threshold = 0.01 # 1%
+# write_threshold_sigma = 1.0 # 1𝜎
+
 [orders]
 # The exchange to route orders to. Can be overridden if desired. This is also
 # used for fetching tickers/prices.
@@ -229,7 +243,9 @@ strike_limit = 1000.0 # never write a put with a strike above $1000
 # red (`write_when.calls.green=true` or `write_when.puts.red=true`), specify a
 # minimum threshold as an absolute value daily percentage change (in this
 # example, use 1% for puts only, but could also be specified as
-# `symbols.QQQ.write_threshold`).
+# `symbols.QQQ.write_threshold`). This can also be specified under
+# `constants.write_threshold` and `constants.puts/calls.write_threshold` to
+# apply to all symbols, either for both puts or calls, or individually.
 #
 # In this example, we'd only write puts on QQQ when the daily change is -1% or
 # greater (provided that we also set `write_when.puts.red=true`).

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -221,6 +221,16 @@ def validate_config(config):
             },
             Optional("constants"): {
                 Optional("daily_stddev_window"): And(str, len),
+                Optional("write_threshold"): And(float, lambda n: 0 <= n <= 1),
+                Optional("write_threshold_sigma"): And(float, lambda n: n > 0),
+                Optional("calls"): {
+                    Optional("write_threshold"): And(float, lambda n: 0 <= n <= 1),
+                    Optional("write_threshold_sigma"): And(float, lambda n: n > 0),
+                },
+                Optional("puts"): {
+                    Optional("write_threshold"): And(float, lambda n: 0 <= n <= 1),
+                    Optional("write_threshold_sigma"): And(float, lambda n: n > 0),
+                },
             },
         }
     )

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -66,6 +66,20 @@ def start(config_path, without_ibc=False):
         f"{config['constants']['daily_stddev_window']}",
     )
 
+    c_write_thresh = (
+        f"{ffmt(get_write_threshold_sigma(config, None, 'C'))}σ"
+        if get_write_threshold_sigma(config, None, "C")
+        else pfmt(get_write_threshold_perc(config, None, "C"))
+    )
+    p_write_thresh = (
+        f"{ffmt(get_write_threshold_sigma(config, None, 'P'))}σ"
+        if get_write_threshold_sigma(config, None, "P")
+        else pfmt(get_write_threshold_perc(config, None, "P"))
+    )
+
+    config_table.add_row("", "Write threshold for puts", "=", p_write_thresh)
+    config_table.add_row("", "Write threshold for calls", "=", c_write_thresh)
+
     config_table.add_section()
     config_table.add_row("[spring_green1]Order settings")
     config_table.add_row(

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -166,27 +166,56 @@ def get_call_cap(config):
     return 1.0
 
 
-def get_write_threshold_sigma(config: dict, symbol: str, right: str) -> Optional[float]:
+def get_write_threshold_sigma(
+    config: dict, symbol: str | None, right: str
+) -> Optional[float]:
     p_or_c = "calls" if right.upper().startswith("C") else "puts"
+    if symbol:
+        if (
+            p_or_c in config["symbols"][symbol]
+            and "write_threshold_sigma" in config["symbols"][symbol][p_or_c]
+        ):
+            return config["symbols"][symbol][p_or_c]["write_threshold_sigma"]
+        if "write_threshold_sigma" in config["symbols"][symbol]:
+            return config["symbols"][symbol]["write_threshold_sigma"]
+        # if there's a percentage-based threshold defined, we want to use that, so we return None here
+        if (
+            p_or_c in config["symbols"][symbol]
+            and "write_threshold" in config["symbols"][symbol][p_or_c]
+        ) or "write_threshold" in config["symbols"][symbol]:
+            return None
+
+    # check if there's a default value in constants
     if (
-        p_or_c in config["symbols"][symbol]
-        and "write_threshold_sigma" in config["symbols"][symbol][p_or_c]
+        p_or_c in config["constants"]
+        and "write_threshold_sigma" in config["constants"][p_or_c]
     ):
-        return config["symbols"][symbol][p_or_c]["write_threshold_sigma"]
-    if "write_threshold_sigma" in config["symbols"][symbol]:
-        return config["symbols"][symbol]["write_threshold_sigma"]
+        return config["constants"][p_or_c]["write_threshold_sigma"]
+    if "write_threshold_sigma" in config["constants"]:
+        return config["constants"]["write_threshold_sigma"]
+
     return None
 
 
-def get_write_threshold_perc(config: dict, symbol: str, right: str) -> float:
+def get_write_threshold_perc(config: dict, symbol: str | None, right: str) -> float:
     p_or_c = "calls" if right.upper().startswith("C") else "puts"
+    if symbol:
+        if (
+            p_or_c in config["symbols"][symbol]
+            and "write_threshold" in config["symbols"][symbol][p_or_c]
+        ):
+            return config["symbols"][symbol][p_or_c]["write_threshold"]
+        if "write_threshold" in config["symbols"][symbol]:
+            return config["symbols"][symbol]["write_threshold"]
+
+    # check if there's a default value in constants
     if (
-        p_or_c in config["symbols"][symbol]
-        and "write_threshold" in config["symbols"][symbol][p_or_c]
+        p_or_c in config["constants"]
+        and "write_threshold" in config["constants"][p_or_c]
     ):
-        return config["symbols"][symbol][p_or_c]["write_threshold"]
-    if "write_threshold" in config["symbols"][symbol]:
-        return config["symbols"][symbol]["write_threshold"]
+        return config["constants"][p_or_c]["write_threshold"]
+    if "write_threshold" in config["constants"]:
+        return config["constants"]["write_threshold"]
     return 0.0
 
 

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -167,7 +167,7 @@ def get_call_cap(config):
 
 
 def get_write_threshold_sigma(
-    config: dict, symbol: str | None, right: str
+    config: dict, symbol: Optional[str], right: str
 ) -> Optional[float]:
     p_or_c = "calls" if right.upper().startswith("C") else "puts"
     if symbol:
@@ -197,7 +197,7 @@ def get_write_threshold_sigma(
     return None
 
 
-def get_write_threshold_perc(config: dict, symbol: str | None, right: str) -> float:
+def get_write_threshold_perc(config: dict, symbol: Optional[str], right: str) -> float:
     p_or_c = "calls" if right.upper().startswith("C") else "puts"
     if symbol:
         if (


### PR DESCRIPTION
You can specify the writing threshold for all symbols and by contract right with:

 * `constants.write_threshold`
 * `constants.write_threshold_sigma`
 * `constants.calls.write_threshold`
 * `constants.calls.write_threshold_sigma`
 * `constants.puts.write_threshold`
 * `constants.puts.write_threshold_sigma`