### PR TITLE
Don't roll an ITM put up

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1463,6 +1463,11 @@ class PortfolioManager:
                         ),
                         2,
                     )
+                    # special case: if we're rolling a put that's ITM, we want to roll to an equal or lower strike, not higher
+                    if isinstance(position.contract, Option) and self.put_is_itm(
+                        position.contract
+                    ):
+                        strike_limit = min([strike_limit, position.contract.strike])
 
                 kind = "calls" if right.startswith("C") else "puts"
 


### PR DESCRIPTION
If we're rolling a put that's ITM, it can sometimes result in rolling up to high strike, which is undesirable. Thus, we limit the strike such that it must be less than or equal to the current put's strike.