### PR TITLE
Allow the inclusion of a symbol, without trading

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -348,6 +348,13 @@ minimum_open_interest = 10
   # randomly from the range defined by `orders.price_update_delay`.
   adjust_price_after_delay = false
 
+  # You can include a symbol, but instruct ThetaGang not to place any trades for
+  # that symbol by setting `no_trading = true`. This allows you to include
+  # placeholders (such as for tracking purposes, or because you want to trade
+  # manually) without actually trading them.
+  #
+  # no_trading = true
+
   [symbols.QQQ]
   weight = 0.3
   # The target DTE may also be specified per-symbol, and takes precedence over

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -180,6 +180,7 @@ def validate_config(config: Dict[str, Dict[str, Any]]) -> None:
                         },
                     },
                     Optional("adjust_price_after_delay"): bool,
+                    Optional("no_trading"): bool,
                 }
             },
             Optional("ib_insync"): {

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -405,3 +405,10 @@ def close_if_unable_to_roll(config: Dict[str, Any], symbol: str) -> bool:
         else config["roll_when"]["close_if_unable_to_roll"]
     )
     return close_if_unable_to_roll
+
+
+def trading_is_allowed(config: Dict[str, Any], symbol: str) -> bool:
+    return (
+        "no_trading" not in config["symbols"][symbol]
+        or not config["symbols"][symbol]["no_trading"]
+    )


### PR DESCRIPTION
Sometimes it can be handy to include a symbol in ThetaGang without actually doing any trades. For example, we might want to buy a stock/ETF and hold it, without running the ThetaGang strat, but include that symbol in ThetaGang's calculations and holding weightings.