### PR TITLE
fix: tolerate account update timeouts

### DIFF
--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -355,13 +355,19 @@ class PortfolioManager:
             try:
                 await self.ibkr.refresh_account_updates(self.account_number)
             except IBKRRequestTimeout as exc:
-                log.warning(
-                    f"Attempt {attempt}/{attempts}: {exc}. Retrying account update request..."
-                )
                 if attempt == attempts:
-                    raise
-                await asyncio.sleep(1)
-                continue
+                    log.warning(
+                        (
+                            f"Attempt {attempt}/{attempts}: {exc}. "
+                            "Proceeding without a fresh account update snapshot."
+                        )
+                    )
+                else:
+                    log.warning(
+                        f"Attempt {attempt}/{attempts}: {exc}. Retrying account update request..."
+                    )
+                    await asyncio.sleep(1)
+                    continue
 
             portfolio_positions = self.ibkr.portfolio(account=self.account_number)
             filtered_positions = self.filter_positions(portfolio_positions)


### PR DESCRIPTION
Keep the run alive when reqAccountUpdatesAsync never finishes but portfolio data is still available. We now only retry the request on the first two attempts and fall back on the third, logging that the snapshot is stale before continuing to reconcile holdings. Tests cover both the new fallback and the existing retry behaviour.