### PR TITLE
Return 0.0 if market price is NaN.

### DIFF
--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -217,7 +217,7 @@ def midpoint_or_market_price(ticker: Ticker) -> float:
             # Fallback to the model price if the greeks are available
             return ticker.modelGreeks.optPrice
         else:
-            return ticker.marketPrice()
+            return ticker.marketPrice() if not util.isNan(ticker.marketPrice()) else 0.0
 
     return ticker.midpoint()
 


### PR DESCRIPTION
On the odd chance `ticker.marketPrice()` returns NaN, return 0.0 instead. This is very rare, and shouldn't happen, but it might when you have contracts that are way OTM and near expiration.

This may hopefully address #368.