### PR TITLE
Floor cash ETF position

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -2185,7 +2185,7 @@ class PortfolioManager:
                             if isinstance(p.contract, Stock)
                         ]
                         position = positions[0] if len(positions) > 0 else 0
-                        qty = min([max([-position, qty]), 0])
+                        qty = min([max([-math.floor(position), qty]), 0])
                         # if for some reason the qty is zero, do nothing
                         if qty == 0:
                             to_print.append(


### PR DESCRIPTION
IBKR doesn't allow fractional quantities with API orders (why? idk), so we need to floor the cash position if we're creating a sell order.