### PR TITLE
fix: improve timeout handling in IBKR API interactions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ version = "1.14.2"
 dev = [
   "pre-commit>=4.0.1",
   "pytest>=8.0.0,<9",
+  "pytest-mock>=3.14.0,<4",
+  "pytest-asyncio>=0.23.0,<0.24",
   "pytest-watch>=4.2.0,<5",
   "ruff>=0.9.1,<0.10.0",
 ]

--- a/thetagang/test_ibkr.py
+++ b/thetagang/test_ibkr.py
@@ -1,0 +1,267 @@
+import asyncio
+
+import pytest
+from ib_async import IB, Contract, Order, OrderStatus, Stock, Ticker, Trade
+
+from thetagang import log
+from thetagang.ibkr import IBKR, RequiredFieldValidationError, TickerField
+
+# Mark all tests in this module as asyncio
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def mock_ib(mocker):
+    """Fixture to create a mock IB object."""
+    mock = mocker.Mock(spec=IB)
+    # Add the missing event attribute needed by IBKR.__init__
+    # Make it a simple mock that accepts the += operation.
+    mock.orderStatusEvent = mocker.Mock()
+    mock.orderStatusEvent.__iadd__ = mocker.Mock(
+        return_value=None
+    )  # Allow += operation
+    return mock
+
+
+@pytest.fixture
+def ibkr(mock_ib):
+    """Fixture to create an IBKR instance with a mock IB."""
+    return IBKR(ib=mock_ib, api_response_wait_time=1, default_order_exchange="SMART")
+
+
+@pytest.fixture
+def mock_ticker(mocker):
+    """Fixture to create a mock Ticker object."""
+    ticker = mocker.Mock(spec=Ticker)
+    ticker.contract = mocker.Mock(spec=Contract)
+    ticker.contract.localSymbol = "TEST"
+    ticker.contract.symbol = "TEST"
+    return ticker
+
+
+@pytest.fixture
+def mock_trade(mocker):
+    """Fixture to create a mock Trade object."""
+    trade = mocker.Mock(spec=Trade)
+    trade.contract = mocker.Mock(spec=Contract)
+    trade.contract.symbol = "TEST"
+    trade.order = mocker.Mock(spec=Order)
+    trade.order.orderId = 123
+    trade.orderStatus = mocker.Mock(spec=OrderStatus)
+    return trade
+
+
+# --- Tests for get_ticker_for_contract ---
+
+
+async def test_get_ticker_for_contract_success(ibkr, mock_ib, mock_ticker, mocker):
+    """Test get_ticker_for_contract when all waits succeed."""
+    mocker.patch.object(
+        ibkr, "__market_data_streaming_handler__", return_value=mock_ticker
+    )
+    # Mock the internal wait methods to return True (success)
+    mocker.patch.object(
+        ibkr, "__ticker_wait_for_condition__", return_value=asyncio.Future()
+    )
+    ibkr.__ticker_wait_for_condition__.return_value.set_result(True)
+
+    contract = Stock("TEST", "SMART", "USD")
+    result = await ibkr.get_ticker_for_contract(
+        contract,
+        required_fields=[TickerField.MARKET_PRICE],
+        optional_fields=[TickerField.MIDPOINT],
+    )
+
+    assert result == mock_ticker
+    # Check that the wait was attempted (indirectly, via the handler logic patch)
+    ibkr.__market_data_streaming_handler__.assert_awaited_once()
+
+
+async def test_get_ticker_for_contract_required_timeout(
+    ibkr, mock_ib, mock_ticker, mocker
+):
+    """Test get_ticker_for_contract when a required field wait times out."""
+    # Mock ib methods called by __market_data_streaming_handler__
+    mock_ib.qualifyContractsAsync = mocker.AsyncMock()
+    mock_ib.reqMktData = mocker.Mock(return_value=mock_ticker)
+
+    # Mock __ticker_field_handler__ to return appropriate async functions
+    async def succeed_wait(ticker):
+        return True
+
+    async def fail_wait(ticker):
+        return False
+
+    def mock_handler_logic(field):
+        if field == TickerField.MARKET_PRICE:  # Required field
+            return fail_wait
+        elif field == TickerField.MIDPOINT:  # Optional field
+            return succeed_wait
+        else:
+            pytest.fail(f"Unexpected field: {field}")
+
+    mocker.patch.object(
+        ibkr, "__ticker_field_handler__", side_effect=mock_handler_logic
+    )
+
+    contract = Stock("TEST", "SMART", "USD")
+    with pytest.raises(RequiredFieldValidationError) as excinfo:
+        await ibkr.get_ticker_for_contract(
+            contract,
+            required_fields=[TickerField.MARKET_PRICE],
+            optional_fields=[TickerField.MIDPOINT],
+        )
+
+    assert "Required fields timed out" in str(excinfo.value)
+    assert "MARKET_PRICE" in str(excinfo.value)
+    # Ensure the handler was called for both fields
+    assert ibkr.__ticker_field_handler__.call_count == 2
+
+
+async def test_get_ticker_for_contract_optional_timeout(
+    ibkr, mock_ib, mock_ticker, mocker
+):
+    """Test get_ticker_for_contract when an optional field wait times out."""
+    # Mock ib methods called by __market_data_streaming_handler__
+    mock_ib.qualifyContractsAsync = mocker.AsyncMock()
+    mock_ib.reqMktData = mocker.Mock(return_value=mock_ticker)
+    mock_log_warning = mocker.patch.object(log, "warning")
+
+    # Mock __ticker_field_handler__ to return appropriate async functions
+    async def succeed_wait(ticker):
+        return True
+
+    async def fail_wait(ticker):
+        return False
+
+    def mock_handler_logic(field):
+        if field == TickerField.MARKET_PRICE:  # Required field
+            return succeed_wait
+        elif field == TickerField.MIDPOINT:  # Optional field
+            return fail_wait
+        else:
+            pytest.fail(f"Unexpected field: {field}")
+
+    mocker.patch.object(
+        ibkr, "__ticker_field_handler__", side_effect=mock_handler_logic
+    )
+
+    contract = Stock("TEST", "SMART", "USD")
+    result = await ibkr.get_ticker_for_contract(
+        contract,
+        required_fields=[TickerField.MARKET_PRICE],
+        optional_fields=[TickerField.MIDPOINT],
+    )
+
+    assert result == mock_ticker
+    # Ensure the handler was called for both fields
+    assert ibkr.__ticker_field_handler__.call_count == 2
+    mock_log_warning.assert_called_once()
+    assert "Optional fields timed out" in mock_log_warning.call_args[0][0]
+    assert "MIDPOINT" in mock_log_warning.call_args[0][0]
+
+
+# --- Tests for wait_for_submitting_orders ---
+
+
+async def test_wait_for_submitting_orders_success(ibkr, mock_trade, mocker):
+    """Test wait_for_submitting_orders when all waits succeed."""
+    mocker.patch.object(
+        ibkr, "__trade_wait_for_condition__", return_value=asyncio.Future()
+    )
+    ibkr.__trade_wait_for_condition__.return_value.set_result(True)
+    mocker.patch.object(
+        log, "track_async", return_value=[True, True]
+    )  # Simulate track_async returning results
+
+    trades = [mock_trade, mock_trade]
+    await ibkr.wait_for_submitting_orders(trades)
+
+    assert ibkr.__trade_wait_for_condition__.call_count == 2
+
+
+async def test_wait_for_submitting_orders_timeout(ibkr, mock_trade, mocker):
+    """Test wait_for_submitting_orders when a wait times out."""
+
+    # Mock the wait to return False for the second trade
+    async def mock_wait(*args, **kwargs):
+        # Simulate different results based on call order or trade details if needed
+        # Simple case: first succeeds, second fails
+        if ibkr.__trade_wait_for_condition__.call_count == 1:
+            return True
+        else:
+            return False
+
+    mocker.patch.object(ibkr, "__trade_wait_for_condition__", side_effect=mock_wait)
+    # Mock track_async to return the results from our side_effect
+    mocker.patch.object(log, "track_async", return_value=[True, False])
+
+    trades = [mocker.Mock(spec=Trade), mocker.Mock(spec=Trade)]
+    trades[0].contract = mocker.Mock(spec=Contract)
+    trades[0].contract.symbol = "PASS"
+    trades[0].order = mocker.Mock(spec=Order)
+    trades[0].order.orderId = 1
+    trades[1].contract = mocker.Mock(spec=Contract)
+    trades[1].contract.symbol = "FAIL"
+    trades[1].order = mocker.Mock(spec=Order)
+    trades[1].order.orderId = 2
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await ibkr.wait_for_submitting_orders(trades)
+
+    assert "Timeout waiting for orders to submit" in str(excinfo.value)
+    assert "FAIL (OrderId: 2)" in str(excinfo.value)
+    assert "PASS (OrderId: 1)" not in str(excinfo.value)
+    assert ibkr.__trade_wait_for_condition__.call_count == 2
+
+
+# --- Tests for wait_for_orders_complete ---
+
+
+async def test_wait_for_orders_complete_success(ibkr, mock_trade, mocker):
+    """Test wait_for_orders_complete when all waits succeed."""
+    mocker.patch.object(
+        ibkr, "__trade_wait_for_condition__", return_value=asyncio.Future()
+    )
+    ibkr.__trade_wait_for_condition__.return_value.set_result(True)
+    mocker.patch.object(log, "track_async", return_value=[True, True])
+    mock_log_warning = mocker.patch.object(log, "warning")
+
+    trades = [mock_trade, mock_trade]
+    await ibkr.wait_for_orders_complete(trades)
+
+    assert ibkr.__trade_wait_for_condition__.call_count == 2
+    mock_log_warning.assert_not_called()
+
+
+async def test_wait_for_orders_complete_timeout(ibkr, mock_trade, mocker):
+    """Test wait_for_orders_complete when a wait times out."""
+
+    # Mock the wait to return False for the second trade
+    async def mock_wait(*args, **kwargs):
+        if ibkr.__trade_wait_for_condition__.call_count == 1:
+            return True
+        else:
+            return False
+
+    mocker.patch.object(ibkr, "__trade_wait_for_condition__", side_effect=mock_wait)
+    mocker.patch.object(log, "track_async", return_value=[True, False])
+    mock_log_warning = mocker.patch.object(log, "warning")
+
+    trades = [mocker.Mock(spec=Trade), mocker.Mock(spec=Trade)]
+    trades[0].contract = mocker.Mock(spec=Contract)
+    trades[0].contract.symbol = "PASS"
+    trades[0].order = mocker.Mock(spec=Order)
+    trades[0].order.orderId = 1
+    trades[1].contract = mocker.Mock(spec=Contract)
+    trades[1].contract.symbol = "FAIL"
+    trades[1].order = mocker.Mock(spec=Order)
+    trades[1].order.orderId = 2
+
+    await ibkr.wait_for_orders_complete(trades)
+
+    assert ibkr.__trade_wait_for_condition__.call_count == 2
+    mock_log_warning.assert_called_once()
+    assert "Timeout waiting for orders to complete" in mock_log_warning.call_args[0][0]
+    assert "FAIL (OrderId: 2)" in mock_log_warning.call_args[0][0]
+    assert "PASS (OrderId: 1)" not in mock_log_warning.call_args[0][0]

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -464,6 +465,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.23.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/b4/0b378b7bf26a8ae161c3890c0b48a91a04106c5713ce81b4b080ea2f4f18/pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3", size = 46920 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/82/62e2d63639ecb0fbe8a7ee59ef0bc69a4669ec50f6d3459f74ad4e4189a2/pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2", size = 17663 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
+]
+
+[[package]]
 name = "pytest-watch"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -622,6 +647,8 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
     { name = "pytest-watch" },
     { name = "ruff" },
 ]
@@ -639,7 +666,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.2,<3" },
     { name = "python-dateutil", specifier = ">=2.8.1,<3" },
     { name = "pytimeparse", specifier = ">=1.1.8,<2" },
-    { name = "rich", specifier = ">=13.7.0,<14" },
+    { name = "rich", specifier = ">=13.7.0,<15" },
     { name = "schema", specifier = ">=0.7.5,<0.8" },
     { name = "toml", specifier = ">=0.10.2,<0.11" },
 ]
@@ -648,6 +675,8 @@ requires-dist = [
 dev = [
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pytest", specifier = ">=8.0.0,<9" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0,<0.24" },
+    { name = "pytest-mock", specifier = ">=3.14.0,<4" },
     { name = "pytest-watch", specifier = ">=4.2.0,<5" },
     { name = "ruff", specifier = ">=0.9.1,<0.10.0" },
 ]


### PR DESCRIPTION
This commit improves the robustness of IBKR API interactions by adding proper timeout handling in several critical methods:

- get_ticker_for_contract:
  - Now identifies specific required fields that time out
  - Includes detailed error messages with contract symbols
  - Logs warnings for optional field timeouts without failing

- wait_for_submitting_orders:
  - Checks boolean results from __trade_wait_for_condition__
  - Raises specific RuntimeError with details of failed order submissions
  - Includes order IDs and symbols in error message for troubleshooting

- wait_for_orders_complete:
  - Identifies orders that don't complete within timeout
  - Logs warnings with details about incomplete orders
  - Allows processing to continue despite timeout

Added comprehensive test suite for IBKR timeout handling:
- Created test_ibkr.py with 7 tests covering success and timeout scenarios
- Added dev dependencies (pytest-mock, pytest-asyncio) for testing
- Includes fixtures for mocking IB connection and event handling

This change helps prevent the application from silently proceeding with incomplete or stale data, which could lead to incorrect trading decisions.