### PR TITLE
Make the price update handling more robust

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -52,6 +52,7 @@ from thetagang.util import (
     wait_n_seconds,
     weighted_avg_long_strike,
     weighted_avg_short_strike,
+    would_increase_spread,
 )
 
 from .options import option_dte
@@ -2274,8 +2275,8 @@ class PortfolioManager:
                     # We only want to tighten spreads, not widen them. If the
                     # resulting price change would increase the spread, we'll
                     # skip it.
-                    if (order.lmtPrice < 0 and updated_price < order.lmtPrice) or (
-                        order.lmtPrice > 0 and updated_price > order.lmtPrice
+                    if contract.secType == "BAG" and would_increase_spread(
+                        order, updated_price
                     ):
                         console.print(
                             f"[yellow]Skipping order for {contract.symbol}"

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import ib_insync.objects
 import ib_insync.ticker
-from ib_insync import AccountValue, PortfolioItem, TagValue, Ticker, util
+from ib_insync import AccountValue, Order, PortfolioItem, TagValue, Ticker, util
 from ib_insync.contract import Option
 
 from thetagang.options import option_dte
@@ -357,3 +357,12 @@ def get_max_dte_for(symbol: str, config: Dict[str, Any]) -> Optional[int]:
         return config["symbols"][symbol]["max_dte"]
 
     return config["target"]["max_dte"]
+
+
+def would_increase_spread(order: Order, updated_price: float) -> bool:
+    return (
+        order.action == "BUY"
+        and updated_price < order.lmtPrice
+        or order.action == "SELL"
+        and updated_price > order.lmtPrice
+    )


### PR DESCRIPTION
The logic is different depending on whether it's a buy/sell, so handle all cases appropriately (just in case).