### PR TITLE
When updating price, use halfway between midpoint

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1959,8 +1959,13 @@ class PortfolioManager:
                     ticker, wait_time=self.api_response_wait_time()
                 ):
                     (contract, order) = (trade.contract, trade.order)
-                    updated_price = round(ticker.midpoint(), 2)
-                    if order.lmtPrice != updated_price:
+                    updated_price = round((order.lmtPrice + ticker.midpoint()) / 2.0, 2)
+                    # Check if the updated price is actually any different
+                    # before proceeding, and make sure the signs match so we
+                    # don't switch a credit to a debit or vice versa.
+                    if order.lmtPrice != updated_price and np.sign(
+                        order.lmtPrice
+                    ) == np.sign(updated_price):
                         console.print(
                             f"[green]Resubmitting order for {contract.symbol}"
                             f" with old lmtPrice={dfmt(order.lmtPrice)} updated lmtPrice={dfmt(updated_price)}"


### PR DESCRIPTION
Previous we'd pick the midpoint price for an order, then wait a few seconds, and then pick the midpoint again. This can lead to less-than-ideal fills on illiquid dogs hit stocks/ETFs. Instead, we'll take the halfway point between the previous and updated midpoint, which should give us slightly less bad fills.

Additionally, we never want to switch a credit to a debit or vice versa, so check that the signs match before proceeding.