### PR TITLE
Increase strike safety factor when scanning chains

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1573,11 +1573,11 @@ class PortfolioManager:
                 if right.startswith("P") and strike_limit:
                     return strike <= strike_limit
                 elif right.startswith("P"):
-                    return strike <= underlying_price + 0.02 * underlying_price
+                    return strike <= underlying_price + 0.05 * underlying_price
                 elif right.startswith("C") and strike_limit:
                     return strike >= strike_limit
                 elif right.startswith("C"):
-                    return strike >= underlying_price - 0.02 * underlying_price
+                    return strike >= underlying_price - 0.05 * underlying_price
                 return False
 
             chain_expirations = self.config["option_chains"]["expirations"]


### PR DESCRIPTION
When no strike limit was specified, we would previously scan above/below the current underlying price, plus/minus 2%, when looking for contracts to either roll to or write. The reason for this is that sometimes a 50 delta contract is ITM, so we might miss out on some juice.

This just increases that safety factor from 2% (relative to the underlying price) to 5%. The only downside of this is that if we're trying to write contracts really far OTM (such as 0.1 delta, for example) we might need to increase the number of strikes to load from the chain.