### PR TITLE
fix(docker): suppress ib gateway status logging

### DIFF
--- a/docker/patch-ibc-java-logging.sh
+++ b/docker/patch-ibc-java-logging.sh
@@ -16,7 +16,7 @@ EOF
 all_options_present=true
 missing_options=
 for option in $required_options; do
-  if ! grep -q -- "$option" "$ibcstart"; then
+  if ! grep -Fq -- "$option" "$ibcstart"; then
     all_options_present=false
     missing_options="${missing_options}${option}
 "
@@ -27,11 +27,17 @@ if $all_options_present; then
   exit 0
 fi
 
+anchor='java_vm_options="$java_vm_options -Dinstall4jType=standalone"'
+if ! grep -Fxq -- "$anchor" "$ibcstart"; then
+  echo "Unable to patch IBC Java logging options into $ibcstart" >&2
+  exit 1
+fi
+
 tmp=$(mktemp)
 while IFS= read -r line; do
   printf '%s\n' "$line"
   case "$line" in
-    'java_vm_options="$java_vm_options -Dinstall4jType=standalone"')
+    "$anchor")
       for option in $missing_options; do
         printf '%s\n' "java_vm_options=\"\$java_vm_options $option\""
       done
@@ -40,18 +46,12 @@ while IFS= read -r line; do
 done < "$ibcstart" > "$tmp"
 
 for option in $required_options; do
-  if ! grep -q -- "$option" "$tmp"; then
+  if ! grep -Fq -- "$option" "$tmp"; then
     rm -f "$tmp"
     echo "Unable to patch IBC Java logging option $option into $ibcstart" >&2
     exit 1
   fi
 done
-
-if ! grep -q -- "-Dinstall4jType=standalone" "$ibcstart"; then
-  rm -f "$tmp"
-  echo "Unable to patch IBC Java logging options into $ibcstart" >&2
-  exit 1
-fi
 
 cat "$tmp" > "$ibcstart"
 rm -f "$tmp"

--- a/docker/patch-ibc-java-logging.sh
+++ b/docker/patch-ibc-java-logging.sh
@@ -4,23 +4,50 @@ set -eu
 ibcstart=${1:-/opt/ibc/scripts/ibcstart.sh}
 log4j_config=${2:-file:/opt/thetagang/ibgateway-log4j2.xml}
 
-if grep -q -- "-Dlog4j.configurationFile=" "$ibcstart"; then
+required_options=$(cat <<EOF
+-Dlog4j.configurationFile=$log4j_config
+-Dlog4j2.statusLoggerLevel=OFF
+-Dlog4j2.StatusLogger.level=OFF
+-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF
+-DStatusLogger.level=OFF
+EOF
+)
+
+all_options_present=true
+missing_options=
+for option in $required_options; do
+  if ! grep -q -- "$option" "$ibcstart"; then
+    all_options_present=false
+    missing_options="${missing_options}${option}
+"
+  fi
+done
+
+if $all_options_present; then
   exit 0
 fi
 
 tmp=$(mktemp)
-awk -v log4j_config="$log4j_config" '
-  {
-    print
-  }
-  $0 ~ /^java_vm_options="\$java_vm_options -Dinstall4jType=standalone"/ {
-    print "java_vm_options=\"$java_vm_options -Dlog4j.configurationFile=" log4j_config "\""
-    print "java_vm_options=\"$java_vm_options -Dlog4j2.statusLoggerLevel=OFF\""
-    print "java_vm_options=\"$java_vm_options -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF\""
-  }
-' "$ibcstart" > "$tmp"
+while IFS= read -r line; do
+  printf '%s\n' "$line"
+  case "$line" in
+    'java_vm_options="$java_vm_options -Dinstall4jType=standalone"')
+      for option in $missing_options; do
+        printf '%s\n' "java_vm_options=\"\$java_vm_options $option\""
+      done
+      ;;
+  esac
+done < "$ibcstart" > "$tmp"
 
-if ! grep -q -- "-Dlog4j.configurationFile=$log4j_config" "$tmp"; then
+for option in $required_options; do
+  if ! grep -q -- "$option" "$tmp"; then
+    rm -f "$tmp"
+    echo "Unable to patch IBC Java logging option $option into $ibcstart" >&2
+    exit 1
+  fi
+done
+
+if ! grep -q -- "-Dinstall4jType=standalone" "$ibcstart"; then
   rm -f "$tmp"
   echo "Unable to patch IBC Java logging options into $ibcstart" >&2
   exit 1

--- a/tests/test_patch_ibc_java_logging.py
+++ b/tests/test_patch_ibc_java_logging.py
@@ -60,3 +60,28 @@ def test_patch_ibc_java_logging_repairs_partial_older_patch(tmp_path):
     for option in REQUIRED_OPTIONS:
         assert option in patched
         assert patched.count(option) == 1
+
+
+def test_patch_ibc_java_logging_requires_exact_anchor(tmp_path):
+    ibcstart = tmp_path / "ibcstart.sh"
+    ibcstart.write_text(
+        "\n".join(
+            (
+                "#!/bin/bash",
+                'java_vm_options="$java_vm_options -Dinstall4jType=standalonex"',
+                '"$java_path/java" $java_vm_options ibcalpha.ibc.IbcGateway',
+            )
+        )
+    )
+
+    result = subprocess.run(
+        ["sh", str(PATCH_SCRIPT), str(ibcstart)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Unable to patch IBC Java logging options" in result.stderr
+    for option in REQUIRED_OPTIONS:
+        assert option not in ibcstart.read_text()

--- a/tests/test_patch_ibc_java_logging.py
+++ b/tests/test_patch_ibc_java_logging.py
@@ -1,0 +1,62 @@
+import subprocess
+from pathlib import Path
+
+PATCH_SCRIPT = Path(__file__).parents[1] / "docker" / "patch-ibc-java-logging.sh"
+
+REQUIRED_OPTIONS = (
+    "-Dlog4j.configurationFile=file:/opt/thetagang/ibgateway-log4j2.xml",
+    "-Dlog4j2.statusLoggerLevel=OFF",
+    "-Dlog4j2.StatusLogger.level=OFF",
+    "-Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF",
+    "-DStatusLogger.level=OFF",
+)
+
+
+def _write_ibcstart(path: Path, extra_options: tuple[str, ...] = ()) -> None:
+    lines = [
+        "#!/bin/bash\n",
+        'java_vm_options="$java_vm_options -Dinstall4jType=standalone"\n',
+    ]
+    lines.extend(
+        f'java_vm_options="$java_vm_options {option}"\n' for option in extra_options
+    )
+    lines.append('"$java_path/java" $java_vm_options ibcalpha.ibc.IbcGateway\n')
+    path.write_text("".join(lines))
+
+
+def test_patch_ibc_java_logging_adds_status_logger_options(tmp_path):
+    ibcstart = tmp_path / "ibcstart.sh"
+    _write_ibcstart(ibcstart)
+
+    subprocess.run(["sh", str(PATCH_SCRIPT), str(ibcstart)], check=True)
+
+    patched = ibcstart.read_text()
+    for option in REQUIRED_OPTIONS:
+        assert f'java_vm_options="$java_vm_options {option}"' in patched
+
+
+def test_patch_ibc_java_logging_is_idempotent(tmp_path):
+    ibcstart = tmp_path / "ibcstart.sh"
+    _write_ibcstart(ibcstart)
+
+    subprocess.run(["sh", str(PATCH_SCRIPT), str(ibcstart)], check=True)
+    subprocess.run(["sh", str(PATCH_SCRIPT), str(ibcstart)], check=True)
+
+    patched = ibcstart.read_text()
+    for option in REQUIRED_OPTIONS:
+        assert patched.count(option) == 1
+
+
+def test_patch_ibc_java_logging_repairs_partial_older_patch(tmp_path):
+    ibcstart = tmp_path / "ibcstart.sh"
+    _write_ibcstart(
+        ibcstart,
+        ("-Dlog4j.configurationFile=file:/opt/thetagang/ibgateway-log4j2.xml",),
+    )
+
+    subprocess.run(["sh", str(PATCH_SCRIPT), str(ibcstart)], check=True)
+
+    patched = ibcstart.read_text()
+    for option in REQUIRED_OPTIONS:
+        assert option in patched
+        assert patched.count(option) == 1


### PR DESCRIPTION
## Summary

Expand the Docker IBC launcher patch so IB Gateway receives all known Log4j StatusLogger suppression properties, and add regression tests for the patch helper.

## User Impact

Operators can still see noisy Log4j startup and shutdown status messages in cron/service logs when the running Gateway version uses a StatusLogger property name the previous patch did not set.

## Root Cause

The existing helper exited as soon as any `-Dlog4j.configurationFile` flag was present, so older partially patched launchers would not be repaired. It also only injected a subset of the StatusLogger property names used across Log4j versions.

## Fix

The patch helper now computes the complete required JVM option set, inserts only missing options after IBC's `-Dinstall4jType=standalone` option, verifies all required flags were written, and remains idempotent across repeated runs. The required set now includes both modern and legacy StatusLogger property names.

## Validation

- `sh -n docker/patch-ibc-java-logging.sh`
- `uv run pytest tests/test_patch_ibc_java_logging.py`
- pre-commit hooks during `git commit`, including Ruff and `ty check`
