### PR TITLE
fix: resolve event loop conflict with ib-async v2.0.1

### DIFF
--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -36,7 +36,7 @@ def start(config_path: str, without_ibc: bool = False, dry_run: bool = False) ->
     ib = IB()
     ib.connectedEvent += onConnected
 
-    completion_future: Future[bool] = Future()
+    completion_future: Future[bool] = util.getLoop().create_future()
     portfolio_manager = PortfolioManager(config, ib, completion_future, dry_run)
 
     probe_contract_config = config.watchdog.probeContract


### PR DESCRIPTION
The upgrade from ib-async v1.0.3 to v2.0.1 introduced a new getLoop() function that caches and automatically creates event loops. This caused a ValueError when the Future was created before IB's event loop was established.

Fixed by using util.getLoop().create_future() to ensure the Future uses the same event loop as IB.