### PR TITLE
Optionally close positions when rolling fails

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -131,6 +131,15 @@ min_pnl = 0.0
 # long positions are ignored.
 # close_at_pnl = 0.99
 
+# Optionally, if we try to roll the position and it fails, just close it. This
+# can happen if the underlying moves too much and there are no suitable
+# contracts. See https://github.com/brndnmtthws/thetagang/issues/347 and
+# https://github.com/brndnmtthws/thetagang/issues/439 for a discussion on this.
+#
+# This can also be set per-symbol, with
+# `symbols.<symbol>.close_if_unable_to_roll`.
+close_if_unable_to_roll = false
+
   [roll_when.calls]
   # Roll calls to the next expiration even if they're in the money. Defaults to
   # true if not specified.
@@ -344,6 +353,9 @@ minimum_open_interest = 10
   # value.
   # max_dte = 45
 
+  # Optional: If we try to roll the position and it fails, just close it.
+  close_if_unable_to_roll = true
+
     # parts = 30
     [symbols.QQQ.puts]
     # Override delta just for QQQ puts
@@ -386,35 +398,35 @@ minimum_open_interest = 10
       green = false
       red   = true
 
-[symbols.QQQ.calls]
-strike_limit = 100.0 # never write a call with a strike below $100
+    [symbols.QQQ.calls]
+    strike_limit = 100.0 # never write a call with a strike below $100
 
-maintain_high_water_mark = true # maintain the high water mark when rolling calls
+    maintain_high_water_mark = true # maintain the high water mark when rolling calls
 
-# These values can (optionally) be set on a per-symbol basis, in addition to
-# `write_when.calls.cap_factor` and `write_when.calls.cap_target_floor.
-cap_factor       = 1.0
-cap_target_floor = 0.0
+    # These values can (optionally) be set on a per-symbol basis, in addition to
+    # `write_when.calls.cap_factor` and `write_when.calls.cap_target_floor.
+    cap_factor       = 1.0
+    cap_target_floor = 0.0
 
-[symbols.TLT]
-weight = 0.2
-# parts = 20
-# Override delta for this particular symbol, for both puts and calls.
-delta = 0.4
+  [symbols.TLT]
+  weight = 0.2
+  # parts = 20
+  # Override delta for this particular symbol, for both puts and calls.
+  delta = 0.4
 
-[symbols.ABNB]
-# For symbols that require an exchange, which is typically any company stock,
-# you must specify the primary exchange.
-primary_exchange = "NASDAQ"
-weight           = 0.05
+  [symbols.ABNB]
+  # For symbols that require an exchange, which is typically any company stock,
+  # you must specify the primary exchange.
+  primary_exchange = "NASDAQ"
+  weight           = 0.05
 
-# parts = 5
-# Sometimes you may need to wrap the symbol in quotes.
-[symbols."BRK B"]
-# For symbols that require an exchange, which is typically any company stock,
-# you must specify the primary exchange.
-primary_exchange = "NYSE"
-weight           = 0.05
+  # parts = 5
+  # Sometimes you may need to wrap the symbol in quotes.
+  [symbols."BRK B"]
+  # For symbols that require an exchange, which is typically any company stock,
+  # you must specify the primary exchange.
+  primary_exchange = "NYSE"
+  weight           = 0.05
 
 # parts = 5
 [ib_insync]

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -111,6 +111,7 @@ def validate_config(config: Dict[str, Dict[str, Any]]) -> None:
                 "dte": And(int, lambda n: 0 <= n),
                 "min_pnl": float,
                 Optional("close_at_pnl"): float,
+                Optional("close_if_unable_to_roll"): bool,
                 Optional("max_dte"): And(int, lambda n: 1 <= n),
                 Optional("calls"): {
                     Optional("itm"): bool,
@@ -154,6 +155,7 @@ def validate_config(config: Dict[str, Dict[str, Any]]) -> None:
                     Optional("write_threshold_sigma"): And(float, lambda n: n > 0),
                     Optional("max_dte"): And(int, lambda n: 1 <= n),
                     Optional("dte"): And(int, lambda n: 0 <= n),
+                    Optional("close_if_unable_to_roll"): bool,
                     Optional("calls"): {
                         Optional("delta"): And(float, lambda n: 0 <= n <= 1),
                         Optional("write_threshold"): And(float, lambda n: 0 <= n <= 1),

--- a/thetagang/config_defaults.py
+++ b/thetagang/config_defaults.py
@@ -30,6 +30,7 @@ DEFAULT_CONFIG: Dict[str, Dict[str, Any]] = {
     "roll_when": {
         "min_pnl": 0.0,
         "close_at_pnl": 1.0,
+        "close_if_unable_to_roll": False,
         "calls": {
             "itm": True,
             "always_when_itm": False,

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -114,6 +114,12 @@ def start(config_path: str, without_ibc: bool = False) -> None:
         ">=",
         f"{pfmt(config['roll_when']['close_at_pnl'],0)}",
     )
+    config_table.add_row(
+        "",
+        "Close if unable to roll",
+        "=",
+        f"{config['roll_when']['close_if_unable_to_roll']}",
+    )
 
     config_table.add_section()
     config_table.add_row("[spring_green1]Roll options when either condition is true")

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -396,3 +396,12 @@ def can_write_when(
         else config["write_when"][p_or_c]["red"]
     )
     return (can_write_when_green, can_write_when_red)
+
+
+def close_if_unable_to_roll(config: Dict[str, Any], symbol: str) -> bool:
+    close_if_unable_to_roll = (
+        config["symbols"][symbol]["close_if_unable_to_roll"]
+        if "close_if_unable_to_roll" in config["symbols"][symbol]
+        else config["roll_when"]["close_if_unable_to_roll"]
+    )
+    return close_if_unable_to_roll


### PR DESCRIPTION
If we try to roll a position and can't find a suitable contract to roll to, allow the option of closing the position out instead.

This can be configured by setting `roll_when.close_if_unable_to_roll = true`, or per-symbol with `symbols.<symbol>.close_if_unable_to_roll = true`. Disabled by default.

This closes #439.