### PR TITLE
Use a lambda for minimum price

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1504,7 +1504,7 @@ class PortfolioManager:
         minimum_price: Callable[[], float],
         exclude_expirations_before: Optional[str] = None,
         exclude_exp_strike: Optional[Tuple[float, str]] = None,
-        fallback_minimum_price: Optional[Callable[[], float],] = None,
+        fallback_minimum_price: Optional[Callable[[], float]] = None,
         target_dte: Optional[int] = None,
         target_delta: Optional[float] = None,
     ) -> Ticker:


### PR DESCRIPTION
When scanning chains, sometimes the underlying can move a fair bit and it moves the minimum prices around if there's a big move. Instead of calculating the minimum price once, we'll use a lambda so that if there is a big change, it should be accounted for appropriately. This could lead to some odd behaviour, but it should still be less bad than the alternative which is using an out-of-date price.