### PR TITLE
fix(regime): decouple ratio gate from proxy history

### DIFF
--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -171,12 +171,22 @@ def _mock_regime_history(portfolio_manager, mocker, closes):
     return bars
 
 
-def _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0):
+def _mock_regime_tickers(
+    portfolio_manager,
+    mocker,
+    aaa_price=100.0,
+    bbb_price=100.0,
+    extra_prices: dict[str, float] | None = None,
+):
     aaa_ticker = mocker.Mock()
     aaa_ticker.marketPrice.return_value = aaa_price
     bbb_ticker = mocker.Mock()
     bbb_ticker.marketPrice.return_value = bbb_price
     tickers = {"AAA": aaa_ticker, "BBB": bbb_ticker}
+    for symbol, price in (extra_prices or {}).items():
+        ticker = mocker.Mock()
+        ticker.marketPrice.return_value = price
+        tickers[symbol] = ticker
 
     async def _get_ticker(symbol, _primary_exchange):
         return tickers[symbol]
@@ -431,6 +441,50 @@ async def test_regime_rebalance_hard_band_ignores_ratio_gate(portfolio_manager, 
     )
 
     assert orders == [("AAA", "NYSE", -1), ("BBB", "NYSE", 1)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_ratio_gate_handles_uninvested_rest_symbol(
+    portfolio_manager, mocker
+):
+    portfolio_manager.config.portfolio.symbols["AAA"].weight = 0.4
+    portfolio_manager.config.portfolio.symbols["BBB"].weight = 0.4
+    portfolio_manager.config.portfolio.symbols["CCC"] = SimpleNamespace(
+        weight=0.2, primary_exchange="NYSE"
+    )
+    portfolio_manager.config.strategies.regime_rebalance.symbols = [
+        "AAA",
+        "BBB",
+        "CCC",
+    ]
+    portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
+    portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
+    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = SimpleNamespace(
+        enabled=True,
+        anchor="BBB",
+        drift_max=1.25,
+        var_min=0.0,
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="500")}
+    portfolio_positions = {
+        "AAA": [SimpleNamespace(contract=Stock("AAA", "SMART", "USD"), position=3)],
+        "BBB": [SimpleNamespace(contract=Stock("BBB", "SMART", "USD"), position=1)],
+    }
+
+    _mock_regime_tickers(
+        portfolio_manager,
+        mocker,
+        extra_prices={"CCC": 100.0},
+    )
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 100.0, 100.0, 100.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert isinstance(orders, list)
 
 
 @pytest.mark.asyncio

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -933,7 +933,7 @@ class PortfolioManager:
         lookback_days: int,
         cooldown_days: int,
         weights_override: Optional[Dict[str, float]] = None,
-    ) -> Tuple[List[date], List[float], Dict[str, List[float]]]:
+    ) -> Tuple[List[date], List[float]]:
         return await self.regime_engine._get_regime_proxy_series(
             symbols, lookback_days, cooldown_days, weights_override
         )

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -85,12 +85,11 @@ class RegimeRebalanceEngine:
         lookback_days: int,
         cooldown_days: int,
         weights_override: Optional[Dict[str, float]] = None,
-    ) -> Tuple[List[date], List[float], Dict[str, List[float]]]:
+    ) -> Tuple[List[date], List[float]]:
         symbol_configs = resolve_symbol_configs(
             self.config, context="regime proxy series"
         )
-        if weights_override:
-            symbols = list(weights_override.keys())
+        proxy_symbols = list(weights_override.keys()) if weights_override else symbols
         sorted_dates, aligned_closes = await self._get_regime_aligned_closes(
             symbols,
             lookback_days,
@@ -100,7 +99,9 @@ class RegimeRebalanceEngine:
         if weights_override:
             weights = weights_override
         else:
-            weights = {symbol: symbol_configs[symbol].weight for symbol in symbols}
+            weights = {
+                symbol: symbol_configs[symbol].weight for symbol in proxy_symbols
+            }
         total_weight = sum(weights.values())
         if total_weight <= 0:
             log.error("Regime-aware rebalancing weights sum to zero, skipping.")
@@ -114,13 +115,13 @@ class RegimeRebalanceEngine:
         normalized_series = [1.0]
         for idx in range(1, len(sorted_dates)):
             daily_factor = 0.0
-            for symbol in symbols:
+            for symbol in proxy_symbols:
                 prev_close = aligned_closes[symbol][idx - 1]
                 curr_close = aligned_closes[symbol][idx]
                 daily_factor += normalized_weights[symbol] * (curr_close / prev_close)
             normalized_series.append(normalized_series[-1] * daily_factor)
 
-        return (sorted_dates, normalized_series, aligned_closes)
+        return (sorted_dates, normalized_series)
 
     async def _get_regime_aligned_closes(
         self,
@@ -428,7 +429,7 @@ class RegimeRebalanceEngine:
                 symbol: symbol_configs[symbol].weight for symbol in symbols
             }
 
-        dates, values, aligned_closes = await self._get_regime_proxy_series(
+        dates, values = await self._get_regime_proxy_series(
             symbols,
             regime_rebalance.lookback_days,
             regime_rebalance.cooldown_days,
@@ -463,6 +464,11 @@ class RegimeRebalanceEngine:
         ratio_anchor: Optional[str] = None
         ratio_rest: List[str] = []
         if ratio_gate is not None:
+            _, aligned_closes = await self._get_regime_aligned_closes(
+                symbols,
+                regime_rebalance.lookback_days,
+                regime_rebalance.cooldown_days,
+            )
             ratio_anchor = getattr(ratio_gate, "anchor", "")
             ratio_rest = [s for s in symbols if s != ratio_anchor]
             if not ratio_anchor or ratio_anchor not in symbols or not ratio_rest:

--- a/thetagang/trading_operations.py
+++ b/thetagang/trading_operations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 from ib_async import TagValue, Ticker, util
 from ib_async.contract import Contract, Option
@@ -68,7 +68,7 @@ class OrderOperations:
         transmit: bool = True,
         order_id: int | None = None,
     ) -> LimitOrder:
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "tif": tif,
             "account": self.account_number,
             "transmit": transmit,


### PR DESCRIPTION
Add a regression test for an uninvested non-anchor symbol in the ratio basket, fetch aligned closes explicitly for the ratio gate, and widen create_limit_order kwargs typing so the ty pre-commit hook passes.