### PR TITLE
Optionally only write calls on excess positions

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -267,6 +267,19 @@ calculate_net_contracts = false
   # `symbols.<symbol>.calls.cap_target_floor`.
   cap_target_floor = 0.0
 
+  # If set to true, calls are only written on the underlying when the underlying
+  # has an excess of shares. This is useful for covered calls, where you only
+  # want to write calls when you have more shares than you want to hold
+  # long-term. It also provides a way to rebalance your portfolio by writing
+  # calls and taking profits.
+  #
+  # This may also be set per-symbol with `symbols.<symbol>.calls.excess_only`,
+  # which takes precedence.
+  #
+  # When this is set to true, the `cap_factor` and `cap_target_floor` values are
+  # ignored.
+  excess_only = false
+
   [write_when.puts]
   # Optionally, only write puts when the underlying is red
   green = false
@@ -419,6 +432,11 @@ minimum_open_interest = 10
     # `write_when.calls.cap_factor` and `write_when.calls.cap_target_floor.
     cap_factor       = 1.0
     cap_target_floor = 0.0
+
+    # Optionally, only write calls when the underlying has an excess of shares
+    # when set to `true`. This overrides the `write_when.calls.excess_only`
+    # value.
+    excess_only = false
 
   [symbols.TLT]
   weight = 0.2

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -110,6 +110,7 @@ def validate_config(config: Dict[str, Dict[str, Any]]) -> None:
                     Optional("red"): bool,
                     Optional("cap_factor"): And(float, lambda n: 0 <= n <= 1),
                     Optional("cap_target_floor"): And(float, lambda n: 0 <= n <= 1),
+                    Optional("excess_only"): bool,
                 },
                 Optional("puts"): {
                     Optional("green"): bool,
@@ -174,6 +175,7 @@ def validate_config(config: Dict[str, Dict[str, Any]]) -> None:
                         Optional("maintain_high_water_mark"): bool,
                         Optional("cap_factor"): And(float, lambda n: 0 <= n <= 1),
                         Optional("cap_target_floor"): And(float, lambda n: 0 <= n <= 1),
+                        Optional("excess_only"): bool,
                         Optional("write_when"): {
                             Optional("green"): bool,
                             Optional("red"): bool,

--- a/thetagang/config_defaults.py
+++ b/thetagang/config_defaults.py
@@ -25,6 +25,7 @@ DEFAULT_CONFIG: Dict[str, Dict[str, Any]] = {
             "red": False,
             "cap_factor": 1.0,
             "cap_target_floor": 0.0,
+            "excess_only": False,
         },
     },
     "roll_when": {

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -218,7 +218,12 @@ def start(config_path: str, without_ibc: bool = False) -> None:
         "=",
         f"{pfmt(config['write_when']['calls']['cap_target_floor'])}",
     )
-
+    config_table.add_row(
+        "",
+        "Excess only",
+        "=",
+        f"{config['write_when']['calls']['excess_only']}",
+    )
     config_table.add_section()
     config_table.add_row("[spring_green1]When contracts are ITM")
     config_table.add_row(


### PR DESCRIPTION
If you want to hold a stock/ETF, you may wish to avoid writing any calls at all on it, except for the positions in excess of your desired allocation. This may be preferable when you're bullish and want to avoid missing out on upside.

For this case, you can just set either `write_when.calls.excess_only = true` for the entire portfolio, or `symbols.<symbol>.calls.excess_only = true` on a per-symbol basis.