### PR TITLE
Cap calls to set a floor on shares

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -159,6 +159,18 @@ green = true
 # on 50% of our positions. This value must be between 1 and 0 inclusive.
 cap_factor = 1.0
 
+# We may want to leave some percentage of our underlying stock perpetually
+# uncovered so we don't miss out on big upside movements. For example, if our
+# target number of shares for a given symbol is 1,000, we may want to ensure
+# 500 shares are _always_ uncovered. This is a bit different from `cap_factor`,
+# as it applies to the _target_ number of shares, as opposed to the current
+# positions. A value of 0.5 (50%) means that we always leave 50% (half) of the
+# target shares uncovered. A bigger number (up to 1.0, 100%) is more bullish,
+# and a smaller number (down to 0.0, 0%) is more bearish (i.e., cover all
+# positions with calls). This essentially sets a floor on the number of shares
+# we try to hold on to in order to avoid missing out on potential upside.
+cap_target_floor = 0.0
+
 [write_when.puts]
 # Optionally, only write puts when the underlying is red
 red = true

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -93,6 +93,7 @@ def validate_config(config):
                 Optional("calls"): {
                     Optional("green"): bool,
                     Optional("cap_factor"): And(float, lambda n: 0 <= n <= 1),
+                    Optional("cap_target_floor"): And(float, lambda n: 0 <= n <= 1),
                 },
                 Optional("puts"): {
                     Optional("red"): bool,

--- a/thetagang/config_defaults.py
+++ b/thetagang/config_defaults.py
@@ -19,6 +19,7 @@ DEFAULT_CONFIG = {
         "calls": {
             "green": False,
             "cap_factor": 1.0,
+            "cap_target_floor": 0.0,
         },
     },
     "roll_when": {

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -153,16 +153,16 @@ def start(config_path, without_ibc=False):
     )
 
     config_table.add_section()
-    config_table.add_row("[spring_green1]For underlying, only write new contracts when")
+    config_table.add_row("[spring_green1]When writing new contracts")
     config_table.add_row(
         "",
-        "Puts, red",
+        "Puts, only write when red",
         "=",
         f"{config['write_when']['puts']['red']}",
     )
     config_table.add_row(
         "",
-        "Calls, green",
+        "Calls, only write when green",
         "=",
         f"{config['write_when']['calls']['green']}",
     )
@@ -170,7 +170,13 @@ def start(config_path, without_ibc=False):
         "",
         "Call cap factor",
         "=",
-        f"{config['write_when']['calls']['cap_factor']}",
+        f"{pfmt(config['write_when']['calls']['cap_factor'])}",
+    )
+    config_table.add_row(
+        "",
+        "Call cap target floor",
+        "=",
+        f"{pfmt(config['write_when']['calls']['cap_target_floor'])}",
     )
 
     config_table.add_section()

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -156,14 +156,14 @@ def get_strike_limit(config, symbol, right):
     return None
 
 
-def get_call_cap(config):
-    if (
-        "write_when" in config
-        and "calls" in config["write_when"]
-        and "cap_factor" in config["write_when"]["calls"]
-    ):
-        return max([0, min([1.0, config["write_when"]["calls"]["cap_factor"]])])
-    return 1.0
+def get_target_calls(config: dict, current_shares: int, target_shares: int) -> int:
+    cap_factor = config["write_when"]["calls"]["cap_factor"]
+    cap_target_floor = config["write_when"]["calls"]["cap_target_floor"]
+    min_uncovered = (target_shares * cap_target_floor) // 100
+    max_covered = (current_shares * cap_factor) // 100
+    total_coverable = current_shares // 100
+
+    return max([0, math.floor(min([max_covered, total_coverable - min_uncovered]))])
 
 
 def get_write_threshold_sigma(


### PR DESCRIPTION
Sometimes we want to hold on to some minimum number of shares to avoid losing out on upside. To do this, we can cap the number of covered calls by setting a floor on the number of uncovered shares, which is a factor of the target number of shares.

In other words, if you set `write_when.calls.cap_target_floor` to 0.5, we'll always leave 50% of the target number of shares uncovered to capture upside with a bit of downside protection.

This works with `write_when.calls.cap_factor`, which allows you to set a cap on the total number of covered calls based on the current shares held. This helps in cases where the current number of shares exceeds the target shares, and you want to rebalance if the underlying shoots higher (i.e., allow shares to get called away).