### PR TITLE
Fix ITM rolling DTE

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -121,6 +121,7 @@ min_pnl = 0.0
 
 # Optional: Don't roll contracts when the current DTE is greater than this
 # number of days. This helps avoid cases where you end up rolling out to LEAPs.
+#
 # max_dte = 180
 
 # Optional: Create a closing order when the P&L reaches this threshold. This
@@ -129,12 +130,16 @@ min_pnl = 0.0
 # long-dated options that have slowly become worthless and you just want to get
 # them out of your portfolio. This only applies to short contract positions,
 # long positions are ignored.
+#
 # close_at_pnl = 0.99
 
-# Optionally, if we try to roll the position and it fails, just close it. This
+# Optional: if we try to roll the position and it fails, just close it. This
 # can happen if the underlying moves too much and there are no suitable
 # contracts. See https://github.com/brndnmtthws/thetagang/issues/347 and
 # https://github.com/brndnmtthws/thetagang/issues/439 for a discussion on this.
+#
+# If `roll_when.max_dte` is set, this will only close the position if the DTE is
+# <= `roll_when.max_dte`.
 #
 # This can also be set per-symbol, with
 # `symbols.<symbol>.close_if_unable_to_roll`.

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1561,10 +1561,10 @@ class PortfolioManager:
                 self.enqueue_order(combo, order)
             except NoValidContractsError:
                 dte = option_dte(position.contract.lastTradeDateOrContractMonth)
-                roll_when_dte = self.config["roll_when"]["dte"]
                 if (
                     close_if_unable_to_roll(self.config, position.contract.symbol)
-                    and dte <= roll_when_dte
+                    and "max_dte" in self.config["roll_when"]
+                    and dte <= self.config["roll_when"]["max_dte"]
                 ):
                     console.print(
                         f"[yellow]Unable to find a suitable contract to roll to for {position.contract.localSymbol}. Closing position instead...",


### PR DESCRIPTION
If rolling because ITM, use `roll_when.max_dte` not `roll_when.dte`.