### PR TITLE
Fix algo params in default config

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -2,5 +2,5 @@
 align_entries       = true
 array_auto_collapse = false
 indent_tables       = true
-reorder_arrays      = true
+reorder_arrays      = false
 reorder_keys        = true

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -84,7 +84,12 @@ minimum_credit = 0.05
   # For `algoParams`, the TagValue parameter has 2 values, so any values with
   # anything other than 2 parameters are invalid. Pass an empty list to use the
   # defaults (i.e., params = []).
-  params = [["Patient", "adaptivePriority"]]
+  params = [
+    [
+      "adaptivePriority",
+      "Patient",
+    ],
+  ]
 
 [option_chains]
 # The option chains are lazy loaded, and before you can determine the greeks


### PR DESCRIPTION
The arrays in TOML should not be sorted by value.