### PR TITLE
feat(regime): base on net liq excluding options and cash fund

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ version = "2.0.0"
 [dependency-groups]
 dev = [
   "pre-commit>=4.0.1",
-  "pytest>=8.0.0,<10",
+  "pytest>=9.0.0,<10",
   "pytest-mock>=3.14.0,<4",
   "pytest-asyncio>=0.23.0,<1.4",
   "pytest-watch>=4.2.0,<5",

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -549,6 +549,12 @@ class RatioGateConfig(BaseModel, DisplayMixin):
         table.add_row("", "Ratio gate var min", "=", f"{ffmt(self.var_min)}")
 
 
+class RegimeRebalanceBaseEnum(str, Enum):
+    net_liq = "net_liq"
+    managed_stocks = "managed_stocks"
+    net_liq_ex_options_cash_fund = "net_liq_ex_options_cash_fund"
+
+
 class RegimeRebalanceConfig(BaseModel, DisplayMixin):
     enabled: bool = Field(default=False)
     symbols: List[str] = Field(default_factory=list)
@@ -567,6 +573,9 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
     eps: float = Field(default=1e-8, gt=0.0)
     order_history_lookback_days: int = Field(default=30, ge=1)
     shares_only: bool = Field(default=False)
+    weight_base: RegimeRebalanceBaseEnum = Field(
+        default=RegimeRebalanceBaseEnum.net_liq_ex_options_cash_fund
+    )
     ratio_gate: Optional[RatioGateConfig] = None
 
     @model_validator(mode="after")
@@ -618,6 +627,7 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
         table.add_row("", "Deficit rail start", "=", f"{dfmt(self.deficit_rail_start)}")
         table.add_row("", "Deficit rail stop", "=", f"{dfmt(self.deficit_rail_stop)}")
         table.add_row("", "Shares only", "=", f"{self.shares_only}")
+        table.add_row("", "Weight base", "=", f"{self.weight_base.value}")
         if self.ratio_gate is not None:
             self.ratio_gate.add_to_table(table, section)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1213,7 +1213,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.0.1" },
-    { name = "pytest", specifier = ">=8.0.0,<10" },
+    { name = "pytest", specifier = ">=9.0.0,<10" },
     { name = "pytest-asyncio", specifier = ">=0.23.0,<1.4" },
     { name = "pytest-mock", specifier = ">=3.14.0,<4" },
     { name = "pytest-watch", specifier = ">=4.2.0,<5" },


### PR DESCRIPTION
Add a single-weight-base mode that subtracts all option market value and the cash fund from net liquidation before applying margin usage. Make this mode the default and log the adjusted base calculation during regime rebalance. Add synthetic tests covering excluded options and SPX box-spread borrowing scenarios, plus DRY position helpers. Update pytest version constraints to >=9.0.0 and refresh uv.lock.