### PR TITLE
fix(regime): harden history fetching

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -157,6 +157,46 @@ def test_record_historical_bars_upserts_and_parses_dates(tmp_path) -> None:
     assert volume == 20
 
 
+def test_get_historical_bars_filters_by_symbol_timeframe_and_time(tmp_path) -> None:
+    db_path = tmp_path / "state.db"
+    data_store = DataStore(
+        f"sqlite:///{db_path}",
+        str(tmp_path / "thetagang.toml"),
+        dry_run=False,
+        config_text="test",
+    )
+
+    data_store.record_historical_bars(
+        "AAA",
+        "1 day",
+        [
+            SimpleNamespace(date="20240104", close=1.0),
+            SimpleNamespace(date="20240105", close=2.0),
+        ],
+    )
+    data_store.record_historical_bars(
+        "AAA",
+        "1 hour",
+        [SimpleNamespace(date="20240105 12:00:00", close=99.0)],
+    )
+    data_store.record_historical_bars(
+        "BBB",
+        "1 day",
+        [SimpleNamespace(date="20240105", close=100.0)],
+    )
+
+    bars = data_store.get_historical_bars(
+        "AAA",
+        "1 day",
+        datetime(2024, 1, 5, 0, 0, 0),
+        datetime(2024, 1, 5, 23, 59, 59),
+    )
+
+    assert len(bars) == 1
+    assert bars[0].date == datetime(2024, 1, 5)
+    assert bars[0].close == 2.0
+
+
 def test_record_executions_parses_string_times(tmp_path) -> None:
     db_path = tmp_path / "state.db"
     data_store = DataStore(

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1,5 +1,5 @@
 import math
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from types import SimpleNamespace
 from typing import cast
 
@@ -16,6 +16,13 @@ from thetagang.legacy_config import (
     normalize_config,
 )
 from thetagang.portfolio_manager import PortfolioManager
+from thetagang.strategies.regime_engine import (
+    REGIME_HISTORY_MAX_ATTEMPTS,
+    REGIME_HISTORY_TIMEFRAME,
+)
+
+REGIME_HISTORY_START = datetime(2024, 1, 2)
+REGIME_SYMBOLS = ("AAA", "BBB")
 
 
 @pytest.fixture
@@ -157,11 +164,8 @@ def _freeze_now(monkeypatch, fixed: datetime) -> None:
 
 
 def _mock_regime_history(portfolio_manager, mocker, closes):
-    start_date = datetime(2024, 1, 2)
-    bars = [
-        SimpleNamespace(date=start_date + timedelta(days=offset), close=close)
-        for offset, close in enumerate(closes)
-    ]
+    bars = _regime_bars(closes)
+    _mock_required_regime_history_dates(portfolio_manager, mocker)
 
     async def _get_history(*_args, **_kwargs):
         return bars
@@ -172,15 +176,18 @@ def _mock_regime_history(portfolio_manager, mocker, closes):
     return bars
 
 
+def _regime_bars(closes, start_date: datetime = REGIME_HISTORY_START):
+    return [
+        SimpleNamespace(date=start_date + timedelta(days=offset), close=close)
+        for offset, close in enumerate(closes)
+    ]
+
+
 def _mock_regime_histories(portfolio_manager, mocker, closes_by_symbol):
-    start_date = datetime(2024, 1, 2)
     bars_by_symbol = {
-        symbol: [
-            SimpleNamespace(date=start_date + timedelta(days=offset), close=close)
-            for offset, close in enumerate(closes)
-        ]
-        for symbol, closes in closes_by_symbol.items()
+        symbol: _regime_bars(closes) for symbol, closes in closes_by_symbol.items()
     }
+    _mock_required_regime_history_dates(portfolio_manager, mocker)
 
     async def _get_history(contract, *_args, **_kwargs):
         return bars_by_symbol[contract.symbol]
@@ -216,12 +223,77 @@ def _mock_regime_tickers(
     )
 
 
+def _mock_regime_broker(portfolio_manager, mocker, **history_mock_kwargs) -> None:
+    _mock_regime_tickers(portfolio_manager, mocker)
+    portfolio_manager.ibkr.request_historical_data = mocker.AsyncMock(
+        **history_mock_kwargs
+    )
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+
 def _stock_position(symbol: str, position: int, market_value: float | None = None):
     return SimpleNamespace(
         contract=Stock(symbol, "SMART", "USD"),
         position=position,
         marketValue=market_value,
     )
+
+
+def _regime_account_summary(value: str = "400"):
+    return {"NetLiquidation": SimpleNamespace(value=value)}
+
+
+def _regime_stock_positions(aaa: int = 3, bbb: int = 1):
+    return {
+        "AAA": [_stock_position("AAA", aaa)],
+        "BBB": [_stock_position("BBB", bbb)],
+    }
+
+
+def _expected_regime_history_fetches(symbols=REGIME_SYMBOLS) -> int:
+    return len(symbols) * REGIME_HISTORY_MAX_ATTEMPTS
+
+
+def _disable_regime_history_retry_delay(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "thetagang.strategies.regime_engine.REGIME_HISTORY_RETRY_DELAY_SECONDS",
+        0.0,
+    )
+
+
+def _required_regime_history_dates(required_points: int) -> list[date]:
+    return [
+        (REGIME_HISTORY_START + timedelta(days=offset)).date()
+        for offset in range(required_points)
+    ]
+
+
+def _set_required_regime_history_dates(
+    portfolio_manager, monkeypatch, required_points: int
+) -> list[date]:
+    required_dates = _required_regime_history_dates(required_points)
+    monkeypatch.setattr(
+        portfolio_manager.regime_engine,
+        "_get_required_history_dates",
+        lambda _required_points: required_dates,
+    )
+    return required_dates
+
+
+def _mock_required_regime_history_dates(portfolio_manager, mocker) -> None:
+    mocker.patch.object(
+        portfolio_manager.regime_engine,
+        "_get_required_history_dates",
+        side_effect=_required_regime_history_dates,
+    )
+
+
+def _seed_regime_history_cache(portfolio_manager, closes, symbols=REGIME_SYMBOLS):
+    cache_bars = _regime_bars(closes)
+    for symbol in symbols:
+        portfolio_manager.data_store.record_historical_bars(
+            symbol, REGIME_HISTORY_TIMEFRAME, cache_bars
+        )
 
 
 def _option_position(
@@ -345,6 +417,172 @@ async def test_regime_rebalance_generates_orders(portfolio_manager, mocker):
     )
 
     assert orders == [("AAA", "NYSE", -1), ("BBB", "NYSE", 1)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_retries_empty_history(
+    portfolio_manager, mocker, monkeypatch
+):
+    _disable_regime_history_retry_delay(monkeypatch)
+    _mock_required_regime_history_dates(portfolio_manager, mocker)
+    account_summary = _regime_account_summary()
+    portfolio_positions = _regime_stock_positions()
+    bars = _regime_bars([100.0, 110.0, 100.0, 110.0])
+    attempts_by_symbol = {"AAA": 0, "BBB": 0}
+
+    async def _get_history(contract, *_args, **_kwargs):
+        attempts_by_symbol[contract.symbol] += 1
+        if attempts_by_symbol[contract.symbol] == 1:
+            return []
+        return bars
+
+    _mock_regime_broker(portfolio_manager, mocker, side_effect=_get_history)
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert attempts_by_symbol == {"AAA": 2, "BBB": 2}
+    assert orders == [("AAA", "NYSE", -1), ("BBB", "NYSE", 1)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_uses_fresh_cached_history_when_api_empty(
+    portfolio_manager_with_db, mocker, monkeypatch
+):
+    _disable_regime_history_retry_delay(monkeypatch)
+    _set_required_regime_history_dates(
+        portfolio_manager_with_db, monkeypatch, required_points=4
+    )
+    _seed_regime_history_cache(portfolio_manager_with_db, [100.0, 110.0, 100.0, 110.0])
+    account_summary = _regime_account_summary()
+    portfolio_positions = _regime_stock_positions()
+
+    _mock_regime_broker(portfolio_manager_with_db, mocker, return_value=[])
+
+    _, orders = await portfolio_manager_with_db.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert (
+        portfolio_manager_with_db.ibkr.request_historical_data.call_count
+        == _expected_regime_history_fetches()
+    )
+    assert orders == [("AAA", "NYSE", -1), ("BBB", "NYSE", 1)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_uses_fresh_cache_when_api_history_is_stale(
+    portfolio_manager_with_db, mocker, monkeypatch
+):
+    _disable_regime_history_retry_delay(monkeypatch)
+    _set_required_regime_history_dates(
+        portfolio_manager_with_db, monkeypatch, required_points=4
+    )
+    _seed_regime_history_cache(portfolio_manager_with_db, [100.0, 110.0, 100.0, 110.0])
+    stale_bars = _regime_bars(
+        [100.0, 99.0, 98.0, 97.0],
+        start_date=datetime(2023, 12, 20),
+    )
+    account_summary = _regime_account_summary()
+    portfolio_positions = _regime_stock_positions()
+
+    _mock_regime_broker(portfolio_manager_with_db, mocker, return_value=stale_bars)
+
+    _, orders = await portfolio_manager_with_db.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert portfolio_manager_with_db.ibkr.request_historical_data.call_count == len(
+        REGIME_SYMBOLS
+    )
+    assert orders == [("AAA", "NYSE", -1), ("BBB", "NYSE", 1)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_ignores_history_after_required_sessions(
+    portfolio_manager, mocker, monkeypatch
+):
+    _disable_regime_history_retry_delay(monkeypatch)
+    required_dates = _set_required_regime_history_dates(
+        portfolio_manager, monkeypatch, required_points=4
+    )
+    bars_with_extra_partial_session = _regime_bars([100.0, 110.0, 100.0, 110.0, 1.0])
+
+    _mock_regime_broker(
+        portfolio_manager, mocker, return_value=bars_with_extra_partial_session
+    )
+
+    (
+        dates,
+        aligned_closes,
+    ) = await portfolio_manager.regime_engine._get_regime_aligned_closes(
+        list(REGIME_SYMBOLS),
+        lookback_days=3,
+        cooldown_days=0,
+    )
+
+    assert dates == required_dates
+    assert aligned_closes == {
+        "AAA": [100.0, 110.0, 100.0, 110.0],
+        "BBB": [100.0, 110.0, 100.0, 110.0],
+    }
+    assert portfolio_manager.ibkr.request_historical_data.call_count == len(
+        REGIME_SYMBOLS
+    )
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_rejects_incomplete_cached_history(
+    portfolio_manager_with_db, mocker, monkeypatch
+):
+    _disable_regime_history_retry_delay(monkeypatch)
+    _set_required_regime_history_dates(
+        portfolio_manager_with_db, monkeypatch, required_points=4
+    )
+    _seed_regime_history_cache(portfolio_manager_with_db, [100.0, 110.0, 100.0])
+    account_summary = _regime_account_summary()
+    portfolio_positions = _regime_stock_positions()
+
+    _mock_regime_broker(portfolio_manager_with_db, mocker, return_value=[])
+
+    with pytest.raises(ValueError, match="fresh historical data"):
+        await portfolio_manager_with_db.check_regime_rebalance_positions(
+            account_summary, portfolio_positions
+        )
+
+    assert (
+        portfolio_manager_with_db.ibkr.request_historical_data.call_count
+        == _expected_regime_history_fetches()
+    )
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_rejects_unreadable_cached_history(
+    portfolio_manager_with_db, mocker, monkeypatch
+):
+    _disable_regime_history_retry_delay(monkeypatch)
+    _set_required_regime_history_dates(
+        portfolio_manager_with_db, monkeypatch, required_points=4
+    )
+    account_summary = _regime_account_summary()
+    portfolio_positions = _regime_stock_positions()
+
+    _mock_regime_broker(portfolio_manager_with_db, mocker, return_value=[])
+    portfolio_manager_with_db.data_store.get_historical_bars = mocker.Mock(
+        side_effect=RuntimeError("database unavailable")
+    )
+
+    with pytest.raises(ValueError, match="readable history cache"):
+        await portfolio_manager_with_db.check_regime_rebalance_positions(
+            account_summary, portfolio_positions
+        )
+
+    assert (
+        portfolio_manager_with_db.ibkr.request_historical_data.call_count
+        == _expected_regime_history_fetches()
+    )
+    assert portfolio_manager_with_db.data_store.get_historical_bars.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -1392,7 +1630,7 @@ async def test_regime_rebalance_insufficient_history(portfolio_manager, mocker):
     _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0])
     portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
 
-    with pytest.raises(ValueError, match="full lookback history"):
+    with pytest.raises(ValueError, match="fresh historical data"):
         await portfolio_manager.check_regime_rebalance_positions(
             account_summary, portfolio_positions
         )
@@ -2121,6 +2359,27 @@ async def test_regime_rebalance_no_common_dates_raises(portfolio_manager, mocker
         await portfolio_manager.check_regime_rebalance_positions(
             account_summary, portfolio_positions
         )
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_empty_history_stays_hard_failure(
+    portfolio_manager, mocker, monkeypatch
+):
+    _disable_regime_history_retry_delay(monkeypatch)
+    account_summary = _regime_account_summary()
+    portfolio_positions = _regime_stock_positions()
+
+    _mock_regime_broker(portfolio_manager, mocker, return_value=[])
+
+    with pytest.raises(ValueError, match="aligned history"):
+        await portfolio_manager.check_regime_rebalance_positions(
+            account_summary, portfolio_positions
+        )
+
+    assert (
+        portfolio_manager.ibkr.request_historical_data.call_count
+        == _expected_regime_history_fetches()
+    )
 
 
 @pytest.mark.asyncio

--- a/thetagang/db.py
+++ b/thetagang/db.py
@@ -8,6 +8,7 @@ import shutil
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, Iterable, Iterator, Mapping, Optional
 
 from alembic.config import Config as AlembicConfig
@@ -558,6 +559,40 @@ class DataStore:
                     session.execute(stmt)
         except Exception as exc:
             log.warning(f"Failed to record historical bars: {exc}")
+
+    def get_historical_bars(
+        self,
+        symbol: str,
+        timeframe: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[Any]:
+        with self.session_scope() as session:
+            rows = (
+                session.execute(
+                    select(HistoricalBar)
+                    .where(HistoricalBar.symbol == symbol)
+                    .where(HistoricalBar.timeframe == timeframe)
+                    .where(HistoricalBar.bar_time >= start_time)
+                    .where(HistoricalBar.bar_time <= end_time)
+                    .order_by(HistoricalBar.bar_time.asc())
+                )
+                .scalars()
+                .all()
+            )
+            return [
+                SimpleNamespace(
+                    date=row.bar_time,
+                    open=row.open,
+                    high=row.high,
+                    low=row.low,
+                    close=row.close,
+                    volume=row.volume,
+                    barCount=row.bar_count,
+                    average=row.average,
+                )
+                for row in rows
+            ]
 
     def get_last_regime_rebalance_time(
         self,

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import math
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple
+from typing import Any, Callable, Coroutine, Dict, Iterable, List, Optional, Tuple
 
 import exchange_calendars as xcals
 import numpy as np
@@ -25,7 +26,17 @@ AlignedClosesResult = Tuple[List[date], Dict[str, List[float]]]
 AlignedClosesFetcher = Callable[
     [List[str], int, int], Coroutine[Any, Any, AlignedClosesResult]
 ]
+ClosesBySymbol = Dict[str, Dict[date, float]]
 TRADING_DAYS_PER_YEAR = 252
+REGIME_HISTORY_TIMEFRAME = "1 day"
+REGIME_HISTORY_MAX_ATTEMPTS = 3
+REGIME_HISTORY_RETRY_DELAY_SECONDS = 0.25
+
+
+class RegimeHistoryValidationError(ValueError):
+    def __init__(self, message: str, *, cache_recoverable: bool) -> None:
+        super().__init__(message)
+        self.cache_recoverable = cache_recoverable
 
 
 @dataclass(frozen=True)
@@ -174,6 +185,97 @@ class RegimeRebalanceEngine:
                 daily_factor += weights[symbol] * (curr_close / prev_close)
             index.append(index[-1] * max(daily_factor, eps))
         return index
+
+    @staticmethod
+    def _bars_to_closes(bars: Iterable[Any]) -> Dict[date, float]:
+        closes: Dict[date, float] = {}
+        for bar in bars:
+            bar_date = bar.date.date() if hasattr(bar.date, "date") else bar.date
+            closes[bar_date] = float(bar.close)
+        return closes
+
+    @staticmethod
+    def _describe_history_closes(closes: Dict[date, float]) -> str:
+        if not closes:
+            return "0 bars"
+        sorted_dates = sorted(closes)
+        return f"{len(sorted_dates)} bars {sorted_dates[0]}..{sorted_dates[-1]}"
+
+    @classmethod
+    def _align_regime_closes(
+        cls,
+        *,
+        symbols: List[str],
+        closes_by_symbol: ClosesBySymbol,
+        required_points: int,
+        required_dates: List[date],
+        missing_dates_cache_recoverable: bool,
+    ) -> AlignedClosesResult:
+        close_dates_by_symbol = {
+            symbol: set(closes_by_symbol.get(symbol, {})) for symbol in symbols
+        }
+        common_dates = set.intersection(*close_dates_by_symbol.values())
+        if not common_dates:
+            details = ", ".join(
+                (
+                    f"{symbol}: "
+                    f"{cls._describe_history_closes(closes_by_symbol.get(symbol, {}))}"
+                )
+                for symbol in symbols
+            )
+            log.error(
+                "Regime-aware rebalancing history has no common dates across "
+                f"symbols ({details})."
+            )
+            raise RegimeHistoryValidationError(
+                "Regime-aware rebalancing requires aligned history for all symbols.",
+                cache_recoverable=True,
+            )
+
+        missing_dates = [
+            required_date
+            for required_date in required_dates
+            if required_date not in common_dates
+        ]
+        if missing_dates:
+            sample = ", ".join(str(missing) for missing in missing_dates[:5])
+            if len(missing_dates) > 5:
+                sample += ", ..."
+            log.error(
+                f"Regime history is missing required completed sessions: {sample}."
+            )
+            raise RegimeHistoryValidationError(
+                "Regime-aware rebalancing requires fresh historical data.",
+                cache_recoverable=missing_dates_cache_recoverable,
+            )
+        sorted_dates = sorted(required_dates)
+        if len(sorted_dates) < required_points:
+            log.error(
+                "Insufficient historical data for regime rebalancing "
+                f"({len(sorted_dates)}/{required_points} common points), aborting."
+            )
+            raise RegimeHistoryValidationError(
+                "Regime-aware rebalancing requires full lookback history.",
+                cache_recoverable=True,
+            )
+
+        aligned_closes: Dict[str, List[float]] = {}
+        for symbol in symbols:
+            aligned: List[float] = []
+            for date_point in sorted_dates:
+                close = closes_by_symbol[symbol].get(date_point)
+                if close is None or math.isnan(close) or math.isclose(close, 0):
+                    log.error(
+                        f"Invalid close for {symbol} on {date_point} (close={close})."
+                    )
+                    raise RegimeHistoryValidationError(
+                        "Regime-aware rebalancing found invalid historical closes.",
+                        cache_recoverable=False,
+                    )
+                aligned.append(close)
+            aligned_closes[symbol] = aligned
+
+        return (sorted_dates, aligned_closes)
 
     def _calculate_ratio_gate(
         self,
@@ -345,6 +447,143 @@ class RegimeRebalanceEngine:
         )
         return (sorted_dates, normalized_series)
 
+    def _get_required_history_dates(self, required_points: int) -> Optional[List[date]]:
+        if required_points <= 0:
+            return []
+        try:
+            exchange = self.config.runtime.exchange_hours.exchange
+            calendar = xcals.get_calendar(exchange)
+            now = pd.Timestamp.now(tz="UTC")
+            today = now.tz_convert(None).normalize()
+            sessions = calendar.sessions[calendar.sessions <= today]
+            if sessions.empty:
+                return None
+
+            latest_session = sessions[-1]
+            latest_close = calendar.session_close(latest_session, _parse=False)
+            if now < latest_close:
+                latest_index = calendar.sessions.get_loc(latest_session)
+                if latest_index == 0:
+                    return None
+                latest_session = calendar.sessions[latest_index - 1]
+
+            latest_index = calendar.sessions.get_loc(latest_session)
+            first_index = latest_index - required_points + 1
+            if first_index < 0:
+                return None
+            return [
+                session.date()
+                for session in calendar.sessions[first_index : latest_index + 1]
+            ]
+        except Exception as exc:
+            log.warning(
+                f"Regime history freshness calculation failed ({type(exc).__name__})."
+            )
+            return None
+
+    async def _fetch_regime_history_bars(
+        self, symbol: str, duration: str
+    ) -> Tuple[str, List[Any]]:
+        contract = Stock(
+            symbol,
+            self.order_ops.get_order_exchange(),
+            currency="USD",
+            primaryExchange=self.get_primary_exchange(symbol),
+        )
+        for attempt in range(1, REGIME_HISTORY_MAX_ATTEMPTS + 1):
+            bars = list(await self.ibkr.request_historical_data(contract, duration))
+            if bars:
+                if attempt > 1:
+                    log.warning(
+                        f"{symbol}: regime history fetch recovered after "
+                        f"{attempt} attempts."
+                    )
+                return symbol, bars
+            if attempt < REGIME_HISTORY_MAX_ATTEMPTS:
+                log.warning(
+                    f"{symbol}: regime history fetch returned no bars "
+                    f"(attempt {attempt}/{REGIME_HISTORY_MAX_ATTEMPTS}); retrying."
+                )
+                await asyncio.sleep(REGIME_HISTORY_RETRY_DELAY_SECONDS)
+        log.error(
+            f"{symbol}: regime history fetch returned no bars after "
+            f"{REGIME_HISTORY_MAX_ATTEMPTS} attempts."
+        )
+        return symbol, []
+
+    async def _fetch_regime_history_closes(
+        self, symbols: List[str], duration: str
+    ) -> ClosesBySymbol:
+        tasks: List[Coroutine[Any, Any, Tuple[str, List[Any]]]] = [
+            self._fetch_regime_history_bars(symbol, duration) for symbol in symbols
+        ]
+        histories = await log.track_async(
+            tasks, description="Fetching regime rebalancing history..."
+        )
+        return {symbol: self._bars_to_closes(bars) for symbol, bars in histories}
+
+    def _merge_cached_regime_closes(
+        self,
+        symbols: List[str],
+        api_closes_by_symbol: ClosesBySymbol,
+        required_dates: List[date],
+    ) -> ClosesBySymbol:
+        if self.data_store is None:
+            raise RegimeHistoryValidationError(
+                "Regime-aware rebalancing requires a history cache.",
+                cache_recoverable=False,
+            )
+        start_time = datetime.combine(required_dates[0], datetime.min.time())
+        end_time = datetime.combine(required_dates[-1], datetime.max.time())
+        merged_closes_by_symbol: ClosesBySymbol = {}
+        for symbol in symbols:
+            try:
+                cached_bars = self.data_store.get_historical_bars(
+                    symbol, REGIME_HISTORY_TIMEFRAME, start_time, end_time
+                )
+            except Exception as exc:
+                log.error(f"{symbol}: failed to read cached regime history.")
+                raise RegimeHistoryValidationError(
+                    "Regime-aware rebalancing requires a readable history cache.",
+                    cache_recoverable=False,
+                ) from exc
+            cached_closes = self._bars_to_closes(cached_bars)
+            if cached_closes:
+                log.warning(
+                    f"{symbol}: using {len(cached_closes)} cached historical bars "
+                    "to validate regime history."
+                )
+            merged = dict(cached_closes)
+            merged.update(api_closes_by_symbol[symbol])
+            merged_closes_by_symbol[symbol] = merged
+        return merged_closes_by_symbol
+
+    def _recover_regime_history_from_cache(
+        self,
+        *,
+        symbols: List[str],
+        api_closes_by_symbol: ClosesBySymbol,
+        required_points: int,
+        required_dates: List[date],
+    ) -> AlignedClosesResult:
+        merged_closes_by_symbol = self._merge_cached_regime_closes(
+            symbols,
+            api_closes_by_symbol,
+            required_dates,
+        )
+        dates, aligned_closes = self._align_regime_closes(
+            symbols=symbols,
+            closes_by_symbol=merged_closes_by_symbol,
+            required_points=required_points,
+            required_dates=required_dates,
+            missing_dates_cache_recoverable=False,
+        )
+        log.warning(
+            "Regime-aware rebalancing recovered from incomplete API history "
+            "using fresh cached bars."
+        )
+        return (dates, aligned_closes)
+
     async def _get_regime_aligned_closes(
         self,
         symbols: List[str],
@@ -354,69 +593,37 @@ class RegimeRebalanceEngine:
         if not symbols:
             log.error("Regime-aware rebalancing has no symbols to build a proxy.")
             raise ValueError("Regime-aware rebalancing requires proxy symbols.")
+        required_points = lookback_days + 1
+        required_dates = self._get_required_history_dates(required_points)
+        if required_dates is None:
+            raise RegimeHistoryValidationError(
+                "Regime-aware rebalancing requires completed session dates.",
+                cache_recoverable=False,
+            )
         trading_days_needed = lookback_days + 1 + max(cooldown_days, 0)
         calendar_days = math.ceil(trading_days_needed * 7 / 5) + 5
         duration = f"{calendar_days} D"
-
-        async def fetch_history_task(symbol: str) -> Tuple[str, List[Any]]:
-            contract = Stock(
-                symbol,
-                self.order_ops.get_order_exchange(),
-                currency="USD",
-                primaryExchange=self.get_primary_exchange(symbol),
-            )
-            bars = await self.ibkr.request_historical_data(contract, duration)
-            return symbol, list(bars)
-
-        tasks: List[Coroutine[Any, Any, Tuple[str, List[Any]]]] = [
-            fetch_history_task(symbol) for symbol in symbols
-        ]
-        histories = await log.track_async(
-            tasks, description="Fetching regime rebalancing history..."
+        api_closes_by_symbol = await self._fetch_regime_history_closes(
+            symbols, duration
         )
 
-        closes_by_symbol: Dict[str, Dict[date, float]] = {}
-        for symbol, bars in histories:
-            closes: Dict[date, float] = {}
-            for bar in bars:
-                bar_date = bar.date.date() if hasattr(bar.date, "date") else bar.date
-                closes[bar_date] = float(bar.close)
-            closes_by_symbol[symbol] = closes
-
-        common_dates = set.intersection(
-            *(set(closes.keys()) for closes in closes_by_symbol.values())
-        )
-        if not common_dates:
-            log.error(
-                "Regime-aware rebalancing history has no common dates across symbols."
+        try:
+            return self._align_regime_closes(
+                symbols=symbols,
+                closes_by_symbol=api_closes_by_symbol,
+                required_points=required_points,
+                required_dates=required_dates,
+                missing_dates_cache_recoverable=True,
             )
-            raise ValueError(
-                "Regime-aware rebalancing requires aligned history for all symbols."
+        except RegimeHistoryValidationError as api_exc:
+            if not api_exc.cache_recoverable or self.data_store is None:
+                raise
+            return self._recover_regime_history_from_cache(
+                symbols=symbols,
+                api_closes_by_symbol=api_closes_by_symbol,
+                required_points=required_points,
+                required_dates=required_dates,
             )
-
-        sorted_dates = sorted(common_dates)
-        if len(sorted_dates) < 2:
-            log.error("Regime-aware rebalancing history has fewer than 2 points.")
-            raise ValueError(
-                "Regime-aware rebalancing requires at least 2 history points."
-            )
-
-        aligned_closes: Dict[str, List[float]] = {}
-        for symbol in symbols:
-            aligned: List[float] = []
-            for date_point in sorted_dates:
-                close = closes_by_symbol[symbol].get(date_point)
-                if close is None or math.isnan(close) or math.isclose(close, 0):
-                    log.error(
-                        f"Invalid close for {symbol} on {date_point} (close={close})."
-                    )
-                    raise ValueError(
-                        "Regime-aware rebalancing found invalid historical closes."
-                    )
-                aligned.append(close)
-            aligned_closes[symbol] = aligned
-
-        return (sorted_dates, aligned_closes)
 
     async def _resolve_effective_weights(
         self,


### PR DESCRIPTION
## Summary

Harden regime-aware rebalancing history fetches so bad or incomplete historical data does not drive trades. The branch retries empty IBKR history responses, validates that the completed-session lookback window is present, and only recovers from API history problems when SQLite has a fresh readable cache for that same window.

## User Impact

Operators avoid both unnecessary hard failures from transient empty history responses and unsafe rebalancing decisions from stale, partial, or unaligned history. If neither the API nor the cache can prove the completed lookback window is fresh, the bot fails closed instead of acting on questionable data.

## Root Cause

Regime history previously trusted the raw API result after checking only common dates. Empty responses, stale non-empty responses, or extra partial-session bars could either abort unexpectedly or enter the regime, volatility-weight, and ratio-gate calculations.

## Fix

- Add retry handling for empty regime-history API responses.
- Validate history against the exchange calendar's completed sessions.
- Align calculations to the required completed-session dates only, ignoring newer partial bars.
- Add SQLite historical-bar reads for cache recovery and fail clearly when the cache is unreadable or incomplete.
- Cover API retry, stale API recovery, incomplete/unreadable cache failures, empty-history hard failure, and partial-session exclusion in tests.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest tests/test_regime_rebalance.py tests/test_db.py -q` (`79 passed`)
- `uv run pytest -q` (`272 passed`)
