### PR TITLE
fix(tws): suppress log4j status output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,8 @@ RUN wget -qO- https://astral.sh/uv/install.sh | sh \
   && echo '--add-opens java.desktop/java.awt=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '--add-opens java.base/java.util=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '--add-opens javafx.graphics/com.sun.javafx.application=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
-  && echo '-Dlog4j2.statusLoggerLevel=OFF' | tee -a /root/Jts/*/tws.vmoptions \
-  && echo '-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF' | tee -a /root/Jts/*/tws.vmoptions \
+  && echo '-Dlog4j2.statusLoggerLevel=ERROR' | tee -a /root/Jts/*/tws.vmoptions \
+  && echo '-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=ERROR' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '[Logon]' | tee -a /root/Jts/jts.ini \
   && echo 'UseSSL=true' | tee -a /root/Jts/jts.ini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,8 @@ RUN wget -qO- https://astral.sh/uv/install.sh | sh \
   && echo '--add-opens java.desktop/java.awt=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '--add-opens java.base/java.util=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '--add-opens javafx.graphics/com.sun.javafx.application=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
+  && echo '-Dlog4j2.statusLoggerLevel=OFF' | tee -a /root/Jts/*/tws.vmoptions \
+  && echo '-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '[Logon]' | tee -a /root/Jts/jts.ini \
   && echo 'UseSSL=true' | tee -a /root/Jts/jts.ini
 


### PR DESCRIPTION
## Summary

Suppress noisy Log4j2 status logger output emitted by the TWS JVM during startup and shutdown.

## User Impact

ThetaGang cron logs stay focused on bot output instead of showing Java configuration lifecycle messages like `Starting configuration` and `Stopping configuration` around every TWS run.

## Root Cause

TWS 1045 emits Log4j2 internal status logger messages to the container log while its logging configuration initializes and shuts down. Those messages are not ThetaGang events and do not indicate a runtime problem.

## Fix

Append Log4j2 status logger suppression properties to the generated `tws.vmoptions` file in the Docker image. This keeps normal Java stdout/stderr visible while disabling Log4j2 internal status chatter.

## Validation

- `git diff --check HEAD~1..HEAD`
