### PR TITLE
feat: add buy-only rebalancing mode for direct stock purchases

### DIFF
--- a/thetagang.toml
+++ b/thetagang.toml
@@ -347,6 +347,11 @@ minimum_open_interest = 10
   # The target delta may also be specified per-symbol, and takes precedence over
   # `target.delta` or `target.puts/calls.delta`. You can specify a value for the
   # symbol, or override individually for puts/calls.
+  #
+  # Additionally, you can enable buy-only rebalancing for any symbol by setting
+  # `buy_only_rebalancing = true`. This will cause the bot to buy shares directly
+  # instead of writing puts, which is useful for maintaining core positions in
+  # certain assets. See the TLT example below for more details.
   [symbols.SPY]
   weight = 0.4
 
@@ -445,6 +450,28 @@ minimum_open_interest = 10
   # parts = 20
   # Override delta for this particular symbol, for both puts and calls.
   delta = 0.4
+
+  # Buy-only rebalancing: this will buy shares directly instead of writing puts
+  # to build the position. This is useful for symbols where you want to maintain
+  # a core position without the complexity of options.
+  #
+  # When buy_only_rebalancing = true:
+  # - The bot will never write puts for this symbol
+  # - It will buy shares directly when below target allocation
+  # - It will only buy (never sell) to maintain target weight
+  # - You can still write covered calls on the shares you own
+  # - The position is built through direct stock purchases instead of CSPs
+  #
+  # Minimum thresholds (optional):
+  # - buy_only_min_threshold_shares: Minimum number of shares to buy (default: 1)
+  # - buy_only_min_threshold_amount: Minimum dollar amount for a purchase
+  #   * Dollar amount takes precedence over share count
+  #   * If min amount < 1 share price, it rounds up to 1 share
+  #
+  # Examples:
+  # buy_only_rebalancing = true
+  # buy_only_min_threshold_shares = 10  # Only buy if buying at least 10 shares
+  # buy_only_min_threshold_amount = 1000.0  # Only buy if order is at least $1000
 
   [symbols.ABNB]
   # For symbols that require an exchange, which is typically any company stock,

--- a/thetagang/test_config.py
+++ b/thetagang/test_config.py
@@ -52,3 +52,37 @@ def test_trading_is_allowed_with_symbol_trading_allowed() -> None:
         symbols={"AAPL": SymbolConfigFactory.build(no_trading=False, weight=1.0)},
     )
     assert config.trading_is_allowed("AAPL")
+
+
+def test_is_buy_only_rebalancing_when_true() -> None:
+    config = ConfigFactory.build(
+        symbols={
+            "AAPL": SymbolConfigFactory.build(buy_only_rebalancing=True, weight=1.0)
+        },
+    )
+    assert config.is_buy_only_rebalancing("AAPL")
+
+
+def test_is_buy_only_rebalancing_when_false() -> None:
+    config = ConfigFactory.build(
+        symbols={
+            "AAPL": SymbolConfigFactory.build(buy_only_rebalancing=False, weight=1.0)
+        },
+    )
+    assert not config.is_buy_only_rebalancing("AAPL")
+
+
+def test_is_buy_only_rebalancing_when_none() -> None:
+    config = ConfigFactory.build(
+        symbols={
+            "AAPL": SymbolConfigFactory.build(buy_only_rebalancing=None, weight=1.0)
+        },
+    )
+    assert not config.is_buy_only_rebalancing("AAPL")
+
+
+def test_is_buy_only_rebalancing_for_missing_symbol() -> None:
+    config = ConfigFactory.build(
+        symbols={"AAPL": SymbolConfigFactory.build(weight=1.0)},
+    )
+    assert not config.is_buy_only_rebalancing("MSFT")

--- a/thetagang/test_portfolio_manager.py
+++ b/thetagang/test_portfolio_manager.py
@@ -160,3 +160,533 @@ class TestPortfolioManager:
         # 2. Falling back to market price if it is
         # 3. This ensures the code continues to work with both versions
         pass
+
+    @pytest.mark.asyncio
+    async def test_check_if_can_write_puts_skips_buy_only_symbols(
+        self, portfolio_manager, mocker
+    ):
+        """Test that check_if_can_write_puts skips buy-only rebalancing symbols."""
+        # Mock config
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(weight=0.5, buy_only_rebalancing=True),
+            "MSFT": mocker.Mock(weight=0.5, buy_only_rebalancing=False),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            side_effect=lambda s: s == "AAPL"
+        )
+        portfolio_manager.config.trading_is_allowed = mocker.Mock(return_value=True)
+        portfolio_manager.config.can_write_when = mocker.Mock(return_value=(True, True))
+        portfolio_manager.config.write_when = mocker.Mock()
+        portfolio_manager.config.write_when.calculate_net_contracts = False
+
+        # Mock account summary
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # Mock portfolio positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=50000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock get_maximum_new_contracts_for
+        portfolio_manager.get_maximum_new_contracts_for = mocker.AsyncMock(
+            return_value=10
+        )
+
+        # Mock get_write_threshold
+        portfolio_manager.get_write_threshold = mocker.AsyncMock(
+            return_value=(0.01, 0.02)  # threshold, daily_change
+        )
+
+        # Mock get_close_price
+        mocker.patch(
+            "thetagang.portfolio_manager.PortfolioManager.get_close_price",
+            return_value=149.0,
+        )
+
+        # Mock log.track_async to execute tasks immediately
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        (
+            positions_table,
+            put_actions_table,
+            to_write,
+        ) = await portfolio_manager.check_if_can_write_puts(
+            account_summary, portfolio_positions
+        )
+
+        # Verify AAPL (buy-only) has 0 puts to write
+        # Verify MSFT (normal) would have puts to write if conditions are met
+        assert len(to_write) <= 1  # At most MSFT
+
+        # If MSFT was added to to_write, verify it's not AAPL
+        for symbol, _, _, _ in to_write:
+            assert symbol != "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_check_buy_only_positions(self, portfolio_manager, mocker):
+        """Test check_buy_only_positions method."""
+        # Mock config
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.5,
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+            ),
+            "MSFT": mocker.Mock(
+                weight=0.3,
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+            ),
+            "GOOGL": mocker.Mock(
+                weight=0.2,
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            side_effect=lambda s: s in ["AAPL", "GOOGL"]
+        )
+
+        # Mock account summary
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # Mock portfolio positions - AAPL has 100 shares, others have 0
+        mock_aapl_position = mocker.Mock()
+        mock_aapl_position.contract = mocker.Mock(spec=Stock)
+        mock_aapl_position.contract.symbol = "AAPL"
+        mock_aapl_position.position = 100
+
+        portfolio_positions = {"AAPL": [mock_aapl_position]}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=50000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Expected calculations:
+        # AAPL: target = 0.5 * 50000 = $25000, target_shares = 25000/150 = 166
+        #       current = 100, to_buy = 166 - 100 = 66
+        # GOOGL: target = 0.2 * 50000 = $10000, target_shares = 10000/150 = 66
+        #        current = 0, to_buy = 66
+
+        assert len(to_buy) == 2
+
+        # Check the buy orders
+        buy_dict = {symbol: qty for symbol, _, qty in to_buy}
+        assert "AAPL" in buy_dict
+        assert "GOOGL" in buy_dict
+        assert buy_dict["AAPL"] == 66
+        assert buy_dict["GOOGL"] == 66
+
+        # MSFT should not be in the list (not buy-only)
+        assert "MSFT" not in buy_dict
+
+    @pytest.mark.asyncio
+    async def test_execute_buy_orders(self, portfolio_manager, mocker):
+        """Test execute_buy_orders method."""
+        # Mock dependencies
+        portfolio_manager.get_order_exchange = mocker.Mock(return_value="SMART")
+        portfolio_manager.get_algo_strategy = mocker.Mock(return_value="Adaptive")
+        portfolio_manager.get_algo_params = mocker.Mock(return_value=[])
+        portfolio_manager.enqueue_order = mocker.AsyncMock()
+        portfolio_manager.trades = mocker.Mock()
+
+        # Mock ticker
+        mock_ticker = mocker.Mock()
+        mock_ticker.bid = 149.50
+        mock_ticker.ask = 150.50
+        mocker.patch(
+            "thetagang.portfolio_manager.midpoint_or_market_price", return_value=150.0
+        )
+
+        portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock Stock class
+        mock_stock = mocker.Mock(spec=Stock)
+        mocker.patch("thetagang.portfolio_manager.Stock", return_value=mock_stock)
+
+        # Mock LimitOrder class
+        mock_order = mocker.Mock()
+        mocker.patch("thetagang.portfolio_manager.LimitOrder", return_value=mock_order)
+
+        # Mock log.notice and log.error
+        mocker.patch("thetagang.log.notice")
+        mocker.patch("thetagang.log.error")
+
+        # Mock enqueue_order (returns None)
+        portfolio_manager.enqueue_order = mocker.Mock()
+
+        # Test data
+        buy_orders = [
+            ("AAPL", "NASDAQ", 50),
+            ("GOOGL", "NASDAQ", 30),
+        ]
+
+        # Execute
+        await portfolio_manager.execute_buy_orders(buy_orders)
+
+        # Verify orders were created
+        assert portfolio_manager.enqueue_order.call_count == 2
+
+        # Verify order parameters
+        from thetagang.portfolio_manager import LimitOrder
+
+        LimitOrder.assert_any_call(
+            "BUY",
+            50,
+            150.0,
+            algoStrategy="Adaptive",
+            algoParams=[],
+            tif="DAY",
+            account=portfolio_manager.account_number,
+        )
+        LimitOrder.assert_any_call(
+            "BUY",
+            30,
+            150.0,
+            algoStrategy="Adaptive",
+            algoParams=[],
+            tif="DAY",
+            account=portfolio_manager.account_number,
+        )
+
+    @pytest.mark.asyncio
+    async def test_buy_only_positions_insufficient_buying_power(
+        self, portfolio_manager, mocker
+    ):
+        """Test check_buy_only_positions when there's insufficient buying power."""
+        # Mock config
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=1.0,  # 100% allocation
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - very limited buying power
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power - only $1000 available
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=1000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # With $1000 buying power and $150/share, can only buy 6 shares
+        assert len(to_buy) == 1
+        assert to_buy[0][0] == "AAPL"
+        assert to_buy[0][2] == 6  # floor(1000/150)
+
+    def test_calc_pending_cash_balance_with_stock_orders(
+        self, portfolio_manager, mocker
+    ):
+        """Test that calc_pending_cash_balance correctly handles stock BUY orders."""
+        # Create mock stock contract
+        mock_stock = mocker.Mock()
+        mock_stock.secType = "STK"
+        mock_stock.multiplier = ""  # Stocks often have empty multiplier
+
+        # Create mock option contract
+        mock_option = mocker.Mock()
+        mock_option.secType = "OPT"
+        mock_option.multiplier = "100"
+
+        # Create mock orders
+        stock_buy_order = mocker.Mock()
+        stock_buy_order.action = "BUY"
+        stock_buy_order.lmtPrice = 150.0
+        stock_buy_order.totalQuantity = 100
+
+        option_sell_order = mocker.Mock()
+        option_sell_order.action = "SELL"
+        option_sell_order.lmtPrice = 2.50
+        option_sell_order.totalQuantity = 5
+
+        # Mock the orders.records() to return our test orders
+        portfolio_manager.orders.records = mocker.Mock(
+            return_value=[
+                (mock_stock, stock_buy_order),
+                (mock_option, option_sell_order),
+            ]
+        )
+
+        # Calculate pending cash balance
+        pending_balance = portfolio_manager.calc_pending_cash_balance()
+
+        # Expected:
+        # Stock BUY: -150 * 100 * 1 = -15,000
+        # Option SELL: +2.50 * 5 * 100 = +1,250
+        # Total: -13,750
+        assert pending_balance == -13750.0
+
+    @pytest.mark.asyncio
+    async def test_buy_only_minimum_shares_threshold(self, portfolio_manager, mocker):
+        """Test that buy-only rebalancing respects minimum shares threshold."""
+        # Mock config with minimum shares threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.1,
+                buy_only_min_threshold_shares=10,
+                buy_only_min_threshold_amount=None,
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power - enough for target allocation
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=10000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.1 * 10000 = $1000, which is 6.66 shares
+        # Since 6 shares < 10 minimum, should not buy
+        assert len(to_buy) == 0
+
+    @pytest.mark.asyncio
+    async def test_buy_only_minimum_amount_threshold(self, portfolio_manager, mocker):
+        """Test that buy-only rebalancing respects minimum dollar amount threshold."""
+        # Mock config with minimum amount threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.05,
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=1000.0,
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=10000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.05 * 10000 = $500, which is 3.33 shares (3 shares = $450)
+        # Since $450 < $1000 minimum, should not buy
+        assert len(to_buy) == 0
+
+    @pytest.mark.asyncio
+    async def test_buy_only_amount_less_than_one_share_rounds_up(
+        self, portfolio_manager, mocker
+    ):
+        """Test that when min amount is less than 1 share price, it rounds up to 1 share."""
+        # Mock config with small minimum amount threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.01,  # Small allocation
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=100.0,  # Less than 1 share
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=10000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.01 * 10000 = $100, which is 0.66 shares
+        # Min amount is $100, which is less than 1 share ($150)
+        # Should round up to 1 share
+        assert len(to_buy) == 1
+        assert to_buy[0][0] == "AAPL"
+        assert to_buy[0][2] == 1  # Should buy 1 share
+
+    @pytest.mark.asyncio
+    async def test_buy_only_amount_threshold_takes_precedence(
+        self, portfolio_manager, mocker
+    ):
+        """Test that dollar amount threshold takes precedence over shares threshold."""
+        # Mock config with both thresholds
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.1,
+                buy_only_min_threshold_shares=1,  # Would allow purchase
+                buy_only_min_threshold_amount=2000.0,  # Would block purchase
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=10000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.1 * 10000 = $1000, which is 6.66 shares (6 shares = $900)
+        # Even though 6 shares meets min shares (1), $900 < $2000 min amount
+        # Should not buy due to amount threshold
+        assert len(to_buy) == 0


### PR DESCRIPTION
- Add buy_only_rebalancing option to SymbolConfig for per-symbol control
- Skip put writing for buy-only symbols, buy shares directly instead
- Add minimum thresholds: buy_only_min_threshold_shares and buy_only_min_threshold_amount
- Dollar amount threshold takes precedence over share count
- Round up to 1 share when min amount < 1 share price
- Fix calc_pending_cash_balance() to handle stock orders with multiplier of 1
- Add comprehensive tests for all buy-only functionality
- Update configuration documentation with examples