### PR TITLE
feat(flex): ingest IBKR cash transactions

### DIFF
--- a/alembic/versions/0003_add_cash_transactions.py
+++ b/alembic/versions/0003_add_cash_transactions.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0003_add_cash_transactions"
+down_revision = "0002_add_order_intents"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cash_transactions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("unique_hash", sa.String(), nullable=False),
+        sa.Column("external_id", sa.String(), nullable=True),
+        sa.Column("account_id", sa.String(), nullable=True),
+        sa.Column("section", sa.String(), nullable=True),
+        sa.Column("row_type", sa.String(), nullable=True),
+        sa.Column("currency", sa.String(), nullable=True),
+        sa.Column("amount", sa.Float(), nullable=True),
+        sa.Column("trade_date", sa.DateTime(), nullable=True),
+        sa.Column("settle_date", sa.DateTime(), nullable=True),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("symbol", sa.String(), nullable=True),
+        sa.Column("con_id", sa.Integer(), nullable=True),
+        sa.Column("asset_category", sa.String(), nullable=True),
+        sa.Column("transaction_type", sa.String(), nullable=True),
+        sa.Column("raw_json", sa.Text(), nullable=True),
+        sa.UniqueConstraint("source", "unique_hash", name="uniq_cash_transaction"),
+        sqlite_autoincrement=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("cash_transactions")

--- a/tests/test_flex.py
+++ b/tests/test_flex.py
@@ -1,0 +1,54 @@
+import xml.etree.ElementTree as ET
+
+from thetagang.flex import _extract_cash_transactions, _extract_statement_info
+
+
+def test_flex_cash_transaction_parsing() -> None:
+    xml = """
+    <FlexQueryResponse>
+      <FlexStatements>
+        <FlexStatement accountId="U123" fromDate="20240101" toDate="20240131">
+          <CashTransactions>
+            <CashTransaction accountId="U123" currency="USD" amount="5.00"
+              type="Dividends" description="DIV" tradeDate="20240115"
+              conid="123" symbol="AAA"/>
+          </CashTransactions>
+          <Dividends>
+            <Dividend accountId="U123" currency="USD" amount="2.00"
+              description="DIV2" date="20240116"/>
+          </Dividends>
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>
+    """
+    root = ET.fromstring(xml)
+    statement = _extract_statement_info(root)
+    assert statement["account_id"] == "U123"
+    assert statement["from_date"] == "20240101"
+    assert statement["to_date"] == "20240131"
+
+    transactions = _extract_cash_transactions(root, ["CashTransactions", "Dividends"])
+    assert len(transactions) == 2
+    amounts = sorted([t["amount"] for t in transactions if t["amount"] is not None])
+    assert amounts == [2.0, 5.0]
+
+
+def test_flex_cash_transaction_account_filter() -> None:
+    xml = """
+    <FlexQueryResponse>
+      <FlexStatements>
+        <FlexStatement accountId="U123">
+          <CashTransactions>
+            <CashTransaction accountId="U123" currency="USD" amount="5.00"/>
+            <CashTransaction accountId="U999" currency="USD" amount="7.00"/>
+          </CashTransactions>
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>
+    """
+    root = ET.fromstring(xml)
+    transactions = _extract_cash_transactions(
+        root, ["CashTransactions"], account_id_filter="U123"
+    )
+    assert len(transactions) == 1
+    assert transactions[0]["amount"] == 5.0

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -101,6 +101,36 @@ path = "data/thetagang.db"
 # Optional SQLAlchemy URL override, e.g. "sqlite:////abs/path/thetagang.db".
 # url = "sqlite:////path/to/thetagang.db"
 
+[flex]
+# Optional: ingest cash transactions via the IBKR Flex Web Service.
+# This is a cash ledger only (deposits, withdrawals, dividends, interest, fees).
+# Raw prices remain unadjusted; no corporate-action logic is applied.
+enabled = false
+
+# Flex Web Service token and query ID (configure in IBKR Client Portal).
+# token = "REDACTED"
+# query_id = "123456"
+
+# Optional account ID override (defaults to the Flex statement's accountId).
+# account_id = "U1234567"
+
+# Polling controls for Flex report generation.
+polling_interval_seconds = 5
+timeout_seconds = 120
+
+# Sections to parse for cash-flow rows.
+sections = [
+  "CashTransactions",
+  "Dividends",
+  "Interest",
+  "InterestAccruals",
+  "Fees",
+  "OtherFees",
+  "WithholdingTax",
+  "DepositsWithdrawals",
+  "Transfers",
+]
+
 [option_chains]
 # The option chains are lazy loaded, and before you can determine the greeks
 # (delta) or prices, you need to scan the chains. The settings here tell

--- a/thetagang/db.py
+++ b/thetagang/db.py
@@ -187,6 +187,34 @@ class HistoricalBar(Base):
     average: Mapped[Optional[float]] = mapped_column(Float)
 
 
+class CashTransaction(Base):
+    __tablename__ = "cash_transactions"
+    __table_args__ = (
+        UniqueConstraint("source", "unique_hash", name="uniq_cash_transaction"),
+        {"sqlite_autoincrement": True},
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    unique_hash: Mapped[str] = mapped_column(String, nullable=False)
+    external_id: Mapped[Optional[str]] = mapped_column(String)
+    account_id: Mapped[Optional[str]] = mapped_column(String)
+    section: Mapped[Optional[str]] = mapped_column(String)
+    row_type: Mapped[Optional[str]] = mapped_column(String)
+    currency: Mapped[Optional[str]] = mapped_column(String)
+    amount: Mapped[Optional[float]] = mapped_column(Float)
+    trade_date: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    settle_date: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    description: Mapped[Optional[str]] = mapped_column(String)
+    symbol: Mapped[Optional[str]] = mapped_column(String)
+    con_id: Mapped[Optional[int]] = mapped_column(Integer)
+    asset_category: Mapped[Optional[str]] = mapped_column(String)
+    transaction_type: Mapped[Optional[str]] = mapped_column(String)
+    raw_json: Mapped[Optional[str]] = mapped_column(Text)
+
+
 def sqlite_db_path(db_url: str) -> Optional[Path]:
     url = make_url(db_url)
     if not url.drivername.startswith("sqlite"):
@@ -558,6 +586,63 @@ class DataStore:
                     session.execute(stmt)
         except Exception as exc:
             log.warning(f"Failed to record historical bars: {exc}")
+
+    def record_cash_transactions(
+        self, transactions: Iterable[Mapping[str, Any]]
+    ) -> int:
+        try:
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            rows = []
+            for tx in transactions:
+                rows.append(
+                    dict(
+                        run_id=self.run_id,
+                        created_at=now,
+                        source=tx.get("source"),
+                        unique_hash=tx.get("unique_hash"),
+                        external_id=tx.get("external_id"),
+                        account_id=tx.get("account_id"),
+                        section=tx.get("section"),
+                        row_type=tx.get("row_type"),
+                        currency=tx.get("currency"),
+                        amount=tx.get("amount"),
+                        trade_date=tx.get("trade_date"),
+                        settle_date=tx.get("settle_date"),
+                        description=tx.get("description"),
+                        symbol=tx.get("symbol"),
+                        con_id=tx.get("con_id"),
+                        asset_category=tx.get("asset_category"),
+                        transaction_type=tx.get("transaction_type"),
+                        raw_json=tx.get("raw_json"),
+                    )
+                )
+            if rows:
+                with self.session_scope() as session:
+                    stmt = sqlite_insert(CashTransaction).values(rows)
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["source", "unique_hash"],
+                        set_={
+                            "external_id": stmt.excluded.external_id,
+                            "account_id": stmt.excluded.account_id,
+                            "section": stmt.excluded.section,
+                            "row_type": stmt.excluded.row_type,
+                            "currency": stmt.excluded.currency,
+                            "amount": stmt.excluded.amount,
+                            "trade_date": stmt.excluded.trade_date,
+                            "settle_date": stmt.excluded.settle_date,
+                            "description": stmt.excluded.description,
+                            "symbol": stmt.excluded.symbol,
+                            "con_id": stmt.excluded.con_id,
+                            "asset_category": stmt.excluded.asset_category,
+                            "transaction_type": stmt.excluded.transaction_type,
+                            "raw_json": stmt.excluded.raw_json,
+                        },
+                    )
+                    session.execute(stmt)
+            return len(rows)
+        except Exception as exc:
+            log.warning(f"Failed to record cash transactions: {exc}")
+            return 0
 
     def get_last_regime_rebalance_time(
         self,

--- a/thetagang/flex.py
+++ b/thetagang/flex.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Mapping, Optional, Tuple
+
+from thetagang.db import _parse_datetime
+
+FLEX_BASE_URL = (
+    "https://gdcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService"
+)
+
+DEFAULT_SECTIONS = [
+    "CashTransactions",
+    "Dividends",
+    "Interest",
+    "InterestAccruals",
+    "Fees",
+    "OtherFees",
+    "WithholdingTax",
+    "DepositsWithdrawals",
+    "Transfers",
+]
+
+AMOUNT_KEYS = (
+    "amount",
+    "netCash",
+    "cash",
+    "grossAmount",
+    "netAmount",
+    "proceeds",
+    "value",
+    "total",
+)
+
+
+@dataclass(frozen=True)
+class FlexConfig:
+    token: str
+    query_id: str
+    account_id: Optional[str]
+    polling_interval_seconds: int
+    timeout_seconds: int
+    sections: List[str]
+
+
+def fetch_cash_transactions(
+    config: FlexConfig,
+) -> Tuple[List[Mapping[str, Any]], Mapping[str, Any]]:
+    root = _fetch_flex_report(config)
+    transactions = _extract_cash_transactions(
+        root, config.sections, account_id_filter=config.account_id
+    )
+    statement_info = _extract_statement_info(root)
+    return transactions, statement_info
+
+
+def _fetch_flex_report(config: FlexConfig) -> ET.Element:
+    reference_code = _send_request(config.token, config.query_id)
+    start = time.monotonic()
+
+    while True:
+        root = _get_statement(config.token, reference_code)
+        if _looks_like_flex_query(root):
+            return root
+
+        status = _get_status(root)
+        if status and status.lower() == "pending":
+            if time.monotonic() - start > config.timeout_seconds:
+                raise RuntimeError("Flex statement request timed out")
+            time.sleep(config.polling_interval_seconds)
+            continue
+
+        raise RuntimeError(f"Flex statement request failed: status={status}")
+
+
+def _send_request(token: str, query_id: str) -> str:
+    params = {"t": token, "q": query_id}
+    url = f"{FLEX_BASE_URL}.SendRequest?{urllib.parse.urlencode(params)}"
+    root = _fetch_xml(url)
+    status = _get_status(root)
+    if status and status.lower() != "success":
+        raise RuntimeError(f"Flex SendRequest failed: status={status}")
+    reference_code = root.findtext(".//ReferenceCode")
+    if not reference_code:
+        raise RuntimeError("Flex SendRequest missing reference code")
+    return reference_code
+
+
+def _get_statement(token: str, reference_code: str) -> ET.Element:
+    params = {"t": token, "q": reference_code}
+    url = f"{FLEX_BASE_URL}.GetStatement?{urllib.parse.urlencode(params)}"
+    return _fetch_xml(url)
+
+
+def _fetch_xml(url: str) -> ET.Element:
+    with urllib.request.urlopen(url) as response:
+        payload = response.read()
+    return ET.fromstring(payload)
+
+
+def _looks_like_flex_query(root: ET.Element) -> bool:
+    if root.tag == "FlexQueryResponse":
+        return True
+    if root.find(".//FlexStatements") is not None:
+        return True
+    return False
+
+
+def _get_status(root: ET.Element) -> Optional[str]:
+    status = root.findtext(".//Status")
+    if status:
+        return status.strip()
+    return None
+
+
+def _extract_statement_info(root: ET.Element) -> Mapping[str, Any]:
+    statements = root.findall(".//FlexStatement")
+    if not statements:
+        return {}
+    first = statements[0]
+    return {
+        "account_id": first.attrib.get("accountId"),
+        "from_date": first.attrib.get("fromDate"),
+        "to_date": first.attrib.get("toDate"),
+        "statement_count": len(statements),
+    }
+
+
+def _extract_cash_transactions(
+    root: ET.Element,
+    sections: Iterable[str],
+    *,
+    account_id_filter: Optional[str] = None,
+) -> List[Mapping[str, Any]]:
+    statements = root.findall(".//FlexStatement")
+    if not statements:
+        return []
+
+    section_set = {section.strip() for section in sections if section.strip()}
+    rows: List[Mapping[str, Any]] = []
+
+    for statement in statements:
+        statement_account_id = statement.attrib.get("accountId")
+        if account_id_filter and statement_account_id != account_id_filter:
+            continue
+        for section in statement:
+            if section_set and section.tag not in section_set:
+                continue
+            for row in section:
+                raw = dict(row.attrib)
+                row_account_id = raw.get("accountId") or statement_account_id
+                if account_id_filter and row_account_id != account_id_filter:
+                    continue
+                tx = _normalize_cash_row(
+                    raw,
+                    section=section.tag,
+                    row_type=row.tag,
+                    account_id=row_account_id,
+                )
+                rows.append(tx)
+    return rows
+
+
+def _normalize_cash_row(
+    raw: Mapping[str, Any],
+    *,
+    section: str,
+    row_type: str,
+    account_id: Optional[str],
+) -> Mapping[str, Any]:
+    currency = _first_value(raw, ("currency", "fxCurrency"))
+    amount = _parse_amount(_first_value(raw, AMOUNT_KEYS))
+    trade_date = _parse_datetime(
+        _first_value(raw, ("tradeDate", "date", "reportDate", "dateTime")),
+        assume_start_of_day=True,
+    )
+    settle_date = _parse_datetime(
+        _first_value(raw, ("settleDate", "settlementDate")),
+        assume_start_of_day=True,
+    )
+    description = _first_value(raw, ("description", "memo", "detail"))
+    symbol = _first_value(raw, ("symbol", "underlyingSymbol", "ticker"))
+    con_id = _parse_int(_first_value(raw, ("conid", "conId")))
+    asset_category = _first_value(raw, ("assetCategory", "secType"))
+    transaction_type = _first_value(raw, ("type", "transactionType", "activityCode"))
+    external_id = _first_value(raw, ("transactionID", "tradeID", "id"))
+
+    unique_hash = _hash_cash_row(
+        account_id=account_id,
+        section=section,
+        row_type=row_type,
+        currency=currency,
+        amount=amount,
+        trade_date=trade_date,
+        settle_date=settle_date,
+        description=description,
+        symbol=symbol,
+        con_id=con_id,
+        asset_category=asset_category,
+        transaction_type=transaction_type,
+        external_id=external_id,
+    )
+
+    return {
+        "source": "ibkr_flex",
+        "unique_hash": unique_hash,
+        "external_id": external_id,
+        "account_id": account_id,
+        "section": section,
+        "row_type": row_type,
+        "currency": currency,
+        "amount": amount,
+        "trade_date": trade_date,
+        "settle_date": settle_date,
+        "description": description,
+        "symbol": symbol,
+        "con_id": con_id,
+        "asset_category": asset_category,
+        "transaction_type": transaction_type,
+        "raw_json": json.dumps(raw, default=str),
+    }
+
+
+def _hash_cash_row(**kwargs: Any) -> str:
+    payload = "|".join("" if v is None else str(v) for v in kwargs.values())
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _first_value(mapping: Mapping[str, Any], keys: Iterable[str]) -> Optional[str]:
+    for key in keys:
+        value = mapping.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _parse_amount(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    raw = value.replace(",", "").strip()
+    if raw == "":
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _parse_int(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    raw = value.strip()
+    if raw == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None

--- a/thetagang/ibkr.py
+++ b/thetagang/ibkr.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime
 from enum import Enum
 from typing import Any, Awaitable, Callable, Coroutine, List, Optional, TypeVar, cast
 
@@ -77,10 +78,14 @@ class IBKR:
         self,
         contract: Contract,
         duration: str,
+        end_datetime: Optional[datetime] = None,
     ) -> BarDataList:
+        end_str = ""
+        if end_datetime is not None:
+            end_str = end_datetime.strftime("%Y%m%d %H:%M:%S")
         bars = await self.ib.reqHistoricalDataAsync(
             contract,
-            "",
+            end_str,
             duration,
             "1 day",
             "TRADES",


### PR DESCRIPTION
Add Flex config and parser to ingest cash ledger activity from IBKR. Persist cash transactions with a new database table/migration and upsert logic. Record daily ingestion events and wire ingestion into the portfolio manager. Include new unit tests for Flex parsing and cash transaction upserts.