### PR TITLE
fix(docker): configure ib gateway java logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ ADD ./tws/Jts /root/Jts
 ADD ./dist /src/dist
 ADD entrypoint.bash /src/entrypoint.bash
 ADD ./data/jxbrowser-linux64-arm-7.29.jar /root/Jts/1045/jars/
+ADD ./thetagang/ibgateway-log4j2.xml /opt/thetagang/ibgateway-log4j2.xml
 
 RUN wget -qO- https://astral.sh/uv/install.sh | sh \
   && uv python install 3.14 \
@@ -71,12 +72,11 @@ RUN wget -qO- https://astral.sh/uv/install.sh | sh \
   && echo '--add-opens java.desktop/java.awt=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '--add-opens java.base/java.util=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '--add-opens javafx.graphics/com.sun.javafx.application=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
-  && echo '-Dlog4j2.statusLoggerLevel=ERROR' | tee -a /root/Jts/*/tws.vmoptions \
-  && echo '-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=ERROR' | tee -a /root/Jts/*/tws.vmoptions \
-  && for f in /root/Jts/*/ibgateway.vmoptions; do \
+  && for f in /root/Jts/*/tws.vmoptions /root/Jts/*/ibgateway.vmoptions; do \
     test ! -f "$f" || { \
-      echo '-Dlog4j2.statusLoggerLevel=ERROR' | tee -a "$f" ; \
-      echo '-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=ERROR' | tee -a "$f" ; \
+      echo '-Dlog4j.configurationFile=file:/opt/thetagang/ibgateway-log4j2.xml' | tee -a "$f" ; \
+      echo '-Dlog4j2.statusLoggerLevel=OFF' | tee -a "$f" ; \
+      echo '-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF' | tee -a "$f" ; \
     } ; \
   done \
   && echo '[Logon]' | tee -a /root/Jts/jts.ini \

--- a/tests/test_thetagang_startup.py
+++ b/tests/test_thetagang_startup.py
@@ -1,6 +1,4 @@
-import asyncio
 from pathlib import Path
-from typing import Any, cast
 
 import thetagang.thetagang as tg
 
@@ -52,33 +50,3 @@ def test_configure_ib_async_logging_warns_and_continues_on_oserror(
     assert len(warnings) == 1
     assert "Unable to initialize ib_async logfile" in warnings[0]
     assert str(Path(target)) in warnings[0]
-
-
-def test_quiet_ibc_filters_non_started_appender_noise():
-    messages: list[str] = []
-
-    class FakeLogger:
-        def log(self, _level, message: str) -> None:
-            messages.append(message)
-
-    class FakeStdout:
-        def __init__(self):
-            self._lines = [
-                b"JTS-EServerSocketNotifier-103 ERROR Attempted to append to non-started appender h\n",
-                b"JTS-Main ERROR Real startup failure\n",
-                b"",
-            ]
-
-        async def readline(self):
-            return self._lines.pop(0)
-
-    class FakeProc:
-        stdout = FakeStdout()
-
-    ibc = tg.QuietIBC(1045)
-    ibc._proc = cast(Any, FakeProc())
-    ibc._logger = cast(Any, FakeLogger())
-
-    asyncio.run(ibc.monitorAsync())
-
-    assert messages == ["JTS-Main ERROR Real startup failure"]

--- a/tests/test_thetagang_watchdog.py
+++ b/tests/test_thetagang_watchdog.py
@@ -98,7 +98,7 @@ def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
             if not completion_future.done():
                 completion_future.set_result(True)
 
-    monkeypatch.setattr(tg, "QuietIBC", FakeIBC)
+    monkeypatch.setattr(tg, "IBC", FakeIBC)
     monkeypatch.setattr(tg, "Watchdog", FakeWatchdog)
     monkeypatch.setattr(tg, "IB", FakeIB)
     monkeypatch.setattr(tg, "PortfolioManager", FakePortfolioManager)

--- a/thetagang/ibgateway-log4j2.xml
+++ b/thetagang/ibgateway-log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ISO8601} %t %-5level %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="error">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -31,30 +31,6 @@ else:
 console = Console()
 
 
-USELESS_IBC_LOG_MESSAGES = ("Attempted to append to non-started appender h",)
-
-
-class QuietIBC(IBC):
-    async def monitorAsync(self) -> None:
-        while self._proc:
-            stdout = self._proc.stdout
-            if stdout is None:
-                break
-
-            line = await stdout.readline()
-            if not line:
-                break
-
-            message = line.strip().decode()
-            if any(
-                useless_message in message
-                for useless_message in USELESS_IBC_LOG_MESSAGES
-            ):
-                continue
-
-            self._logger.log(self.IbcLogLevel, message)
-
-
 def _configure_ib_async_logging(logfile: Optional[str]) -> None:
     if not logfile:
         return
@@ -147,7 +123,7 @@ def start(
     if not without_ibc:
         # TWS version is pinned to current stable
         ibc_config = config.runtime.ibc
-        ibc = QuietIBC(1045, **ibc_config.to_dict())
+        ibc = IBC(1045, **ibc_config.to_dict())
         log.info(f"Starting TWS with twsVersion={ibc.twsVersion}")
 
         ib.RaiseRequestErrors = ibc_config.RaiseRequestErrors


### PR DESCRIPTION
## Summary

Configure IB Gateway/TWS Java logging in the Docker image instead of filtering subprocess stdout in Python.

## User Impact

Docker runs should no longer print noisy log4j startup/shutdown status messages or non-actionable IB Gateway WARN output during normal ThetaGang execution, while real Java errors continue to go to stdout.

## Root Cause

The previous fix filtered one known Java log line after IBC emitted it. That left other log4j status chatter visible and kept the suppression logic in the application runtime rather than the Java process configuration.

## Fix

Add a dedicated log4j2 configuration for IB Gateway, copy it into the Docker image, and append JVM options to both TWS and Gateway vmoptions files so log4j uses that config with status logging disabled. Remove the custom QuietIBC stdout filter and return startup to the stock ib_async IBC controller.

## Validation

- pre-commit hooks during commit: ruff check, ruff format, ty check
- `uv run pytest tests/test_thetagang_startup.py tests/test_thetagang_watchdog.py`
