### PR TITLE
feat: add percentage-based minimum threshold for buy-only rebalancing

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,2 @@
+[lint.per-file-ignores]
+"thetagang/test_*.py" = ["ANN"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,24 +43,21 @@ dev = [
   "ruff>=0.9.1,<0.10.0",
 ]
 
-[tool.lint]
+[tool.ruff]
+# Same as Black.
+line-length = 88
+target-version = "py310"
+exclude = ["stubs"]
+
+[tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default. "A" enables type annotation checks.
 select = ["ANN", "E4", "E7", "E9", "F", "I", "W"]
-# ignore self method type annotations
-ignore = ["ANN1"]
-
-exclude = ["stubs"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable   = ["ALL"]
 unfixable = []
-
-# Same as Black.
-line-length = 88
-
-target-version = "py310"
 
 [tool.pyright]
 defineConstant          = { DEBUG = true }

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -247,16 +247,19 @@ class TestPortfolioManager:
                 weight=0.5,
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
             ),
             "MSFT": mocker.Mock(
                 weight=0.3,
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
             ),
             "GOOGL": mocker.Mock(
                 weight=0.2,
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -399,6 +402,7 @@ class TestPortfolioManager:
                 weight=1.0,  # 100% allocation
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -492,6 +496,7 @@ class TestPortfolioManager:
                 weight=0.1,
                 buy_only_min_threshold_shares=10,
                 buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -542,6 +547,7 @@ class TestPortfolioManager:
                 weight=0.05,
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=1000.0,
+                buy_only_min_threshold_percent=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -594,6 +600,7 @@ class TestPortfolioManager:
                 weight=0.01,  # Small allocation
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=100.0,  # Less than 1 share
+                buy_only_min_threshold_percent=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -649,6 +656,7 @@ class TestPortfolioManager:
                 weight=0.1,
                 buy_only_min_threshold_shares=1,  # Would allow purchase
                 buy_only_min_threshold_amount=2000.0,  # Would block purchase
+                buy_only_min_threshold_percent=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -465,13 +465,15 @@ minimum_open_interest = 10
   # Minimum thresholds (optional):
   # - buy_only_min_threshold_shares: Minimum number of shares to buy (default: 1)
   # - buy_only_min_threshold_amount: Minimum dollar amount for a purchase
-  #   * Dollar amount takes precedence over share count
+  # - buy_only_min_threshold_percent: Minimum as percentage of net liquidation value
+  #   * Priority: percent-based (if specified) > dollar amount > share count
   #   * If min amount < 1 share price, it rounds up to 1 share
   #
   # Examples:
   # buy_only_rebalancing = true
   # buy_only_min_threshold_shares = 10  # Only buy if buying at least 10 shares
   # buy_only_min_threshold_amount = 1000.0  # Only buy if order is at least $1000
+  # buy_only_min_threshold_percent = 0.01  # Only buy if order is at least 1% of NLV
 
   [symbols.ABNB]
   # For symbols that require an exchange, which is typically any company stock,

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -471,6 +471,9 @@ class SymbolConfig(BaseModel):
     buy_only_rebalancing: Optional[bool] = None
     buy_only_min_threshold_shares: Optional[int] = Field(default=None, ge=1)
     buy_only_min_threshold_amount: Optional[float] = Field(default=None, ge=0.0)
+    buy_only_min_threshold_percent: Optional[float] = Field(
+        default=None, ge=0.0, le=1.0
+    )
 
 
 class ActionWhenClosedEnum(str, Enum):

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1313,6 +1313,18 @@ class PortfolioManager:
             symbol_config = self.config.symbols[symbol]
             min_shares = symbol_config.buy_only_min_threshold_shares or 1
             min_amount = symbol_config.buy_only_min_threshold_amount
+            min_percent = symbol_config.buy_only_min_threshold_percent
+
+            # Calculate minimum amount from percentage if specified
+            if min_percent is not None:
+                # Get net liquidation value from account summary
+                net_liquidation_value = float(account_summary["NetLiquidation"].value)
+                percent_min_amount = net_liquidation_value * min_percent
+                # If both percent and amount are specified, use the larger one
+                if min_amount is not None:
+                    min_amount = max(min_amount, percent_min_amount)
+                else:
+                    min_amount = percent_min_amount
 
             # If we're below target but target is less than minimum shares,
             # check if we should still buy to meet minimum threshold

--- a/thetagang/test_buy_only_percent.py
+++ b/thetagang/test_buy_only_percent.py
@@ -1,0 +1,248 @@
+import pytest
+
+from thetagang.portfolio_manager import PortfolioManager
+
+
+@pytest.fixture
+def mock_ib(mocker):
+    """Fixture to create a mock IB object."""
+    mock = mocker.Mock()
+    mock.orderStatusEvent = mocker.Mock()
+    mock.orderStatusEvent.__iadd__ = mocker.Mock(return_value=None)
+    return mock
+
+
+@pytest.fixture
+def mock_config(mocker):
+    """Fixture to create a mock Config object."""
+    config = mocker.Mock()
+    config.account = mocker.Mock()
+    config.account.number = "TEST123"
+    config.ib_async = mocker.Mock()
+    config.ib_async.api_response_wait_time = 1
+    config.orders = mocker.Mock()
+    config.orders.exchange = "SMART"
+    return config
+
+
+@pytest.fixture
+def portfolio_manager(mock_ib, mock_config, mocker):
+    """Fixture to create a PortfolioManager instance."""
+    completion_future = mocker.Mock()
+    return PortfolioManager(mock_config, mock_ib, completion_future, dry_run=False)
+
+
+@pytest.mark.asyncio
+class TestBuyOnlyPercentageThreshold:
+    """Test cases for buy-only percentage threshold functionality."""
+
+    async def test_buy_only_percentage_threshold_basic(self, portfolio_manager, mocker):
+        """Test that buy-only rebalancing respects percentage threshold."""
+        # Mock config with percentage threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.1,
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=0.02,  # 2% of NLV
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=10000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.1 * 10000 = $1000, which is 6.66 shares (6 shares = $900)
+        # 2% of $100,000 NLV = $2000 minimum
+        # $900 < $2000, so should not buy
+        assert len(to_buy) == 0
+
+    async def test_buy_only_percentage_threshold_allows_purchase(
+        self, portfolio_manager, mocker
+    ):
+        """Test that purchases are allowed when meeting percentage threshold."""
+        # Mock config with small percentage threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.2,  # 20% allocation
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=0.01,  # 1% of NLV
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=20000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.2 * 20000 = $4000, which is 26.66 shares (26 shares = $3900)
+        # 1% of $100,000 NLV = $1000 minimum
+        # $3900 > $1000, so should buy
+        assert len(to_buy) == 1
+        assert to_buy[0] == ("AAPL", "NASDAQ", 26)
+
+    async def test_buy_only_percent_takes_precedence_over_amount(
+        self, portfolio_manager, mocker
+    ):
+        """Test that percentage threshold takes precedence over dollar amount when larger."""
+        # Mock config with both percentage and amount thresholds
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.15,
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=1000.0,  # $1000
+                buy_only_min_threshold_percent=0.025,  # 2.5% of NLV
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=15000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.15 * 15000 = $2250, which is 15 shares = $2250
+        # 2.5% of $100,000 NLV = $2500 minimum (larger than $1000 amount threshold)
+        # $2250 < $2500, so should not buy
+        assert len(to_buy) == 0
+
+    async def test_buy_only_amount_takes_precedence_when_larger(
+        self, portfolio_manager, mocker
+    ):
+        """Test that dollar amount threshold is used when it's larger than percentage."""
+        # Mock config with both thresholds, amount being larger
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.15,
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=3000.0,  # $3000
+                buy_only_min_threshold_percent=0.005,  # 0.5% of NLV = $500
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing positions
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=15000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.15 * 15000 = $2250, which is 15 shares = $2250
+        # 0.5% of $100,000 = $500, but amount threshold is $3000 (larger)
+        # $2250 < $3000, so should not buy
+        assert len(to_buy) == 0


### PR DESCRIPTION
- Add buy_only_min_threshold_percent configuration option
- Allows setting purchase thresholds as a percentage of Net Liquidation Value
- Percentage thresholds take precedence over dollar amounts when larger
- Maintain backward compatibility with existing threshold options
- Add comprehensive test coverage for the new feature
- Move ruff configuration to separate .ruff.toml file