### PR TITLE
fix(regime): clarify volatility weight output

### DIFF
--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -674,6 +674,56 @@ class Config(BaseModel, DisplayMixin):
             )
         return table
 
+    def create_volatility_weight_table(self) -> Optional[Table]:
+        volatility_symbols = {
+            symbol: sconfig.volatility_weight
+            for symbol, sconfig in self.symbols.items()
+            if sconfig.volatility_weight is not None
+        }
+        if not volatility_symbols:
+            return None
+
+        table = Table(
+            title="Configured volatility-weight targets",
+            box=box.SIMPLE_HEAVY,
+            show_lines=True,
+        )
+        table.add_column("Symbol")
+        table.add_column("Enabled", justify="center")
+        table.add_column("Target vol", justify="right")
+        table.add_column("Lookback", justify="right")
+        table.add_column("Min weight", justify="right")
+        table.add_column("Max weight", justify="right")
+        table.add_column("Band", justify="right")
+        table.add_column("Smooth", justify="right")
+        table.add_column("Up smooth", justify="right")
+        table.add_column("Down smooth", justify="right")
+
+        for symbol, volatility_weight in volatility_symbols.items():
+            if volatility_weight is None:
+                continue
+            table.add_row(
+                symbol,
+                "True" if volatility_weight.enabled else "False",
+                pfmt(volatility_weight.target_vol),
+                str(volatility_weight.lookback_days),
+                pfmt(volatility_weight.min_weight),
+                pfmt(volatility_weight.max_weight),
+                pfmt(volatility_weight.rebalance_band),
+                ffmt(volatility_weight.smoothing_factor),
+                (
+                    ffmt(volatility_weight.increase_smoothing_factor)
+                    if volatility_weight.increase_smoothing_factor is not None
+                    else "-"
+                ),
+                (
+                    ffmt(volatility_weight.decrease_smoothing_factor)
+                    if volatility_weight.decrease_smoothing_factor is not None
+                    else "-"
+                ),
+            )
+        return table
+
     def display(self, config_path: str) -> None:
         console = Console()
         config_table = Table(box=box.SIMPLE_HEAVY)
@@ -698,6 +748,14 @@ class Config(BaseModel, DisplayMixin):
         tree = Tree(":control_knobs:")
         tree.add(Group(f":file_cabinet: Loaded from {config_path}", config_table))
         tree.add(Group(":yin_yang: Symbology", self.create_symbols_table()))
+        volatility_weight_table = self.create_volatility_weight_table()
+        if volatility_weight_table is not None:
+            tree.add(
+                Group(
+                    ":chart_with_upwards_trend: Volatility weights",
+                    volatility_weight_table,
+                )
+            )
 
         console.print(Panel(tree, title="Config"))
 

--- a/thetagang/legacy_config.py
+++ b/thetagang/legacy_config.py
@@ -237,6 +237,56 @@ class LegacyConfig(BaseModel, DisplayMixin):
             )
         return table
 
+    def create_volatility_weight_table(self) -> Optional[Table]:
+        volatility_symbols = {
+            symbol: sconfig.volatility_weight
+            for symbol, sconfig in self.symbols.items()
+            if sconfig.volatility_weight is not None
+        }
+        if not volatility_symbols:
+            return None
+
+        table = Table(
+            title="Configured volatility-weight targets",
+            box=box.SIMPLE_HEAVY,
+            show_lines=True,
+        )
+        table.add_column("Symbol")
+        table.add_column("Enabled", justify="center")
+        table.add_column("Target vol", justify="right")
+        table.add_column("Lookback", justify="right")
+        table.add_column("Min weight", justify="right")
+        table.add_column("Max weight", justify="right")
+        table.add_column("Band", justify="right")
+        table.add_column("Smooth", justify="right")
+        table.add_column("Up smooth", justify="right")
+        table.add_column("Down smooth", justify="right")
+
+        for symbol, volatility_weight in volatility_symbols.items():
+            if volatility_weight is None:
+                continue
+            table.add_row(
+                symbol,
+                "True" if volatility_weight.enabled else "False",
+                pfmt(volatility_weight.target_vol),
+                str(volatility_weight.lookback_days),
+                pfmt(volatility_weight.min_weight),
+                pfmt(volatility_weight.max_weight),
+                pfmt(volatility_weight.rebalance_band),
+                ffmt(volatility_weight.smoothing_factor),
+                (
+                    ffmt(volatility_weight.increase_smoothing_factor)
+                    if volatility_weight.increase_smoothing_factor is not None
+                    else "-"
+                ),
+                (
+                    ffmt(volatility_weight.decrease_smoothing_factor)
+                    if volatility_weight.decrease_smoothing_factor is not None
+                    else "-"
+                ),
+            )
+        return table
+
     def display(self, config_path: str) -> None:
         console = Console()
         config_table = Table(box=box.SIMPLE_HEAVY)
@@ -263,6 +313,14 @@ class LegacyConfig(BaseModel, DisplayMixin):
         tree = Tree(":control_knobs:")
         tree.add(Group(f":file_cabinet: Loaded from {config_path}", config_table))
         tree.add(Group(":yin_yang: Symbology", self.create_symbols_table()))
+        volatility_weight_table = self.create_volatility_weight_table()
+        if volatility_weight_table is not None:
+            tree.add(
+                Group(
+                    ":chart_with_upwards_trend: Volatility weights",
+                    volatility_weight_table,
+                )
+            )
 
         console.print(Panel(tree, title="Config"))
 

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -368,8 +368,12 @@ class RegimeRebalanceEngine:
                     }
                     log.notice(
                         f"{symbol}: volatility weight base={pfmt(base_weight)} "
+                        f"raw={pfmt(raw_weight)} "
                         f"realized_vol={pfmt(realized_vol)} "
-                        f"target={pfmt(target_weight)} effective={pfmt(effective_weight)}"
+                        f"clamped={pfmt(target_weight)} "
+                        f"previous={pfmt(previous_weight)} "
+                        f"smoothing={ffmt(smoothing_factor)} "
+                        f"effective={pfmt(effective_weight)}"
                     )
                 except Exception as exc:
                     log.warning(


### PR DESCRIPTION
## Summary

Clarifies volatility-weight output for regime rebalancing. Startup config display now includes a dedicated volatility-weight table, and the runtime volatility-weight notice separates raw, clamped, previous, smoothing, and effective weights.

## User Impact

Operators can see the configured volatility-weight controls alongside normal symbol weights, making it easier to explain why a dynamic effective target differs from the static portfolio target. Runtime logs now show the full calculation path instead of making the clamped target and effective target look interchangeable.

## Root Cause

PR 660 added dynamic volatility-weight targets, but the config panel continued to show only static symbol weights and the runtime log used a vague `target` label for the clamped volatility target. That made correct output look sloppy or inconsistent when smoothing produced a different effective target.

## Fix

Adds volatility-weight config tables for both v2 and legacy config display paths. Updates the regime engine notice to log raw weight, realized volatility, clamped weight, previous weight, smoothing factor, and effective weight.

## Validation

- `uv run pytest tests/test_config_new.py tests/test_legacy_config.py tests/test_regime_rebalance.py`
- `uv run ruff check thetagang/config.py thetagang/legacy_config.py thetagang/strategies/regime_engine.py`
- `uv run ruff format --check thetagang/config.py thetagang/legacy_config.py thetagang/strategies/regime_engine.py`
