### PR TITLE
introduce `--dry-run` mode

### DIFF
--- a/thetagang/main.py
+++ b/thetagang/main.py
@@ -28,7 +28,12 @@ CONTEXT_SETTINGS = dict(
     help="Run without IBC. Enable this if you want to run the TWS "
     "gateway yourself, without having ThetaGang manage it for you.",
 )
-def cli(config: str, without_ibc: bool) -> None:
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Perform a dry run. This will simulate the execution without making any actual changes or sending any live trades.",
+)
+def cli(config: str, without_ibc: bool, dry_run: bool) -> None:
     """ThetaGang is an IBKR bot for collecting money.
 
     You can configure this tool by supplying a toml configuration file.
@@ -38,4 +43,4 @@ def cli(config: str, without_ibc: bool) -> None:
 
     from .thetagang import start
 
-    start(config, without_ibc)
+    start(config, without_ibc, dry_run)

--- a/thetagang/main.py
+++ b/thetagang/main.py
@@ -31,7 +31,7 @@ CONTEXT_SETTINGS = dict(
 @click.option(
     "--dry-run",
     is_flag=True,
-    help="Perform a dry run. This will simulate the execution without making any actual changes or sending any live trades.",
+    help="Perform a dry run. This will display the the orders without sending any live trades.",
 )
 def cli(config: str, without_ibc: bool, dry_run: bool) -> None:
     """ThetaGang is an IBKR bot for collecting money.

--- a/thetagang/orders.py
+++ b/thetagang/orders.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 
 from ib_async import Contract, LimitOrder
-from rich.box import box
+from rich import box
 from rich.pretty import Pretty
 from rich.table import Table
 

--- a/thetagang/orders.py
+++ b/thetagang/orders.py
@@ -1,0 +1,46 @@
+from typing import List, Tuple
+
+from ib_async import Contract, LimitOrder
+from rich.box import box
+from rich.pretty import Pretty
+from rich.table import Table
+
+from thetagang import log
+from thetagang.fmt import dfmt, ifmt
+
+
+class Orders:
+    def __init__(self) -> None:
+        self.__records: List[Tuple[Contract, LimitOrder]] = []
+
+    def add_order(self, contract: Contract, order: LimitOrder) -> None:
+        self.__records.append((contract, order))
+
+    def records(self) -> List[Tuple[Contract, LimitOrder]]:
+        return self.__records
+
+    def print_summary(self) -> None:
+        if not self.__records:
+            return
+
+        table = Table(
+            title="Order Summary", show_lines=True, box=box.MINIMAL_HEAVY_HEAD
+        )
+        table.add_column("Symbol")
+        table.add_column("Exchange")
+        table.add_column("Contract")
+        table.add_column("Action")
+        table.add_column("Price")
+        table.add_column("Qty")
+
+        for contract, order in self.__records:
+            table.add_row(
+                contract.symbol,
+                contract.exchange,
+                Pretty(contract, indent_size=2),
+                order.action,
+                dfmt(order.lmtPrice),
+                ifmt(int(order.totalQuantity)),
+            )
+
+        log.print(table)

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -2185,7 +2185,8 @@ class PortfolioManager:
                         algoParams=order.algoParams,
                     )
 
-                    # put the trade back from whence it came
+                    # resubmit the order and it will be placed back to the
+                    # original position in the queue
                     self.trades.submit_order(contract, order, idx)
 
                     log.info(f"Order updated, order={order}")

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -8,25 +8,23 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import numpy as np
 from ib_async import (
     AccountValue,
-    Order,
     PortfolioItem,
     TagValue,
     Ticker,
-    Trade,
     util,
 )
 from ib_async.contract import ComboLeg, Contract, Index, Option, Stock
 from ib_async.ib import IB
 from ib_async.order import LimitOrder
-from rich import box
 from rich.console import Group
 from rich.panel import Panel
-from rich.pretty import Pretty
 from rich.table import Table
 
 from thetagang import log
 from thetagang.fmt import dfmt, ffmt, ifmt, pfmt
 from thetagang.ibkr import IBKR, RequiredFieldValidationError, TickerField
+from thetagang.orders import Orders
+from thetagang.trades import Trades
 from thetagang.util import (
     account_summary_to_dict,
     algo_params_from,
@@ -88,8 +86,8 @@ class PortfolioManager:
         self.completion_future = completion_future
         self.has_excess_calls: set[str] = set()
         self.has_excess_puts: set[str] = set()
-        self.orders: List[tuple[Contract, LimitOrder]] = []
-        self.trades: List[Trade] = []
+        self.orders: Orders = Orders()
+        self.trades: Trades = Trades(self.ibkr)
         self.target_quantities: Dict[str, int] = {}
         self.qualified_contracts: Dict[int, Contract] = {}
         self.dry_run = dry_run
@@ -592,18 +590,19 @@ class PortfolioManager:
 
             if self.dry_run:
                 log.warning("Dry run enabled, no trades will be executed.")
+                self.orders.print_summary()
             else:
                 self.submit_orders()
 
                 try:
-                    await self.ibkr.wait_for_submitting_orders(self.trades)
+                    await self.ibkr.wait_for_submitting_orders(self.trades.records())
                 except RuntimeError:
                     log.error("Submitting orders failed. Continuing anyway..")
                     pass
 
                 await self.adjust_prices()
 
-                await self.ibkr.wait_for_submitting_orders(self.trades)
+                await self.ibkr.wait_for_submitting_orders(self.trades.records())
 
             log.info("ThetaGang is done, shutting down! Cya next time. :sparkles:")
         except:
@@ -1954,13 +1953,13 @@ class PortfolioManager:
         return sum(
             [
                 order.lmtPrice * order.totalQuantity * get_multiplier(contract)
-                for (contract, order) in self.orders
+                for (contract, order) in self.orders.records()
                 if order.action == "SELL"
             ]
         ) - sum(
             [
                 order.lmtPrice * order.totalQuantity * get_multiplier(contract)
-                for (contract, order) in self.orders
+                for (contract, order) in self.orders.records()
                 if order.action == "BUY"
             ]
         )
@@ -2093,49 +2092,12 @@ class PortfolioManager:
     def enqueue_order(self, contract: Optional[Contract], order: LimitOrder) -> None:
         if not contract:
             return
-        self.orders.append((contract, order))
+        self.orders.add_order(contract, order)
 
     def submit_orders(self) -> None:
-        def submit(contract: Contract, order: Order) -> Optional[Trade]:
-            try:
-                trade = self.ibkr.place_order(contract, order)
-                return trade
-            except RuntimeError:
-                log.error(f"Failed to submit contract: {contract}, order: {order}")
-            return None
-
-        self.trades = [
-            trade
-            for trade in [submit(order[0], order[1]) for order in self.orders]
-            if trade
-        ]
-
-        if len(self.trades) > 0:
-            table = Table(
-                title="Orders submitted", show_lines=True, box=box.MINIMAL_HEAVY_HEAD
-            )
-            table.add_column("Symbol")
-            table.add_column("Exchange")
-            table.add_column("Contract")
-            table.add_column("Action")
-            table.add_column("Price")
-            table.add_column("Qty")
-            table.add_column("Status")
-            table.add_column("Filled")
-
-            for trade in self.trades:
-                if trade:
-                    table.add_row(
-                        trade.contract.symbol,
-                        trade.contract.exchange,
-                        Pretty(trade.contract, indent_size=2),
-                        trade.order.action,
-                        dfmt(trade.order.lmtPrice),
-                        ifmt(int(trade.order.totalQuantity)),
-                        trade.orderStatus.status,
-                        ffmt(trade.orderStatus.filled, 0),
-                    )
-            log.print(table)
+        for contract, order in self.orders.records():
+            self.trades.submit_order(contract, order)
+        self.trades.print_summary()
 
     async def adjust_prices(self) -> None:
         if (
@@ -2147,7 +2109,7 @@ class PortfolioManager:
                     for symbol in self.config["symbols"]
                 ]
             )
-            or len(self.trades) == 0
+            or self.trades.is_empty() == 0
         ):
             log.warning("Skipping order price adjustments...")
             return
@@ -2157,11 +2119,11 @@ class PortfolioManager:
             self.config["orders"]["price_update_delay"][1],
         )
 
-        await self.ibkr.wait_for_orders_complete(self.trades, delay)
+        await self.ibkr.wait_for_orders_complete(self.trades.records(), delay)
 
         unfilled = [
             (idx, trade)
-            for idx, trade in enumerate(self.trades)
+            for idx, trade in enumerate(self.trades.records())
             if trade
             and trade.contract.symbol in self.config["symbols"]
             and self.config["symbols"][trade.contract.symbol].get(
@@ -2224,9 +2186,9 @@ class PortfolioManager:
                     )
 
                     # put the trade back from whence it came
-                    self.trades[idx] = self.ibkr.place_order(contract, order)
+                    self.trades.submit_order(contract, order, idx)
 
-                    log.info(f"Order updated, order={self.trades[idx].order}")
+                    log.info(f"Order updated, order={order}")
             except (RuntimeError, RequiredFieldValidationError):
                 log.error(
                     "Couldn't generate midpoint price for {trade.contract}, skipping"

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -26,7 +26,7 @@ util.patchAsyncio()
 console = Console()
 
 
-def start(config_path: str, without_ibc: bool = False) -> None:
+def start(config_path: str, without_ibc: bool = False, dry_run: bool = False) -> None:
     import toml
 
     with open(config_path, "r", encoding="utf8") as file:
@@ -418,7 +418,7 @@ def start(config_path: str, without_ibc: bool = False) -> None:
     ib.connectedEvent += onConnected
 
     completion_future: Future[bool] = Future()
-    portfolio_manager = PortfolioManager(config, ib, completion_future)
+    portfolio_manager = PortfolioManager(config, ib, completion_future, dry_run)
 
     probeContractConfig = config["watchdog"]["probeContract"]
     watchdogConfig = config.get("watchdog", {})

--- a/thetagang/trades.py
+++ b/thetagang/trades.py
@@ -1,0 +1,70 @@
+from typing import List, Optional
+
+from ib_async import Contract, LimitOrder, Trade
+from rich.box import box
+from rich.pretty import Pretty
+from rich.table import Table
+
+from thetagang import log
+from thetagang.fmt import dfmt, ffmt, ifmt
+from thetagang.ibkr import IBKR
+
+
+class Trades:
+    def __init__(self, ibkr: IBKR) -> None:
+        self.ibkr = ibkr
+        self.__records: List[Trade] = []
+
+    def submit_order(
+        self, contract: Contract, order: LimitOrder, idx: Optional[int] = None
+    ) -> None:
+        try:
+            trade = self.ibkr.place_order(contract, order)
+            if idx is not None:
+                self.__replace_trade(trade, idx)
+            else:
+                self.__add_trade(trade)
+        except RuntimeError:
+            log.error(f"Failed to submit contract: {contract}, order: {order}")
+
+    def records(self) -> List[Trade]:
+        return self.__records
+
+    def is_empty(self) -> bool:
+        return len(self.__records) == 0
+
+    def print_summary(self) -> None:
+        if not self.__records:
+            return
+
+        table = Table(
+            title="Trade Summary", show_lines=True, box=box.MINIMAL_HEAVY_HEAD
+        )
+        table.add_column("Symbol")
+        table.add_column("Exchange")
+        table.add_column("Contract")
+        table.add_column("Action")
+        table.add_column("Price")
+        table.add_column("Qty")
+        table.add_column("Status")
+        table.add_column("Filled")
+
+        for trade in self.__records:
+            table.add_row(
+                trade.contract.symbol,
+                trade.contract.exchange,
+                Pretty(trade.contract, indent_size=2),
+                trade.order.action,
+                dfmt(trade.order.lmtPrice),
+                ifmt(int(trade.order.totalQuantity)),
+                trade.orderStatus.status,
+                ffmt(trade.orderStatus.filled, 0),
+            )
+
+        log.print(table)
+
+    def __add_trade(self, trade: Trade) -> None:
+        self.__records.append(trade)
+
+    def __replace_trade(self, trade: Trade, idx: int) -> None:
+        self.__records[idx] = trade

--- a/thetagang/trades.py
+++ b/thetagang/trades.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from ib_async import Contract, LimitOrder, Trade
-from rich.box import box
+from rich import box
 from rich.pretty import Pretty
 from rich.table import Table
 

--- a/thetagang/trades_test.py
+++ b/thetagang/trades_test.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+
+import pytest
+from ib_async import Contract, LimitOrder, Trade
+
+from thetagang.ibkr import IBKR
+from thetagang.trades import Trades
+
+
+@pytest.fixture
+def mock_ibkr() -> Mock:
+    return Mock(spec=IBKR)
+
+
+@pytest.fixture
+def trades(mock_ibkr: Mock) -> Trades:
+    return Trades(mock_ibkr)
+
+
+@pytest.fixture
+def mock_contract() -> Mock:
+    return Mock(spec=Contract)
+
+
+@pytest.fixture
+def mock_order() -> Mock:
+    return Mock(spec=LimitOrder)
+
+
+@pytest.fixture
+def mock_trade() -> Mock:
+    return Mock(spec=Trade)
+
+
+def test_submit_order_successful(
+    trades: Trades,
+    mock_contract: Mock,
+    mock_order: Mock,
+    mock_trade: Mock,
+    mock_ibkr: Mock,
+) -> None:
+    mock_ibkr.place_order.return_value = mock_trade
+    trades.submit_order(mock_contract, mock_order)
+    mock_ibkr.place_order.assert_called_once_with(mock_contract, mock_order)
+    assert len(trades.records()) == 1
+    assert trades.records()[0] == mock_trade
+
+
+def test_submit_order_with_replacement(
+    trades: Trades,
+    mock_contract: Mock,
+    mock_order: Mock,
+    mock_trade: Mock,
+    mock_ibkr: Mock,
+) -> None:
+    mock_ibkr.place_order.return_value = mock_trade
+    trades.submit_order(mock_contract, mock_order)
+    new_trade = Mock(spec=Trade)
+    mock_ibkr.place_order.return_value = new_trade
+    trades.submit_order(mock_contract, mock_order, idx=0)
+    assert len(trades.records()) == 1
+    assert trades.records()[0] == new_trade
+
+
+def test_submit_order_failure(
+    trades: Trades, mock_contract: Mock, mock_order: Mock, mock_ibkr: Mock
+) -> None:
+    mock_ibkr.place_order.side_effect = RuntimeError("Failed to place order")
+    trades.submit_order(mock_contract, mock_order)
+    mock_ibkr.place_order.assert_called_once_with(mock_contract, mock_order)
+    assert len(trades.records()) == 0
+
+
+def test_submit_order_multiple_trades(
+    trades: Trades,
+    mock_contract: Mock,
+    mock_order: Mock,
+    mock_trade: Mock,
+    mock_ibkr: Mock,
+) -> None:
+    mock_ibkr.place_order.return_value = mock_trade
+    trades.submit_order(mock_contract, mock_order)
+    trades.submit_order(mock_contract, mock_order)
+    assert mock_ibkr.place_order.call_count == 2
+    assert len(trades.records()) == 2


### PR DESCRIPTION
When I try to test specific changes with a live account, I have to comment on a few functions.

in this PR I am going to add a `--dry-run` CLI flag so we can see the result without executing them.

```
Dry run enabled, no trades will be executed.
                                                                                   Order Summary                                                                                    
         ╷          ╷                                                                                                                                     ╷        ╷         ╷      
  Symbol │ Exchange │ Contract                                                                                                                            │ Action │ Price   │ Qty  
╺━━━━━━━━┿━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━┿━━━━━━━━━┿━━━━━╸
  SGOV   │ SMART    │ Stock(conId=424099317, symbol='SGOV', exchange='SMART', primaryExchange='ARCA', currency='USD', localSymbol='SGOV',                 │ BUY    │ $100.38 │ 144  
         │          │ tradingClass='SGOV')                                                                                                                │        │         │      
         ╵          ╵                                                                                                                                     ╵        ╵         ╵      
ThetaGang is done, shutting down! Cya next time. ✨
```