### PR TITLE
Only close ITM contracts when DTE <= rolling DTE

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1560,7 +1560,12 @@ class PortfolioManager:
                 # Enqueue order
                 self.enqueue_order(combo, order)
             except NoValidContractsError:
-                if close_if_unable_to_roll(self.config, position.contract.symbol):
+                dte = option_dte(position.contract.lastTradeDateOrContractMonth)
+                roll_when_dte = self.config["roll_when"]["dte"]
+                if (
+                    close_if_unable_to_roll(self.config, position.contract.symbol)
+                    and dte <= roll_when_dte
+                ):
                     console.print(
                         f"[yellow]Unable to find a suitable contract to roll to for {position.contract.localSymbol}. Closing position instead...",
                     )


### PR DESCRIPTION
If configured to close when unable to roll with
`roll_when.{calls,puts}.always_when_itm`, only close contracts where the DTE is <= the configured value for `roll_when.dte`.