### PR TITLE
feat: add buy_only_min_threshold_percent_relative for relative threshold based rebalancing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,12 @@ repos:
     hooks:
       # Update the uv lockfile
       - id: uv-lock
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: uv run pyright
+        language: system
+        types: [python]
+        pass_filenames: true
+        require_serial: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
   "pytest-asyncio>=0.23.0,<0.24",
   "pytest-watch>=4.2.0,<5",
   "ruff>=0.9.1,<0.10.0",
+  "pyright>=1.1.388",
 ]
 
 [tool.ruff]

--- a/tests/test_buy_only_relative_threshold.py
+++ b/tests/test_buy_only_relative_threshold.py
@@ -1,0 +1,327 @@
+import pytest
+from ib_async import Stock
+
+from thetagang.portfolio_manager import PortfolioManager
+
+
+@pytest.fixture
+def mock_ib(mocker):
+    """Fixture to create a mock IB object."""
+    mock = mocker.Mock()
+    mock.orderStatusEvent = mocker.Mock()
+    mock.orderStatusEvent.__iadd__ = mocker.Mock(return_value=None)
+    return mock
+
+
+@pytest.fixture
+def mock_config(mocker):
+    """Fixture to create a mock Config object."""
+    config = mocker.Mock()
+    config.account = mocker.Mock()
+    config.account.number = "TEST123"
+    config.ib_async = mocker.Mock()
+    config.ib_async.api_response_wait_time = 1
+    config.orders = mocker.Mock()
+    config.orders.exchange = "SMART"
+    return config
+
+
+@pytest.fixture
+def portfolio_manager(mock_ib, mock_config, mocker):
+    """Fixture to create a PortfolioManager instance."""
+    completion_future = mocker.Mock()
+    return PortfolioManager(mock_config, mock_ib, completion_future, dry_run=False)
+
+
+@pytest.mark.asyncio
+class TestBuyOnlyRelativeThreshold:
+    """Test cases for buy-only relative percentage threshold functionality."""
+
+    async def test_relative_threshold_blocks_small_differences(
+        self, portfolio_manager, mocker
+    ):
+        """Test that relative threshold blocks purchases when difference is too small."""
+        # Mock config with relative threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.5,  # 50% allocation
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=0.2,  # 20% relative threshold
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # Existing position: 250 shares at $150 = $37,500 (75% of target)
+        mock_stock_contract = mocker.MagicMock(spec=Stock)
+        mock_stock_contract.symbol = "AAPL"
+        portfolio_positions = {
+            "AAPL": [mocker.Mock(contract=mock_stock_contract, position=250)]
+        }
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=50000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.5 * 50000 = $25,000, which is 166.66 shares (166 shares)
+        # Current: 250 shares * $150 = $37,500
+        # We're above target, so shares_to_buy would be negative
+        # No purchase should be made
+        assert len(to_buy) == 0
+
+    async def test_relative_threshold_allows_large_differences(
+        self, portfolio_manager, mocker
+    ):
+        """Test that purchases are allowed when relative difference exceeds threshold."""
+        # Mock config with relative threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.5,  # 50% allocation
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=0.1,  # 10% relative threshold
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing position
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=50000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.5 * 50000 = $25,000, which is 166.66 shares (166 shares)
+        # Current: 0 shares
+        # Relative difference: (25000 - 0) / 25000 = 100%
+        # 100% > 10% threshold, so should buy
+        assert len(to_buy) == 1
+        assert to_buy[0] == ("AAPL", "NASDAQ", 166)
+
+    async def test_relative_threshold_with_partial_position(
+        self, portfolio_manager, mocker
+    ):
+        """Test relative threshold with a partial position."""
+        # Mock config with relative threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.4,  # 40% allocation
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=0.3,  # 30% relative threshold
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # Existing position: 50 shares at $200 = $10,000 (50% of target)
+        mock_stock_contract = mocker.MagicMock(spec=Stock)
+        mock_stock_contract.symbol = "AAPL"
+        portfolio_positions = {
+            "AAPL": [mocker.Mock(contract=mock_stock_contract, position=50)]
+        }
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=40000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 200.0  # $200 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.4 * 40000 = $16,000, which is 80 shares
+        # Current: 50 shares * $200 = $10,000
+        # Shares to buy: 80 - 50 = 30
+        # Relative difference: (16000 - 10000) / 16000 = 37.5%
+        # 37.5% > 30% threshold, so should buy
+        assert len(to_buy) == 1
+        assert to_buy[0] == ("AAPL", "NASDAQ", 30)
+
+    async def test_relative_threshold_priority_over_absolute(
+        self, portfolio_manager, mocker
+    ):
+        """Test that relative threshold takes priority over absolute threshold."""
+        # Mock config with both relative and absolute thresholds
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.2,  # 20% allocation
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=0.001,  # 0.1% of NLV (very low)
+                buy_only_min_threshold_percent_relative=0.5,  # 50% relative threshold
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # Existing position: 40 shares at $100 = $4,000 (40% of target)
+        mock_stock_contract = mocker.MagicMock(spec=Stock)
+        mock_stock_contract.symbol = "AAPL"
+        portfolio_positions = {
+            "AAPL": [mocker.Mock(contract=mock_stock_contract, position=40)]
+        }
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=20000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 100.0  # $100 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.2 * 20000 = $4,000, which is 40 shares
+        # Current: 40 shares * $100 = $4,000
+        # We're exactly at target, so shares_to_buy = 0
+        # Even though we meet the absolute threshold, relative difference is 0%
+        # 0% < 50% relative threshold, so should NOT buy
+        assert len(to_buy) == 0
+
+    async def test_relative_threshold_edge_case_zero_target(
+        self, portfolio_manager, mocker
+    ):
+        """Test that relative threshold is ignored when target value is zero."""
+        # Mock config with relative threshold
+        portfolio_manager.config.symbols = {
+            "AAPL": mocker.Mock(
+                weight=0.0,  # 0% allocation
+                buy_only_min_threshold_shares=None,
+                buy_only_min_threshold_amount=None,
+                buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=0.1,  # 10% relative threshold
+            ),
+        }
+        portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
+            return_value=True
+        )
+
+        # Mock account summary - NLV = $100,000
+        account_summary = {"NetLiquidation": mocker.Mock(value=100000)}
+
+        # No existing position
+        portfolio_positions = {}
+
+        # Mock get_buying_power
+        portfolio_manager.get_buying_power = mocker.Mock(return_value=50000)
+
+        # Mock IBKR methods
+        mock_ticker = mocker.Mock()
+        mock_ticker.marketPrice.return_value = 150.0  # $150 per share
+        portfolio_manager.ibkr.get_ticker_for_stock = mocker.AsyncMock(
+            return_value=mock_ticker
+        )
+
+        # Mock get_primary_exchange
+        portfolio_manager.get_primary_exchange = mocker.Mock(return_value="NASDAQ")
+
+        # Mock log.track_async
+        async def mock_track_async(tasks, description):
+            for task in tasks:
+                await task
+
+        mocker.patch("thetagang.log.track_async", side_effect=mock_track_async)
+
+        # Call the method
+        buy_actions_table, to_buy = await portfolio_manager.check_buy_only_positions(
+            account_summary, portfolio_positions
+        )
+
+        # Target: 0.0 * 50000 = $0
+        # With 0% allocation, no purchase should be made regardless of threshold
+        assert len(to_buy) == 0

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -248,18 +248,21 @@ class TestPortfolioManager:
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
                 buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=None,
             ),
             "MSFT": mocker.Mock(
                 weight=0.3,
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
                 buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=None,
             ),
             "GOOGL": mocker.Mock(
                 weight=0.2,
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
                 buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -403,6 +406,7 @@ class TestPortfolioManager:
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
                 buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -497,6 +501,7 @@ class TestPortfolioManager:
                 buy_only_min_threshold_shares=10,
                 buy_only_min_threshold_amount=None,
                 buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -548,6 +553,7 @@ class TestPortfolioManager:
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=1000.0,
                 buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -601,6 +607,7 @@ class TestPortfolioManager:
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=100.0,  # Less than 1 share
                 buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -657,6 +664,7 @@ class TestPortfolioManager:
                 buy_only_min_threshold_shares=1,  # Would allow purchase
                 buy_only_min_threshold_amount=2000.0,  # Would block purchase
                 buy_only_min_threshold_percent=None,
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -465,8 +465,9 @@ minimum_open_interest = 10
   # Minimum thresholds (optional):
   # - buy_only_min_threshold_shares: Minimum number of shares to buy (default: 1)
   # - buy_only_min_threshold_amount: Minimum dollar amount for a purchase
-  # - buy_only_min_threshold_percent: Minimum as percentage of net liquidation value
-  #   * Priority: percent-based (if specified) > dollar amount > share count
+  # - buy_only_min_threshold_percent: Minimum as percentage of net liquidation value (absolute)
+  # - buy_only_min_threshold_percent_relative: Minimum as percentage difference from target allocation
+  #   * Priority: relative percent > absolute percent > dollar amount > share count
   #   * If min amount < 1 share price, it rounds up to 1 share
   #
   # Examples:
@@ -474,6 +475,12 @@ minimum_open_interest = 10
   # buy_only_min_threshold_shares = 10  # Only buy if buying at least 10 shares
   # buy_only_min_threshold_amount = 1000.0  # Only buy if order is at least $1000
   # buy_only_min_threshold_percent = 0.01  # Only buy if order is at least 1% of NLV
+  # buy_only_min_threshold_percent_relative = 0.1  # Only buy if position is >10% below target
+  #
+  # Relative threshold example:
+  # If TLT is allocated 50% but currently only 25% of NLV:
+  # - Relative difference = (50% - 25%) / 50% = 50%
+  # - If threshold = 0.1 (10%), then 50% > 10%, so buy is allowed
 
   [symbols.ABNB]
   # For symbols that require an exchange, which is typically any company stock,

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -474,6 +474,9 @@ class SymbolConfig(BaseModel):
     buy_only_min_threshold_percent: Optional[float] = Field(
         default=None, ge=0.0, le=1.0
     )
+    buy_only_min_threshold_percent_relative: Optional[float] = Field(
+        default=None, ge=0.0, le=1.0
+    )
 
 
 class ActionWhenClosedEnum(str, Enum):

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1314,6 +1314,7 @@ class PortfolioManager:
             min_shares = symbol_config.buy_only_min_threshold_shares or 1
             min_amount = symbol_config.buy_only_min_threshold_amount
             min_percent = symbol_config.buy_only_min_threshold_percent
+            min_percent_relative = symbol_config.buy_only_min_threshold_percent_relative
 
             # Calculate minimum amount from percentage if specified
             if min_percent is not None:
@@ -1325,6 +1326,26 @@ class PortfolioManager:
                     min_amount = max(min_amount, percent_min_amount)
                 else:
                     min_amount = percent_min_amount
+
+            # Check relative percentage threshold (only when we're below target)
+            if (
+                min_percent_relative is not None
+                and target_value > 0
+                and shares_to_buy > 0
+            ):
+                current_value = current_position * market_price
+                relative_diff = (target_value - current_value) / target_value
+
+                # If relative difference is below threshold, skip this symbol
+                if relative_diff < min_percent_relative:
+                    buy_actions_table.add_row(
+                        symbol,
+                        ifmt(current_position),
+                        ifmt(target_shares),
+                        ifmt(0),
+                        f"[yellow]Below relative threshold {min_percent_relative:.1%} (diff: {relative_diff:.1%})",
+                    )
+                    return
 
             # If we're below target but target is less than minimum shares,
             # check if we should still buy to meet minimum threshold

--- a/thetagang/test_buy_only_percent.py
+++ b/thetagang/test_buy_only_percent.py
@@ -45,6 +45,7 @@ class TestBuyOnlyPercentageThreshold:
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
                 buy_only_min_threshold_percent=0.02,  # 2% of NLV
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -98,6 +99,7 @@ class TestBuyOnlyPercentageThreshold:
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=None,
                 buy_only_min_threshold_percent=0.01,  # 1% of NLV
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -152,6 +154,7 @@ class TestBuyOnlyPercentageThreshold:
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=1000.0,  # $1000
                 buy_only_min_threshold_percent=0.025,  # 2.5% of NLV
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(
@@ -205,6 +208,7 @@ class TestBuyOnlyPercentageThreshold:
                 buy_only_min_threshold_shares=None,
                 buy_only_min_threshold_amount=3000.0,  # $3000
                 buy_only_min_threshold_percent=0.005,  # 0.5% of NLV = $500
+                buy_only_min_threshold_percent_relative=None,
             ),
         }
         portfolio_manager.config.is_buy_only_rebalancing = mocker.Mock(

--- a/uv.lock
+++ b/uv.lock
@@ -495,6 +495,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.403"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -702,6 +715,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -730,6 +744,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "pyright", specifier = ">=1.1.388" },
     { name = "pytest", specifier = ">=8.0.0,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.0,<0.24" },
     { name = "pytest-mock", specifier = ">=3.14.0,<4" },


### PR DESCRIPTION
- Add buy_only_min_threshold_percent_relative field to SymbolConfig
- Calculate threshold based on relative % difference from target allocation
- Priority: relative percent > absolute percent > dollar amount > share count
- Add comprehensive tests for the new functionality
- Update thetagang.toml with documentation and examples
- Add pyright to dev dependencies and pre-commit hooks