### PR TITLE
strike_limit option prevent searching for PUT options

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1333,14 +1333,14 @@ class PortfolioManager:
                             f"[green]Will write {puts_to_write} puts, {additional_quantity}"
                             f" needed, capped at {maximum_new_contracts}",
                         )
-                        to_write.append(
-                            (
-                                symbol,
-                                self.get_primary_exchange(symbol),
-                                puts_to_write,
-                                strike_limit,
-                            )
+                    to_write.append(
+                        (
+                            symbol,
+                            self.get_primary_exchange(symbol),
+                            puts_to_write,
+                            strike_limit,
                         )
+                    )
             elif additional_quantity < 0:
                 self.has_excess_puts.add(symbol)
                 put_actions_table.add_row(


### PR DESCRIPTION
It appears that the missing indentation is causing the action to be displayed in the table, but no contract search is being performed afterward.

Example log:

```
│ RIVN   │ Write  │ Will write 6 puts, 6 needed, capped at 8, at or below strike $12.0         │
└────────┴────────┴────────────────────────────────────────────────────────────────────────────┘
    Call writing summary    
┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
┃ Symbol ┃ Action ┃ Detail ┃
┡━━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
└────────┴────────┴────────┘
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ 0 puts can be rolled                                                                                                                                                                            │
│ 0 puts can be closed                                                                                                                                                                            │
│ 0 calls can be rolled                                                                                                                                                                           │
│ 0 calls can be closed                                                                                                                                                                           │
╰─────────────────────────
```