### PR TITLE
fix: handle None contracts from ib_async v2.0.1 qualifyContractsAsync

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1590,6 +1590,9 @@ class PortfolioManager:
 
         contracts = await self.ibkr.qualify_contracts(*contracts)
 
+        # Filter out None values
+        contracts = [c for c in contracts if c is not None]
+
         # exclude strike, but only for the first exp
         if exclude_exp_strike:
             contracts = [


### PR DESCRIPTION
In ib_async v2.0.1, qualifyContractsAsync now returns None for contracts that fail to qualify (unknown or ambiguous), preserving positional correspondence with input contracts. This caused AttributeError when accessing contract properties on None values.

Added filtering to remove None values after qualify_contracts call, ensuring only valid contracts are processed.