### PR TITLE
fix(regime): gate ratios on annualized volatility

### DIFF
--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import cast
@@ -171,6 +172,25 @@ def _mock_regime_history(portfolio_manager, mocker, closes):
     return bars
 
 
+def _mock_regime_histories(portfolio_manager, mocker, closes_by_symbol):
+    start_date = datetime(2024, 1, 2)
+    bars_by_symbol = {
+        symbol: [
+            SimpleNamespace(date=start_date + timedelta(days=offset), close=close)
+            for offset, close in enumerate(closes)
+        ]
+        for symbol, closes in closes_by_symbol.items()
+    }
+
+    async def _get_history(contract, *_args, **_kwargs):
+        return bars_by_symbol[contract.symbol]
+
+    portfolio_manager.ibkr.request_historical_data = mocker.AsyncMock(
+        side_effect=_get_history
+    )
+    return bars_by_symbol
+
+
 def _mock_regime_tickers(
     portfolio_manager,
     mocker,
@@ -247,6 +267,46 @@ def _volatility_weight(
         smoothing_factor=smoothing_factor,
         increase_smoothing_factor=increase_smoothing_factor,
         decrease_smoothing_factor=decrease_smoothing_factor,
+    )
+
+
+def _ratio_gate_result(
+    portfolio_manager,
+    *,
+    closes_by_symbol,
+    ratio_gate,
+    effective_weights,
+    lookback_days=3,
+):
+    start_date = datetime(2024, 1, 2)
+    symbols = list(closes_by_symbol.keys())
+    dates = [
+        (start_date + timedelta(days=offset)).date()
+        for offset in range(len(next(iter(closes_by_symbol.values()))))
+    ]
+    return portfolio_manager.regime_engine._calculate_ratio_gate(
+        symbols=symbols,
+        dates=dates,
+        aligned_closes=closes_by_symbol,
+        ratio_gate=ratio_gate,
+        effective_weights=effective_weights,
+        lookback_days=lookback_days,
+        eps=1e-8,
+    )
+
+
+def _ratio_gate_config(
+    *,
+    enabled: bool = True,
+    anchor: str = "BBB",
+    drift_max: float = 1.25,
+    vol_min: float = 0.0,
+):
+    return SimpleNamespace(
+        enabled=enabled,
+        anchor=anchor,
+        drift_max=drift_max,
+        vol_min=vol_min,
     )
 
 
@@ -855,12 +915,7 @@ async def test_regime_rebalance_ratio_gate_shadow_metrics_emitted(
     portfolio_manager_with_db, mocker
 ):
     portfolio_manager_with_db.config.strategies.regime_rebalance.ratio_gate = (
-        SimpleNamespace(
-            enabled=False,
-            anchor="BBB",
-            drift_max=1.25,
-            var_min=0.0,
-        )
+        _ratio_gate_config(enabled=False)
     )
     account_summary = {"NetLiquidation": SimpleNamespace(value="400")}
     portfolio_positions = {
@@ -894,11 +949,8 @@ async def test_regime_rebalance_ratio_gate_blocks_soft_rebalance(
 ):
     portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
     portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
-    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = SimpleNamespace(
-        enabled=True,
-        anchor="BBB",
-        drift_max=1.25,
-        var_min=0.0,
+    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = (
+        _ratio_gate_config()
     )
     account_summary = {"NetLiquidation": SimpleNamespace(value="400")}
     portfolio_positions = {
@@ -923,11 +975,8 @@ async def test_regime_rebalance_hard_band_ignores_ratio_gate(portfolio_manager, 
     portfolio_manager.config.strategies.regime_rebalance.hard_band = 0.10
     portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 10.0
     portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 0.01
-    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = SimpleNamespace(
-        enabled=True,
-        anchor="BBB",
-        drift_max=1.25,
-        var_min=0.0,
+    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = (
+        _ratio_gate_config()
     )
     account_summary = {"NetLiquidation": SimpleNamespace(value="400")}
     portfolio_positions = {
@@ -962,11 +1011,8 @@ async def test_regime_rebalance_ratio_gate_handles_uninvested_rest_symbol(
     ]
     portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
     portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
-    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = SimpleNamespace(
-        enabled=True,
-        anchor="BBB",
-        drift_max=1.25,
-        var_min=0.0,
+    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = (
+        _ratio_gate_config()
     )
 
     account_summary = {"NetLiquidation": SimpleNamespace(value="500")}
@@ -988,6 +1034,151 @@ async def test_regime_rebalance_ratio_gate_handles_uninvested_rest_symbol(
     )
 
     assert isinstance(orders, list)
+
+
+def test_regime_rebalance_ratio_gate_reports_nonzero_rebased_metrics(
+    portfolio_manager,
+):
+    result = _ratio_gate_result(
+        portfolio_manager,
+        closes_by_symbol={
+            "AAA": [100.0, 110.0, 105.0, 120.0],
+            "BBB": [100.0, 101.0, 99.0, 103.0],
+        },
+        ratio_gate=_ratio_gate_config(drift_max=999.0),
+        effective_weights={"AAA": 0.5, "BBB": 0.5},
+    )
+
+    assert result.daily_var is not None
+    assert result.daily_std is not None
+    assert result.annualized_vol is not None
+    assert result.daily_var > 0.0
+    assert result.daily_std > 0.0
+    assert result.annualized_vol == pytest.approx(result.daily_std * math.sqrt(252))
+    assert result.ok is True
+
+
+def test_regime_rebalance_ratio_gate_vol_min_is_annualized(portfolio_manager):
+    result = _ratio_gate_result(
+        portfolio_manager,
+        closes_by_symbol={
+            "AAA": [100.0, 110.0, 105.0, 120.0],
+            "BBB": [100.0, 101.0, 99.0, 103.0],
+        },
+        ratio_gate=_ratio_gate_config(drift_max=999.0, vol_min=0.05),
+        effective_weights={"AAA": 0.5, "BBB": 0.5},
+    )
+
+    assert result.daily_var is not None
+    assert result.annualized_vol is not None
+    assert result.daily_var < 0.05
+    assert result.annualized_vol >= 0.05
+    assert result.vol_min == pytest.approx(0.05)
+    assert result.ok is True
+
+
+def test_regime_rebalance_ratio_gate_rebased_index_is_price_scale_invariant(
+    portfolio_manager,
+):
+    closes_by_symbol = {
+        "AAA": [50.0, 55.0, 52.0, 56.0],
+        "BBB": [30.0, 31.0, 30.0, 32.0],
+        "CCC": [20.0, 19.0, 21.0, 22.0],
+    }
+    scaled_closes_by_symbol = {
+        **closes_by_symbol,
+        "AAA": [price * 10 for price in closes_by_symbol["AAA"]],
+    }
+    ratio_gate = _ratio_gate_config(drift_max=999.0)
+    effective_weights = {"AAA": 0.4, "BBB": 0.4, "CCC": 0.2}
+
+    base_result = _ratio_gate_result(
+        portfolio_manager,
+        closes_by_symbol=closes_by_symbol,
+        ratio_gate=ratio_gate,
+        effective_weights=effective_weights,
+    )
+    scaled_result = _ratio_gate_result(
+        portfolio_manager,
+        closes_by_symbol=scaled_closes_by_symbol,
+        ratio_gate=ratio_gate,
+        effective_weights=effective_weights,
+    )
+
+    assert scaled_result.daily_mean == pytest.approx(base_result.daily_mean)
+    assert scaled_result.daily_std == pytest.approx(base_result.daily_std)
+    assert scaled_result.daily_var == pytest.approx(base_result.daily_var)
+    assert scaled_result.annualized_vol == pytest.approx(base_result.annualized_vol)
+    assert scaled_result.tstat == pytest.approx(base_result.tstat)
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_ratio_gate_uses_effective_rest_weights(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager_with_db.config.portfolio.symbols["AAA"].weight = 0.4
+    portfolio_manager_with_db.config.portfolio.symbols[
+        "AAA"
+    ].volatility_weight = _volatility_weight(
+        target_vol=0.05,
+        min_weight=0.1,
+        max_weight=0.4,
+        smoothing_factor=1.0,
+    )
+    portfolio_manager_with_db.config.portfolio.symbols["BBB"].weight = 0.4
+    portfolio_manager_with_db.config.portfolio.symbols["CCC"] = SimpleNamespace(
+        weight=0.2,
+        primary_exchange="NYSE",
+    )
+    portfolio_manager_with_db.config.strategies.regime_rebalance.symbols = [
+        "AAA",
+        "BBB",
+        "CCC",
+    ]
+    portfolio_manager_with_db.config.strategies.regime_rebalance.choppiness_min = 0.0
+    portfolio_manager_with_db.config.strategies.regime_rebalance.efficiency_max = 1.0
+    portfolio_manager_with_db.config.strategies.regime_rebalance.ratio_gate = (
+        _ratio_gate_config(enabled=False, drift_max=999.0)
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="1000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 1)],
+        "BBB": [_stock_position("BBB", 1)],
+        "CCC": [_stock_position("CCC", 1)],
+    }
+
+    _mock_regime_tickers(
+        portfolio_manager_with_db,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=100.0,
+        extra_prices={"CCC": 100.0},
+    )
+    _mock_regime_histories(
+        portfolio_manager_with_db,
+        mocker,
+        {
+            "AAA": [100.0, 200.0, 100.0, 200.0],
+            "BBB": [100.0, 101.0, 100.0, 102.0],
+            "CCC": [100.0, 102.0, 104.0, 106.0],
+        },
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
+
+    await portfolio_manager_with_db.check_regime_rebalance_positions(
+        account_summary,
+        portfolio_positions,
+    )
+
+    payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_gate"
+    )
+    ratio_payload = payload["ratio_gate"]
+    assert ratio_payload["weights"]["AAA"] == pytest.approx(1 / 3)
+    assert ratio_payload["weights"]["CCC"] == pytest.approx(2 / 3)
 
 
 @pytest.mark.asyncio
@@ -1323,6 +1514,9 @@ async def test_regime_rebalance_flow_trades_ignore_regime_gate(
     portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 0.01
     portfolio_manager.config.strategies.regime_rebalance.flow_trade_min = 0.10
     portfolio_manager.config.strategies.regime_rebalance.flow_trade_stop = 0.05
+    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = (
+        _ratio_gate_config(vol_min=0.05)
+    )
 
     account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
     portfolio_positions = {
@@ -1380,6 +1574,37 @@ def test_regime_rebalance_config_rejects_flow_hysteresis_inversion():
 def test_regime_rebalance_config_rejects_deficit_hysteresis_inversion():
     with pytest.raises(ValueError, match="deficit_rail_start"):
         RegimeRebalanceConfig(deficit_rail_start=0.10, deficit_rail_stop=0.20)
+
+
+def test_regime_rebalance_config_accepts_ratio_gate_vol_min():
+    config = RegimeRebalanceConfig(
+        symbols=["AAA", "BBB"],
+        ratio_gate=RatioGateConfig(
+            enabled=True,
+            anchor="AAA",
+            vol_min=0.05,
+        ),
+    )
+
+    assert config.ratio_gate is not None
+    assert config.ratio_gate.vol_min == pytest.approx(0.05)
+
+
+def test_regime_rebalance_config_rejects_ratio_gate_var_min():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "ratio_gate.var_min has been removed; use vol_min instead.*"
+            r"vol_min = sqrt\(var_min \* 252\)"
+        ),
+    ):
+        RatioGateConfig.model_validate(
+            {
+                "enabled": True,
+                "anchor": "AAA",
+                "var_min": 0.01,
+            }
+        )
 
 
 def test_regime_rebalance_config_rejects_ratio_gate_missing_anchor():

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -641,7 +641,7 @@ daily_stddev_window = "30 D"
 # enabled = false  # when true, gates soft rebalances only
 # anchor = "BTAL"  # hedge sleeve anchor; rest is symbols minus anchor
 # drift_max = 1.25  # t-stat threshold for mean drift of ratio returns
-# var_min = 0.0  # minimum variance of ratio returns
+# vol_min = 0.0  # minimum annualized volatility of ratio returns
 
   [portfolio.symbols.TLT]
   weight = 0.2

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -2,7 +2,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from rich.console import Console
 from rich.table import Table
 from typing_extensions import Self
@@ -551,16 +551,35 @@ class SymbolConfig(BaseModel):
 
 
 class RatioGateConfig(BaseModel, DisplayMixin):
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool = Field(default=False)
     anchor: str = Field(default="")
     drift_max: float = Field(default=1.25, ge=0.0)
-    var_min: float = Field(default=0.0, ge=0.0)
+    vol_min: Optional[float] = Field(default=None, ge=0.0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_var_min(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "var_min" in data:
+            raise ValueError(
+                "regime_rebalance.ratio_gate.var_min has been removed; use "
+                "vol_min instead. vol_min is annualized ratio volatility. To "
+                "migrate an old daily variance threshold, set "
+                "vol_min = sqrt(var_min * 252)."
+            )
+        return data
 
     def add_to_table(self, table: Table, section: str = "") -> None:
         table.add_row("", "Ratio gate enabled", "=", f"{self.enabled}")
         table.add_row("", "Ratio gate anchor", "=", self.anchor or "-")
         table.add_row("", "Ratio gate drift max", "=", f"{ffmt(self.drift_max)}")
-        table.add_row("", "Ratio gate var min", "=", f"{ffmt(self.var_min)}")
+        table.add_row(
+            "",
+            "Ratio gate vol min",
+            "=",
+            f"{pfmt(self.vol_min) if self.vol_min is not None else '-'}",
+        )
 
 
 class RegimeRebalanceBaseEnum(str, Enum):

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple
 
@@ -24,6 +25,60 @@ AlignedClosesResult = Tuple[List[date], Dict[str, List[float]]]
 AlignedClosesFetcher = Callable[
     [List[str], int, int], Coroutine[Any, Any, AlignedClosesResult]
 ]
+TRADING_DAYS_PER_YEAR = 252
+
+
+@dataclass(frozen=True)
+class RatioGateResult:
+    ok: bool
+    reason: str
+    anchor: str
+    rest: List[str]
+    weights: Dict[str, float]
+    daily_mean: Optional[float]
+    daily_std: Optional[float]
+    daily_var: Optional[float]
+    annualized_vol: Optional[float]
+    vol_min: float
+    tstat: float
+    drift_max: float
+
+    def to_payload(self, *, enabled: bool) -> Dict[str, Any]:
+        return {
+            "enabled": enabled,
+            "anchor": self.anchor,
+            "rest": self.rest,
+            "weights": self.weights,
+            "var": self.daily_var,
+            "vol": self.annualized_vol,
+            "vol_min": self.vol_min,
+            "std_daily": self.daily_std,
+            "mean_daily": self.daily_mean,
+            "tstat": self.tstat,
+            "drift_max": self.drift_max,
+            "reason": self.reason,
+            "ok": self.ok,
+        }
+
+    def to_log_fields(self) -> str:
+        return (
+            f" ratio_ok={self.ok} "
+            f"ratio_reason={self.reason} "
+            f"ratio_var={_ffmt_or_dash(self.daily_var, 8)} "
+            f"ratio_vol={_pfmt_or_dash(self.annualized_vol)} "
+            f"ratio_vol_min={_pfmt_or_dash(self.vol_min)} "
+            f"ratio_tstat={_ffmt_or_dash(self.tstat)} "
+            f"ratio_drift_max={_ffmt_or_dash(self.drift_max)} "
+            f"anchor={self.anchor} rest={','.join(self.rest)}"
+        )
+
+
+def _ffmt_or_dash(value: Optional[float], precision: int = 2) -> str:
+    return ffmt(value, precision) if value is not None else "-"
+
+
+def _pfmt_or_dash(value: Optional[float]) -> str:
+    return pfmt(value) if value is not None else "-"
 
 
 class RegimeHistoryCache:
@@ -88,6 +143,136 @@ class RegimeRebalanceEngine:
             return float(value)
         return None
 
+    @classmethod
+    def _resolve_ratio_gate_vol_min(cls, ratio_gate: Any) -> float:
+        vol_min = cls._as_float_or_none(getattr(ratio_gate, "vol_min", None))
+        if vol_min is None:
+            return 0.0
+        return max(vol_min, 0.0)
+
+    @staticmethod
+    def _normalize_weights(weights: Dict[str, float]) -> Dict[str, float]:
+        total_weight = sum(weights.values())
+        if total_weight <= 0:
+            raise ValueError("weights must sum to a positive value")
+        return {symbol: weight / total_weight for symbol, weight in weights.items()}
+
+    @staticmethod
+    def _weighted_return_index(
+        symbols: List[str],
+        weights: Dict[str, float],
+        aligned_closes: Dict[str, List[float]],
+        length: int,
+        eps: float = 0.0,
+    ) -> List[float]:
+        index = [1.0]
+        for idx in range(1, length):
+            daily_factor = 0.0
+            for symbol in symbols:
+                prev_close = max(aligned_closes[symbol][idx - 1], eps)
+                curr_close = max(aligned_closes[symbol][idx], eps)
+                daily_factor += weights[symbol] * (curr_close / prev_close)
+            index.append(index[-1] * max(daily_factor, eps))
+        return index
+
+    def _calculate_ratio_gate(
+        self,
+        *,
+        symbols: List[str],
+        dates: List[date],
+        aligned_closes: Dict[str, List[float]],
+        ratio_gate: Any,
+        effective_weights: Dict[str, float],
+        lookback_days: int,
+        eps: float,
+    ) -> RatioGateResult:
+        ratio_anchor = getattr(ratio_gate, "anchor", "")
+        ratio_rest = [symbol for symbol in symbols if symbol != ratio_anchor]
+        if not ratio_anchor or ratio_anchor not in symbols or not ratio_rest:
+            log.error("Regime-aware ratio gate has invalid anchor configuration.")
+            raise ValueError(
+                "Regime-aware ratio gate requires a valid anchor and rest basket."
+            )
+
+        rest_weights = {symbol: effective_weights[symbol] for symbol in ratio_rest}
+        try:
+            normalized_rest_weights = self._normalize_weights(rest_weights)
+        except ValueError:
+            log.error("Ratio gate rest weights sum to zero, skipping.")
+            raise ValueError(
+                "Regime-aware ratio gate requires positive weights."
+            ) from None
+
+        rest_index = self._weighted_return_index(
+            ratio_rest,
+            normalized_rest_weights,
+            aligned_closes,
+            len(dates),
+            eps,
+        )
+        anchor_index = self._weighted_return_index(
+            [ratio_anchor],
+            {ratio_anchor: 1.0},
+            aligned_closes,
+            len(dates),
+            eps,
+        )
+
+        ratio_series = np.log(np.array(rest_index) / np.array(anchor_index))
+        ratio_returns = pd.Series(ratio_series).diff()
+        rolling_returns = ratio_returns.rolling(lookback_days)
+        ratio_var = float(rolling_returns.var(ddof=1).iloc[-1])
+        ratio_mean = float(rolling_returns.mean().iloc[-1])
+        ratio_std = float(rolling_returns.std(ddof=1).iloc[-1])
+        ratio_vol_min = self._resolve_ratio_gate_vol_min(ratio_gate)
+        ratio_drift_max = float(getattr(ratio_gate, "drift_max", 0.0))
+
+        if math.isnan(ratio_var) or math.isnan(ratio_mean) or math.isnan(ratio_std):
+            return RatioGateResult(
+                ok=False,
+                reason="insufficient_history",
+                anchor=ratio_anchor,
+                rest=ratio_rest,
+                weights=normalized_rest_weights,
+                daily_mean=None,
+                daily_std=None,
+                daily_var=None,
+                annualized_vol=None,
+                vol_min=ratio_vol_min,
+                tstat=float("inf"),
+                drift_max=ratio_drift_max,
+            )
+
+        if ratio_std <= 0:
+            ratio_tstat = float("inf")
+        else:
+            ratio_tstat = abs(ratio_mean / (ratio_std / math.sqrt(lookback_days)))
+        annualized_vol = ratio_std * math.sqrt(TRADING_DAYS_PER_YEAR)
+
+        if ratio_std <= 0:
+            reason = "zero_volatility"
+        elif annualized_vol < ratio_vol_min:
+            reason = "vol_below_min"
+        elif ratio_tstat > ratio_drift_max:
+            reason = "drift_above_max"
+        else:
+            reason = "ok"
+
+        return RatioGateResult(
+            ok=reason == "ok",
+            reason=reason,
+            anchor=ratio_anchor,
+            rest=ratio_rest,
+            weights=normalized_rest_weights,
+            daily_mean=ratio_mean,
+            daily_std=ratio_std,
+            daily_var=ratio_var,
+            annualized_vol=annualized_vol,
+            vol_min=ratio_vol_min,
+            tstat=ratio_tstat,
+            drift_max=ratio_drift_max,
+        )
+
     def _resolve_regime_margin_usage(self) -> float:
         fallback_raw = self.config.runtime.account.margin_usage
         fallback = (
@@ -144,25 +329,20 @@ class RegimeRebalanceEngine:
             weights = {
                 symbol: symbol_configs[symbol].weight for symbol in proxy_symbols
             }
-        total_weight = sum(weights.values())
-        if total_weight <= 0:
+        try:
+            normalized_weights = self._normalize_weights(weights)
+        except ValueError:
             log.error("Regime-aware rebalancing weights sum to zero, skipping.")
             raise ValueError(
                 "Regime-aware rebalancing weights must sum to a positive value."
-            )
-        normalized_weights = {
-            symbol: weight / total_weight for symbol, weight in weights.items()
-        }
+            ) from None
 
-        normalized_series = [1.0]
-        for idx in range(1, len(sorted_dates)):
-            daily_factor = 0.0
-            for symbol in proxy_symbols:
-                prev_close = aligned_closes[symbol][idx - 1]
-                curr_close = aligned_closes[symbol][idx]
-                daily_factor += normalized_weights[symbol] * (curr_close / prev_close)
-            normalized_series.append(normalized_series[-1] * daily_factor)
-
+        normalized_series = self._weighted_return_index(
+            proxy_symbols,
+            normalized_weights,
+            aligned_closes,
+            len(sorted_dates),
+        )
         return (sorted_dates, normalized_series)
 
     async def _get_regime_aligned_closes(
@@ -667,90 +847,22 @@ class RegimeRebalanceEngine:
         regime_ok = chop_ok and er_ok
 
         ratio_gate = getattr(regime_rebalance, "ratio_gate", None)
-        ratio_ok: Optional[bool] = None
-        ratio_var: Optional[float] = None
-        ratio_tstat: Optional[float] = None
-        ratio_var_threshold: Optional[float] = None
-        ratio_drift_max: Optional[float] = None
-        ratio_anchor: Optional[str] = None
-        ratio_rest: List[str] = []
+        ratio_result: Optional[RatioGateResult] = None
         if ratio_gate is not None:
-            _, aligned_closes = await history_cache.get(
+            _, ratio_aligned_closes = await history_cache.get(
                 symbols,
                 regime_rebalance.lookback_days,
                 regime_rebalance.cooldown_days,
             )
-            ratio_anchor = getattr(ratio_gate, "anchor", "")
-            ratio_rest = [s for s in symbols if s != ratio_anchor]
-            if not ratio_anchor or ratio_anchor not in symbols or not ratio_rest:
-                log.error("Regime-aware ratio gate has invalid anchor configuration.")
-                raise ValueError(
-                    "Regime-aware ratio gate requires a valid anchor and rest basket."
-                )
-
-            rest_weights = {
-                symbol: symbol_configs[symbol].weight for symbol in ratio_rest
-            }
-            total_rest_weight = sum(rest_weights.values())
-            if total_rest_weight <= 0:
-                log.error("Ratio gate rest weights sum to zero, skipping.")
-                raise ValueError("Regime-aware ratio gate requires positive weights.")
-            normalized_rest_weights = {
-                symbol: weight / total_rest_weight
-                for symbol, weight in rest_weights.items()
-            }
-
-            rest_index = []
-            anchor_series = aligned_closes[ratio_anchor]
-            for idx in range(len(dates)):
-                basket_value = 0.0
-                for symbol in ratio_rest:
-                    basket_value += (
-                        normalized_rest_weights[symbol] * aligned_closes[symbol][idx]
-                    )
-                rest_index.append(max(basket_value, regime_rebalance.eps))
-
-            anchor_prices = [
-                max(price, regime_rebalance.eps) for price in anchor_series
-            ]
-            ratio_series = np.log(np.array(rest_index) / np.array(anchor_prices))
-            ratio_returns = pd.Series(ratio_series).diff()
-            ratio_var = float(
-                ratio_returns.rolling(regime_rebalance.lookback_days)
-                .var(ddof=1)
-                .iloc[-1]
+            ratio_result = self._calculate_ratio_gate(
+                symbols=symbols,
+                dates=dates,
+                aligned_closes=ratio_aligned_closes,
+                ratio_gate=ratio_gate,
+                effective_weights=effective_weights,
+                lookback_days=regime_rebalance.lookback_days,
+                eps=regime_rebalance.eps,
             )
-            ratio_mean = float(
-                ratio_returns.rolling(regime_rebalance.lookback_days).mean().iloc[-1]
-            )
-            ratio_std = float(
-                ratio_returns.rolling(regime_rebalance.lookback_days)
-                .std(ddof=1)
-                .iloc[-1]
-            )
-            if math.isnan(ratio_var) or math.isnan(ratio_mean) or math.isnan(ratio_std):
-                ratio_ok = False
-                ratio_tstat = float("inf")
-                ratio_var_threshold = max(
-                    float(getattr(ratio_gate, "var_min", 0.0)), 0.0
-                )
-                ratio_drift_max = float(getattr(ratio_gate, "drift_max", 0.0))
-            else:
-                if ratio_std <= 0:
-                    ratio_tstat = float("inf")
-                else:
-                    ratio_tstat = abs(
-                        ratio_mean
-                        / (ratio_std / math.sqrt(regime_rebalance.lookback_days))
-                    )
-
-                ratio_var_threshold = max(
-                    float(getattr(ratio_gate, "var_min", 0.0)), 0.0
-                )
-                ratio_drift_max = float(getattr(ratio_gate, "drift_max", 0.0))
-                ratio_ok = (
-                    ratio_var >= ratio_var_threshold and ratio_tstat <= ratio_drift_max
-                )
 
         last_rebalance = await self._get_last_regime_rebalance_time(symbols)
         cooldown_ok = True
@@ -774,7 +886,9 @@ class RegimeRebalanceEngine:
             bool(getattr(ratio_gate, "enabled", False)) if ratio_gate else False
         )
         ratio_gate_ok = (
-            True if ratio_gate is None or not ratio_enabled else bool(ratio_ok)
+            True
+            if ratio_gate is None or not ratio_enabled
+            else bool(ratio_result and ratio_result.ok)
         )
         soft_rebalance = soft_breach and regime_ok and cooldown_ok and ratio_gate_ok
         rebalance_fraction = 1.0
@@ -1251,6 +1365,18 @@ class RegimeRebalanceEngine:
                 )
         self._reserve_cash_for_post_management(reserved_cash_for_post_management)
 
+        ratio_gate_log = ""
+        if ratio_gate is not None:
+            ratio_gate_log = (
+                " ratio_gate="
+                + ("on" if ratio_enabled else "shadow")
+                + (
+                    ratio_result.to_log_fields()
+                    if ratio_result is not None
+                    else " ratio_ok=None"
+                )
+            )
+
         log.info(
             f"Regime rebalancing gates: max_relative_drift={pfmt(max_relative_drift)} "
             f"soft_band={pfmt(regime_rebalance.soft_band, 0)} "
@@ -1264,34 +1390,16 @@ class RegimeRebalanceEngine:
             f"flow_stop={pfmt(regime_rebalance.flow_trade_stop)}({dfmt(flow_trade_stop_amount)}) "
             f"deficit_start={pfmt(regime_rebalance.deficit_rail_start)}({dfmt(deficit_rail_start_amount)}) "
             f"deficit_stop={pfmt(regime_rebalance.deficit_rail_stop)}({dfmt(deficit_rail_stop_amount)}) "
-            f"excess_cash={dfmt(excess_cash)}"
-            + (
-                " "
-                + "ratio_gate="
-                + ("on" if ratio_enabled else "shadow")
-                + f" ratio_ok={ratio_ok} "
-                + f"ratio_var={ffmt(ratio_var) if ratio_var is not None else '-'} "
-                + f"ratio_var_min={ffmt(ratio_var_threshold) if ratio_var_threshold is not None else '-'} "
-                + f"ratio_tstat={ffmt(ratio_tstat) if ratio_tstat is not None else '-'} "
-                + f"ratio_drift_max={ffmt(ratio_drift_max) if ratio_drift_max is not None else '-'} "
-                + f"anchor={ratio_anchor} rest={','.join(ratio_rest)}"
-                if ratio_gate is not None
-                else ""
-            )
+            f"excess_cash={dfmt(excess_cash)}" + ratio_gate_log
         )
         if self.data_store:
             ratio_payload = None
             if ratio_gate is not None:
-                ratio_payload = {
-                    "enabled": ratio_enabled,
-                    "anchor": ratio_anchor,
-                    "rest": ratio_rest,
-                    "var": ratio_var,
-                    "var_min": ratio_var_threshold,
-                    "tstat": ratio_tstat,
-                    "drift_max": ratio_drift_max,
-                    "ok": ratio_ok,
-                }
+                ratio_payload = (
+                    ratio_result.to_payload(enabled=ratio_enabled)
+                    if ratio_result is not None
+                    else {"enabled": ratio_enabled}
+                )
             deficit_active_state = (
                 deficit_gate_after
                 if (hard_rebalance or soft_rebalance)


### PR DESCRIPTION
## Summary
- Replace the ratio gate's raw daily variance threshold with `vol_min`, an annualized ratio volatility threshold.
- Rebuild rest-vs-anchor ratios from rebased return indexes using effective target weights, including volatility-targeted TQQQ weights.
- Keep the ratio gate scoped to soft rebalances while hard-band and flow trades ignore it.

## User Impact
Soft rebalance ratio gating now measures annualized spread volatility instead of comparing a tiny raw daily variance value. This should avoid misleading `ratio_var=0.00` logs and make gate thresholds easier to configure.

Migration: replace `regime_rebalance.ratio_gate.var_min` with `regime_rebalance.ratio_gate.vol_min`. `vol_min` is annualized ratio volatility, so `vol_min = 0.05` means 5% annualized volatility. To migrate an old daily variance threshold, set `vol_min = sqrt(var_min * 252)`. Configs that still set `var_min` now fail fast with this guidance.

## Root Cause
The old gate exposed `var_min` as a raw daily variance threshold, which made configuration and logs easy to misread. It also did not clearly surface the rebased ratio inputs or effective weights used in the gate calculation.

## Fix
- Add a structured ratio gate result with daily mean, daily std, daily variance, annualized volatility, t-stat, threshold, weights, and reason.
- Compute the rest basket as a cumulative return index using normalized effective rest weights and compare it to a rebased anchor index via log ratio returns.
- Gate on `annualized_vol >= vol_min` and `tstat <= drift_max`.
- Update logs and payload fields to preserve `var` while adding clearer `vol`, `vol_min`, `std_daily`, `mean_daily`, and `reason` fields.
- Remove legacy `var_min` config support and reject it with an actionable migration message.

## Validation
- `uv run pytest tests/test_regime_rebalance.py -q`
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run ty check`
