### PR TITLE
docs: update README for accuracy and document hidden features

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ Reddit](https://www.reddit.com/r/options/comments/a36k4j/the_wheel_aka_triple_in
 but has been used by many in the past. This bot implements a slightly
 modified version of The Wheel, with my own personal tweaks.
 
+## Risk Disclaimer
+
+**⚠️ WARNING: Options trading involves substantial risk and is not suitable for
+all investors.** Selling options can result in significant losses, potentially
+exceeding your initial investment. Selling naked puts has theoretically unlimited
+downside risk if the underlying asset goes to zero. This is not a "free money"
+strategy—you are being compensated for taking on real financial risk.
+
+Before using ThetaGang:
+- Understand that you can lose money, especially in trending or volatile markets
+- Ensure you have sufficient capital to handle worst-case scenarios
+- Be prepared to own the underlying securities at potentially unfavorable prices
+- Consider paper trading first to understand the mechanics and risks
+- Consult with a financial advisor if you're unsure about the risks
+
 ## How it works
 
 Start by reading [the Reddit
@@ -23,10 +38,11 @@ to get some background.
 
 The strategy, as implemented here, does a few things differently from the one
 described in the post above. For one, it's intended to be used to augment a
-typical index-fund based portfolio with specific asset allocations. For
-example, you might want to use a 60/40 portfolio with SPY (S&P500 fund) and
-TLT (20 year treasury fund). This strategy reduces risk, but may also limit
-gains from big market swings. By reducing risk, one can increase leverage.
+typical index-fund based portfolio with specific asset allocations. The
+default configuration includes a diversified portfolio with SPY (40%), QQQ
+(30%), TLT (20%), and smaller positions in individual stocks. This strategy
+reduces risk, but may also limit gains from big market swings. By reducing
+risk, one can increase leverage.
 
 ThetaGang is quite configurable, and you can adjust the parameters to suit your
 preferences and needs, but the default configuration is designed to be a good
@@ -66,6 +82,18 @@ you will own the underlying). When rolling puts, the strike of the new contracts
 are capped at the old strike plus the premium received (to prevent your account
 from blowing due to over-ratcheting up the buying power usage).
 
+**⚠️ IMPORTANT RISK WARNING**: Selling naked puts has unlimited downside risk.
+If the underlying goes to $0, you lose the full strike price × 100 shares per
+contract, minus the small premium received. Selling options is NOT "free money"
+and only makes sense when:
+- You're willing to own the underlying at the strike price
+- You believe implied volatility exceeds realized volatility
+- You have adequate capital to handle worst-case scenarios
+- You understand and accept the risks involved
+
+This strategy can and will lose money in trending markets or during sharp
+declines. The premium collected is compensation for taking on this risk.
+
 If puts are exercised due to being ITM at expiration, you will own the stock,
 and ThetaGang switches from writing puts to writing calls at a strike at least
 as high as the average cost of the stock held. To avoid missing out on upward
@@ -104,9 +132,18 @@ enabled = true
 ```
 
 Default values are provided, based on the VXTH index, but you may configure
-them to your taste (refer to
-[`thetagang.toml`](https://github.com/brndnmtthws/thetagang/blob/6eab3823120c10c0563e02c5d7f30dfcc0e333fc/thetagang.toml#L294-L331)
-for details).
+them to your taste. Key parameters include:
+
+```toml
+[vix_call_hedge]
+enabled = true
+allocation = 0.01  # 1% of buying power
+close_hedges_when_vix_exceeds = 50  # Auto-close at high VIX
+ignore_dte = 5  # Don't hedge if expiry within 5 days
+```
+
+See [`thetagang.toml`](https://github.com/brndnmtthws/thetagang/blob/6eab3823120c10c0563e02c5d7f30dfcc0e333fc/thetagang.toml#L294-L331)
+for all available options.
 
 Buying VIX calls is not free, and it _will_ create some drag on your portfolio,
 but in times of extreme volatility–such as the COVID-related 2020 market
@@ -136,9 +173,156 @@ You can enable cash management with:
 ```toml
 [cash_management]
 enabled = true
+fund = "SGOV"  # Default short-term treasury ETF
+buy_threshold = 0.01  # Buy when cash > 1% of buying power
+sell_threshold = 0.005  # Sell when cash < 0.5%
+
+[cash_management.orders]
+algo.strategy = "Vwap"  # Use VWAP for cash fund orders
 ```
 
-Refer to [`thetagang.toml`](https://github.com/brndnmtthws/thetagang/blob/4fc34653786ec17fe6ce6ec2406b2d861277f934/thetagang.toml#L330-L377) for all the options.
+This feature uses VWAP (Volume Weighted Average Price) orders by default to
+minimize market impact when moving in and out of cash positions. Refer to
+[`thetagang.toml`](https://github.com/brndnmtthws/thetagang/blob/4fc34653786ec17fe6ce6ec2406b2d861277f934/thetagang.toml#L330-L377) for all the options.
+
+## Advanced Features
+
+ThetaGang includes several advanced features that provide fine-grained control over your trading strategy:
+
+### Buy-Only Rebalancing
+
+For symbols where options premiums are insufficient or unavailable, you can enable direct stock purchases for portfolio rebalancing:
+
+```toml
+[symbols.AAPL]
+buy_only_rebalancing = true
+buy_only_min_threshold_shares = 10  # Minimum shares to buy
+buy_only_min_threshold_amount = 1000  # Minimum dollar amount to buy
+```
+
+This feature is useful for maintaining target allocations in stocks with limited options liquidity or when you want to dollar-cost average into positions.
+
+### Exchange Hours Management
+
+Control when ThetaGang operates relative to market hours:
+
+```toml
+[exchange_hours]
+exchange = "XNYS"  # NYSE by default
+action_when_closed = "wait"  # Options: "wait", "exit", "continue"
+delay_after_open = 1800  # Wait 30 minutes after market open
+delay_before_close = 1800  # Stop 30 minutes before market close
+max_wait_until_open = 3600  # Max wait time if market is closed
+```
+
+### Strike Price Limits
+
+Set boundaries for option strikes to prevent writing options at unfavorable prices:
+
+```toml
+[symbols.SPY.puts]
+strike_limit = 400  # Don't write puts above $400
+
+[symbols.SPY.calls]
+strike_limit = 450  # Don't write calls below $450
+```
+
+### Write Threshold Sigma
+
+Use standard deviation-based thresholds instead of fixed percentages:
+
+```toml
+[constants]
+write_threshold_sigma = 1.0  # Write when 1 standard deviation from current price
+
+[symbols.QQQ.puts]
+write_threshold_sigma = 1.5  # More conservative for this symbol
+```
+
+When specified, sigma thresholds override regular `write_threshold` values.
+
+### Advanced Rolling Features
+
+#### Maintain High Water Mark
+Prevent rolling calls to lower strikes:
+
+```toml
+[roll_when.calls]
+maintain_high_water_mark = true
+```
+
+#### Close If Unable to Roll
+Automatically close positions when suitable roll contracts aren't available:
+
+```toml
+[roll_when]
+close_if_unable_to_roll = true
+```
+
+### Order Management
+
+#### Price Adjustments
+Automatically adjust limit orders after initial delay:
+
+```toml
+[symbols.SPY]
+adjust_price_after_delay = true  # Adjusts to midpoint after delay
+```
+
+#### Algorithm Configuration
+Customize order execution algorithms:
+
+```toml
+[orders.algo]
+strategy = "Adaptive"
+params.priority = "Patient"  # Options: "Urgent", "Normal", "Patient"
+```
+
+### Position Management
+
+#### Calculate Net Contracts
+Enable for spread strategies (PMCCs, calendars):
+
+```toml
+[write_when]
+calculate_net_contracts = true
+```
+
+#### Excess Only for Calls
+Write calls only on shares exceeding target allocation:
+
+```toml
+[write_when.calls]
+excess_only = true
+```
+
+#### No Trading Flag
+Temporarily disable trading for specific symbols:
+
+```toml
+[symbols.TSLA]
+no_trading = true  # Monitor only, no trades
+```
+
+### API Configuration
+
+Fine-tune IBKR API behavior:
+
+```toml
+[ib_async]
+api_response_wait_time = 60  # Seconds to wait for API responses
+logfile = "ib_async.log"  # Enable API logging for debugging
+```
+
+### Target Limits
+
+Set absolute caps on new contracts:
+
+```toml
+[target]
+maximum_new_contracts = 10  # Absolute limit per run
+maximum_new_contracts_percent = 0.5  # Or limit by percentage
+```
 
 ## Project status
 
@@ -187,7 +371,7 @@ gateway.
 
 To use the bot, you'll need an Interactive Brokers account with a working
 installation of IBC. If you want to modify the bot, you'll need an
-installation of Python 3.10 or newer with the
+installation of Python 3.10 to 3.13 with the
 [`uv`](https://docs.astral.sh/uv/) package manager.
 
 One more thing: to run this on a live account, you'll require enough capital
@@ -265,6 +449,69 @@ something like this to your crontab (on systems with a cron installation, use
 
 ```crontab
 0 9 * * 1-5 docker run --rm -i -v ~/thetagang:/etc/thetagang brndnmtthws/thetagang:main --config /etc/thetagang/thetagang.toml
+```
+
+## Configuration Examples
+
+### Conservative Portfolio
+Focus on stability with major index ETFs:
+
+```toml
+[symbols.SPY]
+weight = 0.50
+delta = 0.20  # Lower delta for safer strikes
+
+[symbols.TLT]
+weight = 0.30
+delta = 0.15
+
+[symbols.GLD]
+weight = 0.20
+delta = 0.15
+```
+
+### Growth Portfolio with Hedging
+Higher risk tolerance with VIX protection:
+
+```toml
+[symbols.QQQ]
+weight = 0.60
+delta = 0.30
+
+[symbols.ARKK]
+weight = 0.30
+delta = 0.35
+
+[symbols.IWM]
+weight = 0.10
+delta = 0.30
+
+[vix_call_hedge]
+enabled = true
+allocation = 0.01  # 1% of buying power
+```
+
+### PMCC Strategy
+Poor man's covered calls with net contract calculation:
+
+```toml
+[write_when]
+calculate_net_contracts = true  # Essential for spreads
+
+[symbols.SPY]
+weight = 1.0
+# Manage long calls separately
+# ThetaGang will write short calls against them
+```
+
+### Market Hours Trading
+Trade only during stable market hours:
+
+```toml
+[exchange_hours]
+delay_after_open = 3600  # Wait 1 hour after open
+delay_before_close = 3600  # Stop 1 hour before close
+action_when_closed = "exit"  # Don't run outside hours
 ```
 
 ## Determining which ETFs or stocks to run ThetaGang with


### PR DESCRIPTION
- Fix default portfolio allocation (was incorrectly stated as 60/40 SPY/TLT)
- Add comprehensive risk warnings about unlimited downside of selling puts
- Document 10+ previously hidden configuration options including:
  - Buy-only rebalancing for direct stock purchases
  - Exchange hours management with configurable delays
  - Strike price limits for risk management
  - Sigma-based write thresholds
  - Advanced rolling features (high water mark, close if unable)
  - Order management (price adjustments, algo configuration)
  - Position management options (net contracts, excess only, no trading)
  - API configuration and debugging options
- Add practical configuration examples for different strategies
- Update Python version requirement to specify 3.10-3.13 range
- Enhance VIX hedging and cash management documentation

This makes the README significantly more accurate and helpful for users who previously had to read source code to discover these features.