### PR TITLE
feat(regime): exclude options from rebalance base

### DIFF
--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -64,7 +64,7 @@ def portfolio_manager(mock_ib, mocker):
         eps=1e-8,
         order_history_lookback_days=30,
         shares_only=False,
-        weight_base=RegimeRebalanceBaseEnum.net_liq_ex_options_cash_fund,
+        weight_base=RegimeRebalanceBaseEnum.net_liq_ex_options,
     )
 
     completion_future = mocker.Mock()
@@ -112,7 +112,7 @@ def portfolio_manager_with_db(mock_ib, mocker, tmp_path):
         eps=1e-8,
         order_history_lookback_days=30,
         shares_only=False,
-        weight_base=RegimeRebalanceBaseEnum.net_liq_ex_options_cash_fund,
+        weight_base=RegimeRebalanceBaseEnum.net_liq_ex_options,
     )
 
     data_store = DataStore(
@@ -234,7 +234,7 @@ async def test_regime_rebalance_excludes_options_and_cash_fund_from_base(
 ):
     portfolio_manager.config.account.margin_usage = 1.2
     portfolio_manager.config.regime_rebalance.weight_base = (
-        RegimeRebalanceBaseEnum.net_liq_ex_options_cash_fund
+        RegimeRebalanceBaseEnum.net_liq_ex_options
     )
     portfolio_manager.config.regime_rebalance.soft_band = 0.0
     portfolio_manager.config.regime_rebalance.choppiness_min = 0.0
@@ -256,7 +256,7 @@ async def test_regime_rebalance_excludes_options_and_cash_fund_from_base(
         account_summary, portfolio_positions
     )
 
-    assert orders == [("AAA", "NYSE", -50), ("BBB", "NYSE", 150)]
+    assert orders == [("AAA", "NYSE", 40), ("BBB", "NYSE", 240)]
 
 
 @pytest.mark.asyncio
@@ -265,7 +265,7 @@ async def test_regime_rebalance_box_spread_borrowing_excluded_from_base(
 ):
     portfolio_manager.config.account.margin_usage = 1.2
     portfolio_manager.config.regime_rebalance.weight_base = (
-        RegimeRebalanceBaseEnum.net_liq_ex_options_cash_fund
+        RegimeRebalanceBaseEnum.net_liq_ex_options
     )
     portfolio_manager.config.regime_rebalance.soft_band = 0.0
     portfolio_manager.config.regime_rebalance.choppiness_min = 0.0
@@ -304,7 +304,7 @@ async def test_regime_rebalance_box_spread_borrowing_excluded_from_base(
         account_summary, portfolio_positions
     )
 
-    assert orders == [("AAA", "NYSE", 104), ("BBB", "NYSE", 104)]
+    assert orders == [("AAA", "NYSE", 224), ("BBB", "NYSE", 224)]
 
 
 @pytest.mark.asyncio

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -552,7 +552,7 @@ class RatioGateConfig(BaseModel, DisplayMixin):
 class RegimeRebalanceBaseEnum(str, Enum):
     net_liq = "net_liq"
     managed_stocks = "managed_stocks"
-    net_liq_ex_options_cash_fund = "net_liq_ex_options_cash_fund"
+    net_liq_ex_options = "net_liq_ex_options"
 
 
 class RegimeRebalanceConfig(BaseModel, DisplayMixin):
@@ -574,7 +574,7 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
     order_history_lookback_days: int = Field(default=30, ge=1)
     shares_only: bool = Field(default=False)
     weight_base: RegimeRebalanceBaseEnum = Field(
-        default=RegimeRebalanceBaseEnum.net_liq_ex_options_cash_fund
+        default=RegimeRebalanceBaseEnum.net_liq_ex_options
     )
     ratio_gate: Optional[RatioGateConfig] = None
 

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1932,18 +1932,11 @@ class PortfolioManager:
         weight_base = regime_rebalance.weight_base
         if weight_base == RegimeRebalanceBaseEnum.managed_stocks:
             total_value = sum(current_values.values())
-        elif weight_base == RegimeRebalanceBaseEnum.net_liq_ex_options_cash_fund:
+        elif weight_base == RegimeRebalanceBaseEnum.net_liq_ex_options:
             excluded_value = 0.0
-            cash_fund = self.config.cash_management.cash_fund
             for positions in portfolio_positions.values():
                 for position in positions:
                     if isinstance(position.contract, Option):
-                        excluded_value += float(position.marketValue or 0.0)
-                        continue
-                    if (
-                        isinstance(position.contract, Stock)
-                        and position.contract.symbol == cash_fund
-                    ):
                         excluded_value += float(position.marketValue or 0.0)
             net_liq = float(account_summary["NetLiquidation"].value)
             adjusted_net_liq = net_liq - excluded_value
@@ -1951,8 +1944,8 @@ class PortfolioManager:
                 adjusted_net_liq * self.config.account.margin_usage
             )
             log.notice(
-                "Regime rebalancing base: mode=net_liq_ex_options_cash_fund "
-                f"net_liq={dfmt(net_liq)} excluded={dfmt(excluded_value)} "
+                "Regime rebalancing base: mode=net_liq_ex_options "
+                f"net_liq={dfmt(net_liq)} excluded_options={dfmt(excluded_value)} "
                 f"margin_usage={ffmt(self.config.account.margin_usage)} "
                 f"base={dfmt(total_value)}"
             )


### PR DESCRIPTION
Change the regime rebalance base to subtract option market value only (cash fund stays in base) and make it the default. Update base logging to report excluded option value. Adjust synthetic regime rebalance tests for the new base math, including a box-spread borrowing scenario. Tighten typing around ib.run with a local Protocol so ty-check passes without Any.