### PR TITLE
fix: gate flow rebalances

### DIFF
--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -310,6 +310,21 @@ def _ratio_gate_config(
     )
 
 
+def _configure_flow_rebalance(
+    portfolio_manager,
+    *,
+    choppiness_min: float = 0.0,
+    efficiency_max: float = 1.0,
+) -> None:
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 0.50
+    regime_rebalance.hard_band = 0.80
+    regime_rebalance.choppiness_min = choppiness_min
+    regime_rebalance.efficiency_max = efficiency_max
+    regime_rebalance.flow_trade_min = 0.10
+    regime_rebalance.flow_trade_stop = 0.05
+
+
 @pytest.mark.asyncio
 async def test_regime_rebalance_generates_orders(portfolio_manager, mocker):
     account_summary = {"NetLiquidation": SimpleNamespace(value="400")}
@@ -1505,23 +1520,19 @@ async def test_regime_rebalance_soft_band_blocked_by_regime(portfolio_manager, m
 
 
 @pytest.mark.asyncio
-async def test_regime_rebalance_flow_trades_ignore_regime_gate(
+async def test_regime_rebalance_flow_trades_require_regime_gate(
     portfolio_manager, mocker
 ):
-    portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.50
-    portfolio_manager.config.strategies.regime_rebalance.hard_band = 0.80
-    portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 10.0
-    portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 0.01
-    portfolio_manager.config.strategies.regime_rebalance.flow_trade_min = 0.10
-    portfolio_manager.config.strategies.regime_rebalance.flow_trade_stop = 0.05
-    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = (
-        _ratio_gate_config(vol_min=0.05)
+    _configure_flow_rebalance(
+        portfolio_manager,
+        choppiness_min=10.0,
+        efficiency_max=0.01,
     )
 
     account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
     portfolio_positions = {
-        "AAA": [SimpleNamespace(contract=Stock("AAA", "SMART", "USD"), position=8)],
-        "BBB": [SimpleNamespace(contract=Stock("BBB", "SMART", "USD"), position=8)],
+        "AAA": [_stock_position("AAA", 8)],
+        "BBB": [_stock_position("BBB", 8)],
     }
 
     _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
@@ -1532,7 +1543,33 @@ async def test_regime_rebalance_flow_trades_ignore_regime_gate(
         account_summary, portfolio_positions
     )
 
-    assert orders == [("AAA", "NYSE", 2), ("BBB", "NYSE", 2)]
+    assert orders == []
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_ratio_gate_blocks_flow_rebalance(
+    portfolio_manager, mocker
+):
+    _configure_flow_rebalance(portfolio_manager)
+    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = (
+        _ratio_gate_config(vol_min=0.05)
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 8)],
+        "BBB": [_stock_position("BBB", 8)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == []
 
 
 def test_normalize_config_converts_parts_to_weights():

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -315,14 +315,16 @@ def _configure_flow_rebalance(
     *,
     choppiness_min: float = 0.0,
     efficiency_max: float = 1.0,
+    flow_trade_min: float = 0.10,
+    flow_trade_stop: float = 0.05,
 ) -> None:
     regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
     regime_rebalance.soft_band = 0.50
     regime_rebalance.hard_band = 0.80
     regime_rebalance.choppiness_min = choppiness_min
     regime_rebalance.efficiency_max = efficiency_max
-    regime_rebalance.flow_trade_min = 0.10
-    regime_rebalance.flow_trade_stop = 0.05
+    regime_rebalance.flow_trade_min = flow_trade_min
+    regime_rebalance.flow_trade_stop = flow_trade_stop
 
 
 @pytest.mark.asyncio
@@ -1570,6 +1572,68 @@ async def test_regime_rebalance_ratio_gate_blocks_flow_rebalance(
     )
 
     assert orders == []
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_blocked_flow_preserves_hysteresis(
+    portfolio_manager_with_db, mocker
+):
+    _configure_flow_rebalance(
+        portfolio_manager_with_db,
+        flow_trade_min=0.25,
+        flow_trade_stop=0.05,
+    )
+    portfolio_manager_with_db.config.strategies.regime_rebalance.ratio_gate = (
+        _ratio_gate_config(vol_min=0.05)
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
+
+    _mock_regime_tickers(
+        portfolio_manager_with_db,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=100.0,
+    )
+    _mock_regime_history(
+        portfolio_manager_with_db,
+        mocker,
+        [100.0, 110.0, 100.0, 110.0],
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
+
+    (
+        _,
+        blocked_orders,
+    ) = await portfolio_manager_with_db.check_regime_rebalance_positions(
+        account_summary,
+        {
+            "AAA": [_stock_position("AAA", 7)],
+            "BBB": [_stock_position("BBB", 7)],
+        },
+    )
+
+    assert blocked_orders == []
+    assert portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_state"
+    ) == {"flow_active": True, "deficit_active": False}
+
+    portfolio_manager_with_db.config.strategies.regime_rebalance.ratio_gate = None
+
+    (
+        _,
+        resumed_orders,
+    ) = await portfolio_manager_with_db.check_regime_rebalance_positions(
+        account_summary,
+        {
+            "AAA": [_stock_position("AAA", 8)],
+            "BBB": [_stock_position("BBB", 8)],
+        },
+    )
+
+    assert resumed_orders == [("AAA", "NYSE", 2), ("BBB", "NYSE", 2)]
 
 
 def test_normalize_config_converts_parts_to_weights():

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -890,7 +890,8 @@ class RegimeRebalanceEngine:
             if ratio_gate is None or not ratio_enabled
             else bool(ratio_result and ratio_result.ok)
         )
-        soft_rebalance = soft_breach and regime_ok and cooldown_ok and ratio_gate_ok
+        soft_or_flow_rebalance_allowed = regime_ok and cooldown_ok and ratio_gate_ok
+        soft_rebalance = soft_breach and soft_or_flow_rebalance_allowed
         rebalance_fraction = 1.0
         if hard_rebalance:
             rebalance_fraction = regime_rebalance.hard_band_rebalance_fraction
@@ -1143,7 +1144,7 @@ class RegimeRebalanceEngine:
                     if delta == 0:
                         continue
                     orders_by_symbol[symbol] = orders_by_symbol.get(symbol, 0) + delta
-        elif flow_gate:
+        elif flow_gate and soft_or_flow_rebalance_allowed:
             rebalance_mode = "flow"
             flow_orders = build_flow_orders(excess_cash)
             for symbol, delta in flow_orders.items():

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -925,6 +925,7 @@ class RegimeRebalanceEngine:
             flow_gate = excess_cash >= flow_trade_min_amount or (
                 flow_active and excess_cash >= flow_trade_stop_amount
             )
+        flow_rebalance = flow_gate and soft_or_flow_rebalance_allowed
 
         allowed_symbols = {
             symbol for symbol in symbols if self.config.trading_is_allowed(symbol)
@@ -1144,7 +1145,7 @@ class RegimeRebalanceEngine:
                     if delta == 0:
                         continue
                     orders_by_symbol[symbol] = orders_by_symbol.get(symbol, 0) + delta
-        elif flow_gate and soft_or_flow_rebalance_allowed:
+        elif flow_rebalance:
             rebalance_mode = "flow"
             flow_orders = build_flow_orders(excess_cash)
             for symbol, delta in flow_orders.items():
@@ -1406,6 +1407,7 @@ class RegimeRebalanceEngine:
                 if (hard_rebalance or soft_rebalance)
                 else deficit_gate
             )
+            flow_active_state = flow_gate and rebalance_mode in {"flow", "no"}
             self.data_store.record_event(
                 "regime_rebalance_gate",
                 {
@@ -1452,7 +1454,7 @@ class RegimeRebalanceEngine:
             self.data_store.record_event(
                 "regime_rebalance_state",
                 {
-                    "flow_active": rebalance_mode == "flow" and flow_gate,
+                    "flow_active": flow_active_state,
                     "deficit_active": deficit_active_state,
                 },
             )


### PR DESCRIPTION
## Summary

Gate regime cash-flow rebalances behind the same regime, cooldown, and ratio checks used for soft-band rebalances while preserving the existing hard-band override behavior.

## User Impact

Operators avoid flow-driven allocation trades when the regime or ratio gate says not to trade, while hard-band breaches can still force a partial rebalance to prevent the portfolio from staying too far from target.

## Root Cause

Flow trades were only checking the flow threshold branch, so they could proceed even when the broader regime or ratio gate would block a soft-band rebalance.

## Fix

Introduce a shared `soft_or_flow_rebalance_allowed` predicate for soft-band and flow rebalances. Add targeted tests for flow trades blocked by the regime gate and by the ratio gate, and keep hard-band ratio-gate override coverage intact.

## Validation

- `git commit` hooks: Ruff, Ruff format, and `ty check`
- `uv run --with pytest-cov pytest --cov=thetagang` -> 259 passed, total coverage 74%
