### PR TITLE
Don't increase price spreads

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -2270,6 +2270,19 @@ class PortfolioManager:
                             ),
                         ]
                     )
+
+                    # We only want to tighten spreads, not widen them. If the
+                    # resulting price change would increase the spread, we'll
+                    # skip it.
+                    if (order.lmtPrice < 0 and updated_price < order.lmtPrice) or (
+                        order.lmtPrice > 0 and updated_price > order.lmtPrice
+                    ):
+                        console.print(
+                            f"[yellow]Skipping order for {contract.symbol}"
+                            f" with old lmtPrice={dfmt(order.lmtPrice)} updated lmtPrice={dfmt(updated_price)}, because updated price would increase spread"
+                        )
+                        continue
+
                     # Check if the updated price is actually any different
                     # before proceeding, and make sure the signs match so we
                     # don't switch a credit to a debit or vice versa.


### PR DESCRIPTION
After waiting to update an order price, sometimes the midpoint goes in the wrong direction after we place the order. We don't want to increase the spread because it almost always makes the order not fill. Instead, leave the price as-is if the change would increase the spread.