### PR TITLE
fix: silence third-party logging by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ cython_debug/
 
 # Ignore notebooks
 *.ipynb
+
+# Ignore local db for testing
+data/thetagang.db

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,7 +9,9 @@ from thetagang.db import Base
 
 config = context.config
 
-if config.config_file_name is not None:
+if config.config_file_name is not None and config.attributes.get(
+    "configure_logger", True
+):
     fileConfig(config.config_file_name)
 
 target_metadata = Base.metadata

--- a/thetagang/db.py
+++ b/thetagang/db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import platform
 import shutil
@@ -200,6 +201,10 @@ def make_alembic_config(db_url: str) -> AlembicConfig:
     alembic_cfg = AlembicConfig(str(base_dir / "alembic.ini"))
     alembic_cfg.set_main_option("sqlalchemy.url", db_url)
     alembic_cfg.set_main_option("script_location", str(base_dir / "alembic"))
+    configure_logger = (
+        logging.getLogger("thetagang.main").getEffectiveLevel() <= logging.INFO
+    )
+    alembic_cfg.attributes["configure_logger"] = configure_logger
     return alembic_cfg
 
 

--- a/thetagang/main.py
+++ b/thetagang/main.py
@@ -13,7 +13,7 @@ CONTEXT_SETTINGS = dict(
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
-@click_log.simple_verbosity_option(logger)
+@click_log.simple_verbosity_option(logger, default="WARNING")
 @click.option(
     "-c",
     "--config",
@@ -40,6 +40,13 @@ def cli(config: str, without_ibc: bool, dry_run: bool) -> None:
     There's a sample config on GitHub, here:
     https://github.com/brndnmtthws/thetagang/blob/main/thetagang.toml
     """
+
+    if logger.getEffectiveLevel() > logging.INFO:
+        logging.getLogger("alembic").setLevel(logging.WARNING)
+        logging.getLogger("alembic.runtime").setLevel(logging.WARNING)
+        logging.getLogger("alembic.runtime.migration").setLevel(logging.WARNING)
+        logging.getLogger("ib_async").setLevel(logging.WARNING)
+        logging.getLogger("ib_async.client").setLevel(logging.WARNING)
 
     from .thetagang import start
 

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -1,3 +1,4 @@
+import asyncio
 from asyncio import Future
 
 import toml
@@ -10,7 +11,12 @@ from thetagang.db import DataStore, sqlite_db_path
 from thetagang.exchange_hours import need_to_exit
 from thetagang.portfolio_manager import PortfolioManager
 
-util.patchAsyncio()
+try:
+    asyncio.get_running_loop()
+except RuntimeError:
+    pass
+else:
+    util.patchAsyncio()
 
 console = Console()
 


### PR DESCRIPTION
Lower default CLI verbosity to WARNING and explicitly bump down alembic and ib_async loggers unless the user opts into extra verbosity.

Gate alembic fileConfig behind a config attribute so migration logging only wires when enabled, and propagate that flag from the runtime config builder.

Guard ib_async asyncio patching so Python 3.14 wait_for timeouts only run inside a running loop, preventing runtime errors when no loop exists.

Ignore the local sqlite db artifact to keep test runs from dirtying the working tree.