### PR TITLE
fix: satisfy ty type checks

### DIFF
--- a/thetagang/ibkr.py
+++ b/thetagang/ibkr.py
@@ -1,6 +1,6 @@
 import asyncio
 from enum import Enum
-from typing import Any, Awaitable, Callable, Coroutine, List, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Coroutine, List, Optional, TypeVar, cast
 
 from ib_async import (
     IB,
@@ -140,7 +140,9 @@ class IBKR:
             if result is None:
                 continue
             elif isinstance(result, list):
-                qualified.extend(c for c in result if c is not None)
+                for contract in result:
+                    if contract is not None:
+                        qualified.append(cast(Contract, contract))
             else:
                 qualified.append(result)
         return qualified

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -538,12 +538,13 @@ class PortfolioManager:
             return ""
 
         async def load_position_task(pos: PortfolioItem) -> None:
+            qty = pos.position
+            if isinstance(qty, float):
+                qty_display = ifmt(int(qty)) if qty.is_integer() else ffmt(qty, 4)
+            else:
+                qty_display = ifmt(int(qty))
             position_values[pos.contract.conId] = {
-                "qty": (
-                    ifmt(int(pos.position))
-                    if pos.position.is_integer()
-                    else ffmt(pos.position, 4)
-                ),
+                "qty": qty_display,
                 "mktprice": dfmt(pos.marketPrice),
                 "avgprice": dfmt(pos.averageCost),
                 "value": dfmt(pos.marketValue, 0),
@@ -2422,12 +2423,12 @@ class PortfolioManager:
             return False
 
         def delta_is_valid(ticker: Ticker) -> bool:
+            model_greeks = ticker.modelGreeks
+            delta = model_greeks.delta if model_greeks is not None else None
             return (
-                ticker.modelGreeks is not None
-                and ticker.modelGreeks
-                and ticker.modelGreeks.delta is not None
-                and not util.isNan(ticker.modelGreeks.delta)
-                and abs(ticker.modelGreeks.delta) <= contract_target_delta
+                delta is not None
+                and not util.isNan(delta)
+                and abs(delta) <= contract_target_delta
             )
 
         def price_is_valid(ticker: Ticker) -> bool:

--- a/thetagang/util.py
+++ b/thetagang/util.py
@@ -1,6 +1,6 @@
 import math
 from operator import itemgetter
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import ib_async.objects
 import ib_async.ticker
@@ -98,19 +98,19 @@ def count_long_option_positions(positions: List[PortfolioItem], right: str) -> i
 
 
 def calculate_net_short_positions(positions: List[PortfolioItem], right: str) -> int:
-    shorts = [
+    shorts: List[Tuple[int, float, float]] = [
         (
             option_dte(p.contract.lastTradeDateOrContractMonth),
-            p.contract.strike,
-            p.position,
+            float(p.contract.strike),
+            float(p.position),
         )
         for p in get_short_positions(positions, right)
     ]
-    longs = [
+    longs: List[Tuple[int, float, float]] = [
         (
             option_dte(p.contract.lastTradeDateOrContractMonth),
-            p.contract.strike,
-            p.position,
+            float(p.contract.strike),
+            float(p.position),
         )
         for p in get_long_positions(positions, right)
     ]


### PR DESCRIPTION
Resolve ty diagnostics across IBKR helpers, portfolio display, and netting math.

- Avoid generator-to-extend typing mismatch when qualifying contracts; cast filtered entries to Contract after runtime None checks.
- Guard position quantity formatting to handle int vs float without calling float-only helpers.
- Make delta validation explicitly bool-safe by extracting the delta once.
- Add explicit tuple typing and numeric casts for net short calculations to match calc_net signatures.