### PR TITLE
fix(tws): bump pinned version to 1045

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /src
 ADD ./tws/Jts /root/Jts
 ADD ./dist /src/dist
 ADD entrypoint.bash /src/entrypoint.bash
-ADD ./data/jxbrowser-linux64-arm-7.29.jar /root/Jts/1037/jars/
+ADD ./data/jxbrowser-linux64-arm-7.29.jar /root/Jts/1045/jars/
 
 RUN wget -qO- https://astral.sh/uv/install.sh | sh \
   && uv python install 3.14 \

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ If you find something that you think is a bug, or some other issue, please
 The bot is based on the [ib_async](https://github.com/ib-api-reloaded/ib_async)
 library, and uses [IBC](https://github.com/IbcAlpha/IBC) for managing the API
 gateway. The bundled IBC configuration targets the current stable TWS/Gateway
-version (see `IBC(1037, ...)` in the code).
+version (see `IBC(1045, ...)` in the code).
 
 To use the bot, you'll need an Interactive Brokers account with a working
 installation of IBC. If you want to modify the bot, you'll need an

--- a/tests/test_thetagang_watchdog.py
+++ b/tests/test_thetagang_watchdog.py
@@ -114,3 +114,4 @@ def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
     assert captured["watchdog"].started is True
     assert captured["watchdog"].stopped is True
     assert captured["ibc"].terminated is True
+    assert captured["ibc"].twsVersion == 1045

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -123,7 +123,7 @@ def start(
     if not without_ibc:
         # TWS version is pinned to current stable
         ibc_config = config.runtime.ibc
-        ibc = IBC(1037, **ibc_config.to_dict())
+        ibc = IBC(1045, **ibc_config.to_dict())
         log.info(f"Starting TWS with twsVersion={ibc.twsVersion}")
 
         ib.RaiseRequestErrors = ibc_config.RaiseRequestErrors


### PR DESCRIPTION
## Summary

Bump the pinned TWS/IBC startup version from 1037 to 1045 and align the Docker image's architecture-specific JxBrowser jar path with the TWS version now present in the published image.

## User Impact

Cron/container runs using the latest image can start IBC against the installed TWS 1045 tree instead of repeatedly failing during startup because the 1037 directory lacks `tws.vmoptions`.

## Root Cause

The Docker workflow refreshed its cached IBKR stable installer output and picked up TWS 1045, but the application still constructed `IBC(1037, ...)`. The Dockerfile also continued to add the arm JxBrowser jar under `/root/Jts/1037/jars/`, creating an incomplete 1037 directory alongside the real 1045 install.

## Fix

Update the runtime IBC pin to 1045, place the arm JxBrowser jar under `/root/Jts/1045/jars/`, refresh the README reference, and add a focused watchdog test assertion that locks the expected startup version.

## Validation

- `uv run pytest tests/test_thetagang_watchdog.py`
- `uv run ruff check thetagang/thetagang.py tests/test_thetagang_watchdog.py`
