### PR TITLE
Use tradingClass for extra filtering of option chain

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -2196,7 +2196,15 @@ class PortfolioManager:
 
         chains = await self.ibkr.get_chains_for_contract(underlying)
 
-        chain = next(c for c in chains if c.exchange == underlying.exchange)
+        # Some option contracts (e.g. IWM) have multiple trading classes; pick the one that matches the underlying exchange
+        chain = next(
+            c
+            for c in chains
+            if (
+                c.exchange == underlying.exchange
+                and c.tradingClass == underlying.tradingClass
+            )
+        )
 
         def valid_strike(strike: float) -> bool:
             if right.startswith("P") and strike_limit:


### PR DESCRIPTION
Sometimes an option has multiple trading classes which causes the filtering logic to prematurely choose the wrong trading class. For example, load the ETF `IWM` in IBKR TWS Options Trader and you can choose multiple trading classes.

Notice how SMART shows up twice in the dataset:

<img width="618" height="431" alt="image" src="https://github.com/user-attachments/assets/0a90acf7-59f5-47ae-a189-544a1797c613" />

[chain-data.py](https://github.com/user-attachments/files/23381078/chain-data.py)
