### PR TITLE
fix(docker): apply ibc java logging options at launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ WORKDIR /src
 ADD ./tws/Jts /root/Jts
 ADD ./dist /src/dist
 ADD entrypoint.bash /src/entrypoint.bash
+ADD docker/patch-ibc-java-logging.sh /src/patch-ibc-java-logging.sh
 ADD ./data/jxbrowser-linux64-arm-7.29.jar /root/Jts/1045/jars/
 ADD ./thetagang/ibgateway-log4j2.xml /opt/thetagang/ibgateway-log4j2.xml
 
@@ -72,13 +73,7 @@ RUN wget -qO- https://astral.sh/uv/install.sh | sh \
   && echo '--add-opens java.desktop/java.awt=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '--add-opens java.base/java.util=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
   && echo '--add-opens javafx.graphics/com.sun.javafx.application=ALL-UNNAMED' | tee -a /root/Jts/*/tws.vmoptions \
-  && for f in /root/Jts/*/tws.vmoptions /root/Jts/*/ibgateway.vmoptions; do \
-    test ! -f "$f" || { \
-      echo '-Dlog4j.configurationFile=file:/opt/thetagang/ibgateway-log4j2.xml' | tee -a "$f" ; \
-      echo '-Dlog4j2.statusLoggerLevel=OFF' | tee -a "$f" ; \
-      echo '-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF' | tee -a "$f" ; \
-    } ; \
-  done \
+  && sh /src/patch-ibc-java-logging.sh \
   && echo '[Logon]' | tee -a /root/Jts/jts.ini \
   && echo 'UseSSL=true' | tee -a /root/Jts/jts.ini
 

--- a/docker/patch-ibc-java-logging.sh
+++ b/docker/patch-ibc-java-logging.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+ibcstart=${1:-/opt/ibc/scripts/ibcstart.sh}
+log4j_config=${2:-file:/opt/thetagang/ibgateway-log4j2.xml}
+
+if grep -q -- "-Dlog4j.configurationFile=" "$ibcstart"; then
+  exit 0
+fi
+
+tmp=$(mktemp)
+awk -v log4j_config="$log4j_config" '
+  {
+    print
+  }
+  $0 ~ /^java_vm_options="\$java_vm_options -Dinstall4jType=standalone"/ {
+    print "java_vm_options=\"$java_vm_options -Dlog4j.configurationFile=" log4j_config "\""
+    print "java_vm_options=\"$java_vm_options -Dlog4j2.statusLoggerLevel=OFF\""
+    print "java_vm_options=\"$java_vm_options -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF\""
+  }
+' "$ibcstart" > "$tmp"
+
+if ! grep -q -- "-Dlog4j.configurationFile=$log4j_config" "$tmp"; then
+  rm -f "$tmp"
+  echo "Unable to patch IBC Java logging options into $ibcstart" >&2
+  exit 1
+fi
+
+cat "$tmp" > "$ibcstart"
+rm -f "$tmp"


### PR DESCRIPTION
## Haiku

Quiet launch command
Options reach the JVM
Logs settle downstream

## Summary

This changes the Docker image build so IBC receives the Log4j JVM settings through its actual Java launch script instead of through TWS/Gateway `*.vmoptions` files.

## User Impact

Operators should no longer see Log4j initialization chatter from IB Gateway/TWS in service logs when running the Docker image.

## Root Cause

IBC builds its own Java command from the selected TWS/Gateway vmoptions file, but it skips `-D...` system properties while reading that file. The previous Docker build appended Log4j settings to vmoptions files, so those settings did not reliably reach the Java process.

## Fix

Add a small Docker build helper that patches `/opt/ibc/scripts/ibcstart.sh` to append the Log4j configuration and status logger system properties after IBC constructs `java_vm_options`. The Dockerfile now runs that helper instead of appending ignored `-D...` lines to vmoptions files.

## Validation

- `sh -n docker/patch-ibc-java-logging.sh`
- `git diff --check HEAD^ HEAD`
- Commit hooks run during `git commit`:
  - `fix end of files`
  - `trim trailing whitespace`
  - YAML/Ruff/uv-lock/ty hooks skipped because no matching files were staged
