### PR TITLE
fix: reserve regime flow cash from cash management

### DIFF
--- a/tests/test_post_strategy_engine.py
+++ b/tests/test_post_strategy_engine.py
@@ -114,9 +114,47 @@ async def test_do_cashman_excess_cash_buys_cash_fund(mocker):
 
 
 @pytest.mark.asyncio
+async def test_do_cashman_reserved_regime_cash_suppresses_cash_fund_buy(mocker):
+    engine, ibkr, order_ops, _scanner = _make_engine(mocker)
+    engine.config.strategies.cash_management.enabled = True
+    engine._get_reserved_cash_for_post_management = lambda: 4100.0
+    account_summary = {"TotalCashValue": SimpleNamespace(value="8400")}
+    stock_contract = Stock("AAA", "SMART", "USD")
+    stock_order = SimpleNamespace(action="BUY", lmtPrice=100.0, totalQuantity=43)
+    engine.orders.records = mocker.Mock(
+        return_value=[(stock_contract, stock_order, None)]
+    )
+
+    await engine.do_cashman(account_summary, {})
+
+    ibkr.get_ticker_for_stock.assert_not_called()
+    order_ops.create_limit_order.assert_not_called()
+    order_ops.enqueue_order.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_do_cashman_cash_deficit_sells_cash_fund(mocker):
     engine, ibkr, order_ops, _scanner = _make_engine(mocker)
     engine.config.strategies.cash_management.enabled = True
+    account_summary = {"TotalCashValue": SimpleNamespace(value="0")}
+    ticker = SimpleNamespace(contract=Contract(), ask=100.0, bid=100.0)
+    ibkr.get_ticker_for_stock = AsyncMock(return_value=ticker)
+    portfolio_positions = {
+        "SGOV": [SimpleNamespace(contract=Stock("SGOV", "SMART", "USD"), position=10)]
+    }
+
+    await engine.do_cashman(account_summary, portfolio_positions)
+
+    order_ops.create_limit_order.assert_called_once()
+    assert order_ops.create_limit_order.call_args.kwargs["action"] == "SELL"
+    assert order_ops.create_limit_order.call_args.kwargs["quantity"] > 0
+
+
+@pytest.mark.asyncio
+async def test_do_cashman_reserved_regime_cash_does_not_block_cash_fund_sell(mocker):
+    engine, ibkr, order_ops, _scanner = _make_engine(mocker)
+    engine.config.strategies.cash_management.enabled = True
+    engine._get_reserved_cash_for_post_management = lambda: 5000.0
     account_summary = {"TotalCashValue": SimpleNamespace(value="0")}
     ticker = SimpleNamespace(contract=Contract(), ask=100.0, bid=100.0)
     ibkr.get_ticker_for_stock = AsyncMock(return_value=ticker)

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1453,6 +1453,69 @@ async def test_regime_rebalance_cash_added_triggers_buys(portfolio_manager, mock
     )
 
     assert orders == [("AAA", "NYSE", 2), ("BBB", "NYSE", 2)]
+    assert portfolio_manager.get_reserved_cash_for_post_management() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_cash_flow_reserves_unspent_deployable_cash(
+    portfolio_manager, mocker
+):
+    portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.90
+    portfolio_manager.config.strategies.regime_rebalance.hard_band = 0.95
+    portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
+    portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
+    portfolio_manager.config.strategies.regime_rebalance.flow_trade_min = 0.10
+    portfolio_manager.config.strategies.regime_rebalance.flow_trade_stop = 0.05
+    portfolio_manager.config.trading_is_allowed = mocker.Mock(
+        side_effect=lambda symbol: symbol == "AAA"
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="10000")}
+    portfolio_positions = {
+        "AAA": [SimpleNamespace(contract=Stock("AAA", "SMART", "USD"), position=8)],
+        "BBB": [SimpleNamespace(contract=Stock("BBB", "SMART", "USD"), position=8)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == [("AAA", "NYSE", 43)]
+    assert portfolio_manager.get_reserved_cash_for_post_management() == 4100.0
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_flow_gate_without_buys_does_not_reserve_cash(
+    portfolio_manager, mocker
+):
+    portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.90
+    portfolio_manager.config.strategies.regime_rebalance.hard_band = 0.95
+    portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
+    portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
+    portfolio_manager.config.strategies.regime_rebalance.flow_trade_min = 0.10
+    portfolio_manager.config.strategies.regime_rebalance.flow_trade_stop = 0.05
+    portfolio_manager.config.trading_is_allowed = mocker.Mock(return_value=False)
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="10000")}
+    portfolio_positions = {
+        "AAA": [SimpleNamespace(contract=Stock("AAA", "SMART", "USD"), position=8)],
+        "BBB": [SimpleNamespace(contract=Stock("BBB", "SMART", "USD"), position=8)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == []
+    assert portfolio_manager.get_reserved_cash_for_post_management() == 0.0
 
 
 @pytest.mark.asyncio
@@ -1481,6 +1544,7 @@ async def test_regime_rebalance_cash_withdrawn_triggers_sells(
     )
 
     assert orders == [("AAA", "NYSE", -2), ("BBB", "NYSE", -2)]
+    assert portfolio_manager.get_reserved_cash_for_post_management() == 0.0
 
 
 @pytest.mark.asyncio

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -116,6 +116,7 @@ class PortfolioManager:
         self.qualified_contracts: Dict[int, Contract] = {}
         self.dry_run = dry_run
         self.last_untracked_positions: Dict[str, List[PortfolioItem]] = {}
+        self._reserved_cash_for_post_management = 0.0
         self.order_ops = OrderOperations(
             config=self.config,
             account_number=self.account_number,
@@ -171,6 +172,9 @@ class PortfolioManager:
             get_primary_exchange=self.get_primary_exchange,
             get_buying_power=self.get_regime_buying_power,
             now_provider=lambda: datetime.now(),
+            set_reserved_cash_for_post_management=(
+                self.set_reserved_cash_for_post_management
+            ),
         )
         self.equity_engine = EquityRebalanceEngine(
             config=self.config,
@@ -186,6 +190,9 @@ class PortfolioManager:
             option_scanner=self.option_scanner,
             orders=self.orders,
             qualified_contracts=self.qualified_contracts,
+            get_reserved_cash_for_post_management=(
+                self.get_reserved_cash_for_post_management
+            ),
         )
         if run_stage_flags is None:
             default_run = RunConfig(strategies=DEFAULT_RUN_STRATEGIES)
@@ -236,6 +243,12 @@ class PortfolioManager:
             enabled_stages=enabled_stages,
             service=self.post_engine,
         )
+
+    def set_reserved_cash_for_post_management(self, amount: float) -> None:
+        self._reserved_cash_for_post_management = max(0.0, amount)
+
+    def get_reserved_cash_for_post_management(self) -> float:
+        return self._reserved_cash_for_post_management
 
     def get_short_calls(
         self, portfolio_positions: Dict[str, List[PortfolioItem]]
@@ -652,6 +665,7 @@ class PortfolioManager:
     async def manage(self) -> None:
         had_error = False
         try:
+            self.set_reserved_cash_for_post_management(0.0)
             if self.data_store:
                 self.data_store.record_event("run_start", {"dry_run": self.dry_run})
             self.initialize_account()

--- a/thetagang/strategies/post_engine.py
+++ b/thetagang/strategies/post_engine.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import math
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 from ib_async import AccountValue, PortfolioItem, Ticker, util
 from ib_async.contract import Contract, Index, Option, Stock
 
 from thetagang import log
 from thetagang.config import Config
+from thetagang.fmt import dfmt
 from thetagang.ibkr import IBKR
 from thetagang.orders import Orders
 from thetagang.trading_operations import (
@@ -28,6 +29,7 @@ class PostStrategyEngine:
         option_scanner: OptionChainScanner,
         orders: Orders,
         qualified_contracts: Dict[int, Contract],
+        get_reserved_cash_for_post_management: Callable[[], float] | None = None,
     ) -> None:
         self.config = config
         self.ibkr = ibkr
@@ -35,6 +37,14 @@ class PostStrategyEngine:
         self.option_scanner = option_scanner
         self.orders = orders
         self.qualified_contracts = qualified_contracts
+        self._get_reserved_cash_for_post_management = (
+            get_reserved_cash_for_post_management
+        )
+
+    def reserved_cash_for_post_management(self) -> float:
+        if self._get_reserved_cash_for_post_management is None:
+            return 0.0
+        return max(0.0, self._get_reserved_cash_for_post_management())
 
     def calc_pending_cash_balance(self) -> float:
         def get_multiplier(contract: Contract) -> float:
@@ -198,11 +208,21 @@ class PostStrategyEngine:
         sell_threshold = self.config.strategies.cash_management.sell_threshold
         cash_balance = math.floor(float(account_summary["TotalCashValue"].value))
         pending_balance = self.calc_pending_cash_balance()
+        effective_cash_balance = cash_balance + pending_balance
+        reserved_cash = self.reserved_cash_for_post_management()
+        sweepable_cash_balance = effective_cash_balance - reserved_cash
+        if reserved_cash > 0:
+            log.notice(
+                "Cash management: reserving "
+                f"{dfmt(reserved_cash)} for regime flow deployment."
+            )
         try:
-            if not (
-                cash_balance + pending_balance > target_cash_balance + buy_threshold
-                or cash_balance + pending_balance < target_cash_balance - sell_threshold
-            ):
+            amount = 0.0
+            if sweepable_cash_balance > target_cash_balance + buy_threshold:
+                amount = sweepable_cash_balance - target_cash_balance
+            elif effective_cash_balance < target_cash_balance - sell_threshold:
+                amount = effective_cash_balance - target_cash_balance
+            else:
                 return
 
             symbol = self.config.strategies.cash_management.cash_fund
@@ -217,7 +237,6 @@ class PostStrategyEngine:
                 if self.config.strategies.cash_management.orders
                 else self.config.runtime.orders.algo
             )
-            amount = cash_balance + pending_balance - target_cash_balance
             price = ticker.ask if amount > 0 else ticker.bid
             qty = amount // price
             if util.isNan(qty):

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -57,6 +57,7 @@ class RegimeRebalanceEngine:
         get_primary_exchange: Callable[[str], str],
         get_buying_power: Callable[[Dict[str, AccountValue]], int],
         now_provider: Callable[[], datetime],
+        set_reserved_cash_for_post_management: Callable[[float], None] | None = None,
     ) -> None:
         self.config = config
         self.ibkr = ibkr
@@ -65,7 +66,15 @@ class RegimeRebalanceEngine:
         self._get_primary_exchange = get_primary_exchange
         self._get_buying_power = get_buying_power
         self._now = now_provider
+        self._set_reserved_cash_for_post_management = (
+            set_reserved_cash_for_post_management
+        )
         self.regime_rebalance_order_ref_prefix = "tg:regime-rebalance"
+
+    def _reserve_cash_for_post_management(self, amount: float) -> None:
+        if self._set_reserved_cash_for_post_management is None:
+            return
+        self._set_reserved_cash_for_post_management(max(0.0, amount))
 
     @staticmethod
     def _as_int_or_none(value: Any) -> int | None:
@@ -457,6 +466,7 @@ class RegimeRebalanceEngine:
         account_summary: Dict[str, AccountValue],
         portfolio_positions: Dict[str, List[PortfolioItem]],
     ) -> Tuple[Table, List[Tuple[str, str, int]]]:
+        self._reserve_cash_for_post_management(0.0)
         symbol_configs = resolve_symbol_configs(
             self.config, context="regime rebalance check"
         )
@@ -1222,6 +1232,25 @@ class RegimeRebalanceEngine:
                 }
             )
 
+        reserved_cash_for_post_management = 0.0
+        if rebalance_mode == "flow" and flow_gate and excess_cash > 0:
+            buy_order_value = sum(
+                shares * market_prices[symbol]
+                for symbol, _primary_exchange, shares in to_trade
+                if shares > 0
+            )
+            if buy_order_value > 0:
+                reserved_cash_for_post_management = max(
+                    0.0, excess_cash - buy_order_value
+                )
+            if reserved_cash_for_post_management > 0:
+                log.notice(
+                    "Regime rebalancing: reserving "
+                    f"{dfmt(reserved_cash_for_post_management)} "
+                    "from cash management for future flow deployment."
+                )
+        self._reserve_cash_for_post_management(reserved_cash_for_post_management)
+
         log.info(
             f"Regime rebalancing gates: max_relative_drift={pfmt(max_relative_drift)} "
             f"soft_band={pfmt(regime_rebalance.soft_band, 0)} "
@@ -1283,6 +1312,9 @@ class RegimeRebalanceEngine:
                     "flow_gate": flow_gate,
                     "deficit_gate": deficit_gate,
                     "excess_cash": excess_cash,
+                    "reserved_cash_for_post_management": (
+                        reserved_cash_for_post_management
+                    ),
                     "mode": rebalance_mode,
                     "orders": to_trade,
                     "ratio_gate": ratio_payload,
@@ -1300,6 +1332,9 @@ class RegimeRebalanceEngine:
                     "flow_gate": flow_gate,
                     "deficit_gate": deficit_gate,
                     "excess_cash": excess_cash,
+                    "reserved_cash_for_post_management": (
+                        reserved_cash_for_post_management
+                    ),
                     "mode": rebalance_mode,
                     "summary": regime_summary,
                     "ratio_gate": ratio_payload,


### PR DESCRIPTION
## Summary

Reserves positive residual regime cash-flow capital from post-run cash management so large deposits are not immediately swept into the configured cash fund when regime flow is still deploying them.

## User Impact

Operators can still use cash management normally, including occasional cash-fund buys and sells, but the bot avoids unnecessary cash-fund churn when a large cash inflow is being staged into regime rebalance buys across runs.

## Root Cause

Cash management only accounted for same-run pending orders. When regime cash-flow rebalancing generated partial buys and left residual deployable cash for future runs, cash management treated that residual as sweepable surplus and bought the cash fund.

## Fix

Adds run-local reserved cash state owned by the portfolio manager. Regime flow sets the reserve only when positive flow mode generates actual buy orders, subtracting those buy orders from excess cash. Cash management subtracts the reserve only for cash-fund buy decisions, while cash-fund sells continue to use actual cash plus pending orders.

## Validation

- `uv run pytest tests/test_regime_rebalance.py tests/test_post_strategy_engine.py tests/test_strategy_stage_runners.py`
- `uv run ruff check thetagang/strategies/regime_engine.py thetagang/strategies/post_engine.py thetagang/portfolio_manager.py tests/test_regime_rebalance.py tests/test_post_strategy_engine.py`
- Pre-commit hooks during commit: ruff check, ruff format, ty check
