### PR TITLE
Set call cap per symbol

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -185,6 +185,9 @@ green = true
 # With covered calls, we can cap the number of calls to write by this factor. At
 # 1.0, we write covered calls on 100% of our positions. At 0.5, we'd only write
 # on 50% of our positions. This value must be between 1 and 0 inclusive.
+#
+# This can also be set per-symbol with
+# `symbols.<symbol>.calls.cap_factor`.
 cap_factor = 1.0
 
 # We may want to leave some percentage of our underlying stock perpetually
@@ -197,6 +200,9 @@ cap_factor = 1.0
 # and a smaller number (down to 0.0, 0%) is more bearish (i.e., cover all
 # positions with calls). This essentially sets a floor on the number of shares
 # we try to hold on to in order to avoid missing out on potential upside.
+#
+# This can also be set per-symbol with
+# `symbols.<symbol>.calls.cap_target_floor`.
 cap_target_floor = 0.0
 
 [write_when.puts]
@@ -312,6 +318,11 @@ write_threshold = 0.01 # 1%, absolute value
 strike_limit = 100.0 # never write a call with a strike below $100
 
 maintain_high_water_mark = true # maintain the high water mark when rolling calls
+
+# These values can (optionally) be set on a per-symbol basis, in addition to
+# `write_when.calls.cap_factor` and `write_when.calls.cap_target_floor.
+cap_factor = 1.0
+cap_target_floor = 0.0
 
 [symbols.TLT]
 weight = 0.2

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -149,6 +149,8 @@ def validate_config(config):
                         Optional("write_threshold_sigma"): And(float, lambda n: n > 0),
                         Optional("strike_limit"): And(float, lambda n: n > 0),
                         Optional("maintain_high_water_mark"): bool,
+                        Optional("cap_factor"): And(float, lambda n: 0 <= n <= 1),
+                        Optional("cap_target_floor"): And(float, lambda n: 0 <= n <= 1),
                     },
                     Optional("puts"): {
                         Optional("delta"): And(float, lambda n: 0 <= n <= 1),

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -764,7 +764,7 @@ class PortfolioManager:
             )
 
             target_short_calls = get_target_calls(
-                self.config, stock_count, self.target_quantities[symbol]
+                self.config, symbol, stock_count, self.target_quantities[symbol]
             )
             new_contracts_needed = target_short_calls - short_call_count
             excess_calls = short_call_count - target_short_calls


### PR DESCRIPTION
We can now set the call caps per symbol with
`symbols.<symbol>.calls.cap_factor` and
`symbols.<symbol>.calls.cap_target_floor`.

Also fixed some typings.