### PR TITLE
chore: bump bundled IBC to 3.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN apt-get update \
   wget \
   xdg-utils \
   xvfb \
-  && echo 'a3f9b93ea1ff6740d2880760fb73e1a6e63b454f86fe6366779ebd9cd41c1542  ibc.zip' | tee ibc.zip.sha256 \
-  && wget -q https://github.com/IbcAlpha/IBC/releases/download/3.20.0/IBCLinux-3.20.0.zip -O ibc.zip \
+  && echo '0bd03c713f04c0a64367abbd3d5a40d228fcc2fb969c927bd7cdbd85baddac4b  ibc.zip' | tee ibc.zip.sha256 \
+  && wget -q https://github.com/IbcAlpha/IBC/releases/download/3.23.0/IBCLinux-3.23.0.zip -O ibc.zip \
   && sha256sum -c ibc.zip.sha256 \
   && unzip ibc.zip -d /opt/ibc \
   && chmod o+x /opt/ibc/*.sh /opt/ibc/*/*.sh \

--- a/ibc-config.ini
+++ b/ibc-config.ini
@@ -799,3 +799,16 @@ LogStructureWhen=never
 # of LogStructureScope and LogStructureWhen are honoured.
 
 #LogComponents=
+
+
+# Include Stack Trace for Exceptions
+# ----------------------------------
+#
+# When an exception is thrown in the Java code (either in
+# IBC or in TWS), this setting determines whether a stack
+# trace is printed to the IBC logfile.
+#
+# Valid values are 'yes', 'true', 'false' and 'no'. The
+# default is 'no'.
+
+IncludeStackTraceForExceptions=


### PR DESCRIPTION
## Summary

Bump the bundled IBC Linux release used by the Docker image from 3.20.0 to the current 3.23.0 release and update the pinned asset checksum. The bundled sample `ibc-config.ini` now includes the new `IncludeStackTraceForExceptions` option from the 3.23.0 upstream config.

## User Impact

Docker-based users get the latest IBC fixes and logging/API-precaution behavior while keeping the build pinned to a verified release asset. Operators using the bundled config can also see and set the new stack-trace logging option explicitly.

## Root Cause

The Docker image still downloaded the older 3.20.0 IBC Linux zip and verified it with the corresponding old SHA-256. The bundled sample config also predated the new 3.23.0 config option.

## Fix

Update the Dockerfile to download `IBCLinux-3.23.0.zip` and verify its `0bd03c713f04c0a64367abbd3d5a40d228fcc2fb969c927bd7cdbd85baddac4b` SHA-256 digest. Add the upstream `IncludeStackTraceForExceptions` setting and comments to `ibc-config.ini`.

## Validation

- `uv run pytest tests/test_patch_ibc_java_logging.py`
- Downloaded `IBCLinux-3.23.0.zip`, verified the pinned checksum, extracted the real `scripts/ibcstart.sh`, and confirmed `docker/patch-ibc-java-logging.sh` still applies the required Log4j options.
- Pre-commit hooks run during commit passed for the touched file set.
