### PR TITLE
Refactor handling of red/green for new contracts

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -206,6 +206,7 @@ calculate_net_contracts = false
   [write_when.calls]
   # Optionally, only write calls when the underlying is green
   green = true
+  red   = false
 
   # With covered calls, we can cap the number of calls to write by this factor. At
   # 1.0, we write covered calls on 100% of our positions. At 0.5, we'd only write
@@ -232,7 +233,8 @@ calculate_net_contracts = false
 
   [write_when.puts]
   # Optionally, only write puts when the underlying is red
-  red = true
+  green = false
+  red   = true
 
 [target]
 # Target 45 or more days to expiry
@@ -325,9 +327,9 @@ minimum_open_interest = 10
     strike_limit = 1000.0 # never write a put with a strike above $1000
 
     # Optionally, if we only write new contracts when the underlying is green or
-    # red (`write_when.calls.green=true` or `write_when.puts.red=true`), specify a
-    # minimum threshold as an absolute value daily percentage change (in this
-    # example, use 1% for puts only, but could also be specified as
+    # red (`write_when.*.green=true` && `write_when.*.red=false` or vice versa),
+    # specify a minimum threshold as an absolute value daily percentage change
+    # (in this example, use 1% for puts only, but could also be specified as
     # `symbols.QQQ.write_threshold`). This can also be specified under
     # `constants.write_threshold` and `constants.puts/calls.write_threshold` to
     # apply to all symbols, either for both puts or calls, or individually.
@@ -353,15 +355,20 @@ minimum_open_interest = 10
     #
     # write_threshold_sigma = 1.0 # 1x the standard devation of log returns for the daily stddev window
 
-    [symbols.QQQ.calls]
-    strike_limit = 100.0 # never write a call with a strike below $100
+      # the values for `write_when.*.green` and `write_when.*.red` can also be set per-symbol
+      [symbols.QQQ.puts.write_when]
+      green = false
+      red   = true
 
-    maintain_high_water_mark = true # maintain the high water mark when rolling calls
+[symbols.QQQ.calls]
+strike_limit = 100.0 # never write a call with a strike below $100
 
-    # These values can (optionally) be set on a per-symbol basis, in addition to
-    # `write_when.calls.cap_factor` and `write_when.calls.cap_target_floor.
-    cap_factor       = 1.0
-    cap_target_floor = 0.0
+maintain_high_water_mark = true # maintain the high water mark when rolling calls
+
+# These values can (optionally) be set on a per-symbol basis, in addition to
+# `write_when.calls.cap_factor` and `write_when.calls.cap_target_floor.
+cap_factor       = 1.0
+cap_target_floor = 0.0
 
 [symbols.TLT]
 weight = 0.2

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -97,10 +97,12 @@ def validate_config(config: Dict[str, Dict[str, Any]]) -> None:
                 Optional("calculate_net_contracts"): bool,
                 Optional("calls"): {
                     Optional("green"): bool,
+                    Optional("red"): bool,
                     Optional("cap_factor"): And(float, lambda n: 0 <= n <= 1),
                     Optional("cap_target_floor"): And(float, lambda n: 0 <= n <= 1),
                 },
                 Optional("puts"): {
+                    Optional("green"): bool,
                     Optional("red"): bool,
                 },
             },

--- a/thetagang/config_defaults.py
+++ b/thetagang/config_defaults.py
@@ -19,9 +19,10 @@ DEFAULT_CONFIG: Dict[str, Dict[str, Any]] = {
     },
     "write_when": {
         "calculate_net_contracts": False,
-        "puts": {"red": False},
+        "puts": {"red": True, "green": False},
         "calls": {
-            "green": False,
+            "green": True,
+            "red": False,
             "cap_factor": 1.0,
             "cap_target_floor": 0.0,
         },

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -178,15 +178,27 @@ def start(config_path: str, without_ibc: bool = False) -> None:
     )
     config_table.add_row(
         "",
-        "Puts, only write when red",
+        "Puts, write when red",
         "=",
         f"{config['write_when']['puts']['red']}",
     )
     config_table.add_row(
         "",
-        "Calls, only write when green",
+        "Puts, write when green",
+        "=",
+        f"{config['write_when']['puts']['green']}",
+    )
+    config_table.add_row(
+        "",
+        "Calls, write when green",
         "=",
         f"{config['write_when']['calls']['green']}",
+    )
+    config_table.add_row(
+        "",
+        "Calls, write when red",
+        "=",
+        f"{config['write_when']['calls']['red']}",
     )
     config_table.add_row(
         "",

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -1,7 +1,7 @@
 import math
 from datetime import datetime
 from operator import itemgetter
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import ib_insync.objects
 import ib_insync.ticker
@@ -368,3 +368,24 @@ def would_increase_spread(order: Order, updated_price: float) -> bool:
         or order.action == "SELL"
         and updated_price > order.lmtPrice
     )
+
+
+def can_write_when(
+    config: Dict[str, Any], symbol: str, right: str
+) -> Tuple[bool, bool]:
+    p_or_c = "calls" if right.upper().startswith("C") else "puts"
+    can_write_when_green = (
+        config["symbols"][symbol][p_or_c]["write_when"]["green"]
+        if p_or_c in config["symbols"][symbol]
+        and "write_when" in config["symbols"][symbol][p_or_c]
+        and "green" in config["symbols"][symbol][p_or_c]["write_when"]
+        else config["write_when"][p_or_c]["green"]
+    )
+    can_write_when_red = (
+        config["symbols"][symbol][p_or_c]["write_when"]["red"]
+        if p_or_c in config["symbols"][symbol]
+        and "write_when" in config["symbols"][symbol][p_or_c]
+        and "red" in config["symbols"][symbol][p_or_c]["write_when"]
+        else config["write_when"][p_or_c]["red"]
+    )
+    return (can_write_when_green, can_write_when_red)


### PR DESCRIPTION
Previously, the behaviour of `write_when.calls.green` and `write_when.puts.red` was such that each option was treated as "only write when red/green", but this was confusing and had a bug.

Now, there are separate red/green options for both puts and calls, and they can be set per-symbol. Now there are (with default values):

 * `write_when.puts.red=true` and `write_when.puts.green=false`
 * `write_when.calls.green=true` and `write_when.calls.red=false`

You can also specify these on a per-symbol basis with `symbols.<symbol>.<right>.write_when.(green|red)`.

Refer to thetagang.toml for details.

If you had previously used the default config, or didn't specify these values, then the behaviour should remain unchanged. You may want to verify your settings. You can keep the default behaviour with:

```toml
  [write_when.calls]
  # Optionally, only write calls when the underlying is green
  green = true
  red   = false

  [write_when.puts]
  # Optionally, only write puts when the underlying is red
  green = false
  red   = true
```

Thetagang will still respect the setting for write thresholds.

This resolves #410.