### PR TITLE
Only close profitable positions we can't roll

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -133,9 +133,10 @@ min_pnl = 0.0
 #
 # close_at_pnl = 0.99
 
-# Optional: if we try to roll the position and it fails, just close it. This
-# can happen if the underlying moves too much and there are no suitable
-# contracts. See https://github.com/brndnmtthws/thetagang/issues/347 and
+# Optional: if we try to roll the position and it fails, just close it (but only
+# if the position currently has positive P&L). This can happen if the underlying
+# moves too much and there are no suitable contracts. See
+# https://github.com/brndnmtthws/thetagang/issues/347 and
 # https://github.com/brndnmtthws/thetagang/issues/439 for a discussion on this.
 #
 # If `roll_when.max_dte` is set, this will only close the position if the DTE is
@@ -378,7 +379,8 @@ minimum_open_interest = 10
   # value.
   # max_dte = 45
 
-  # Optional: If we try to roll the position and it fails, just close it.
+  # Optional: If we try to roll the position and it fails, just close it (but
+  # only if it's profitable).
   close_if_unable_to_roll = true
 
     # parts = 30

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1576,6 +1576,7 @@ class PortfolioManager:
                     close_if_unable_to_roll(self.config, position.contract.symbol)
                     and "max_dte" in self.config["roll_when"]
                     and dte <= self.config["roll_when"]["max_dte"]
+                    and position_pnl(position) > 0
                 ):
                     console.print(
                         f"[yellow]Unable to find a suitable contract to roll to for {position.contract.localSymbol}. Closing position instead...",


### PR DESCRIPTION
Previously, if `roll_when.close_if_unable_to_roll` was enabled, we would close positions with a negative P&L, which is usually undesirable. Instead, we only close positions that have positive P&L.