### PR TITLE
feat(watchdog): add maxStartupRetries to limit 2FA retry loops

### DIFF
--- a/tests/test_thetagang_watchdog.py
+++ b/tests/test_thetagang_watchdog.py
@@ -64,6 +64,8 @@ def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
         def __init__(self, *_args, **_kwargs):
             self.started = False
             self.stopped = False
+            self.startedEvent = DummyEvent()
+            self.stoppedEvent = DummyEvent()
             captured["watchdog"] = self
 
         def start(self):

--- a/tests/test_thetagang_watchdog.py
+++ b/tests/test_thetagang_watchdog.py
@@ -4,9 +4,24 @@ from pathlib import Path
 import tomlkit
 
 
-def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
-    import thetagang.thetagang as tg
+class DummyEvent:
+    def __init__(self):
+        self._handlers = []
 
+    def __iadd__(self, handler):
+        self._handlers.append(handler)
+        return self
+
+    def __isub__(self, handler):
+        self._handlers.remove(handler)
+        return self
+
+    def emit(self, *args):
+        for handler in list(self._handlers):
+            handler(*args)
+
+
+def _write_config(tmp_path, *, max_startup_retries=None):
     base_config = tomlkit.parse(
         Path("thetagang.toml").read_text(encoding="utf8")
     ).unwrap()
@@ -23,29 +38,41 @@ def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
                     "enabled": True,
                 }
             ]
+        if max_startup_retries is not None:
+            base_config["runtime"]["watchdog"]["maxStartupRetries"] = (
+                max_startup_retries
+            )
     else:
         base_config["database"]["enabled"] = False
         base_config["ib_async"]["logfile"] = ""
+        if max_startup_retries is not None:
+            base_config["watchdog"]["maxStartupRetries"] = max_startup_retries
     config_path = tmp_path / "thetagang.toml"
     config_path.write_text(tomlkit.dumps(tomlkit.item(base_config)), encoding="utf8")
+    return config_path
+
+
+def _run_start(monkeypatch, tmp_path, *, max_startup_retries=None, event_script=()):
+    """Run ``thetagang.start`` with a fake IB stack.
+
+    ``event_script`` is a sequence of ``"started"``/``"stopped"`` strings that
+    the fake watchdog emits (in order) from ``start()`` to simulate connect
+    cycles. After replaying the script the fake resolves the completion future
+    so the run loop terminates, unless a startup-retry failure has already
+    failed the future.
+
+    Returns ``(captured, error)`` where ``error`` is any exception raised out of
+    ``start`` (e.g. the ``RuntimeError`` raised when the retry limit is hit).
+    """
+    import thetagang.thetagang as tg
+
+    config_path = _write_config(tmp_path, max_startup_retries=max_startup_retries)
 
     loop = asyncio.new_event_loop()
     monkeypatch.setattr(tg.util, "getLoop", lambda: loop)
     monkeypatch.setattr(tg, "need_to_exit", lambda *_: False)
 
     captured = {}
-
-    class DummyEvent:
-        def __init__(self):
-            self._handlers = []
-
-        def __iadd__(self, handler):
-            self._handlers.append(handler)
-            return self
-
-        def __isub__(self, handler):
-            self._handlers.remove(handler)
-            return self
 
     class FakeContract:
         def __init__(self, **_kwargs):
@@ -71,6 +98,16 @@ def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
         def start(self):
             assert asyncio.get_running_loop() is loop
             self.started = True
+            for event in event_script:
+                if event == "started":
+                    self.startedEvent.emit(self)
+                elif event == "stopped":
+                    self.stoppedEvent.emit(self)
+                else:  # pragma: no cover - guards against typos in tests
+                    raise ValueError(f"unknown event {event!r}")
+            completion_future = captured["completion_future"]
+            if not completion_future.done():
+                completion_future.set_result(True)
 
         def stop(self):
             self.stopped = True
@@ -82,9 +119,11 @@ def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
 
         def run(self, awaitable):
             assert asyncio.iscoroutine(awaitable)
-            loop.run_until_complete(awaitable)
-            loop.stop()
-            loop.close()
+            try:
+                loop.run_until_complete(awaitable)
+            finally:
+                loop.stop()
+                loop.close()
 
     class FakePortfolioManager:
         def __init__(
@@ -97,8 +136,9 @@ def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
             run_stage_flags=None,
             run_stage_order=None,
         ):
-            if not completion_future.done():
-                completion_future.set_result(True)
+            # Leave the future pending; the fake watchdog drives completion so
+            # tests can exercise the startup-retry handling first.
+            captured["completion_future"] = completion_future
 
     monkeypatch.setattr(tg, "IBC", FakeIBC)
     monkeypatch.setattr(tg, "Watchdog", FakeWatchdog)
@@ -106,14 +146,109 @@ def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
     monkeypatch.setattr(tg, "PortfolioManager", FakePortfolioManager)
     monkeypatch.setattr(tg, "Contract", FakeContract)
 
-    tg.start(
-        str(config_path),
-        without_ibc=False,
-        dry_run=True,
-        auto_approve_migration=False,
-    )
+    error = None
+    try:
+        tg.start(
+            str(config_path),
+            without_ibc=False,
+            dry_run=True,
+            auto_approve_migration=False,
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced to the test for asserting
+        error = exc
 
+    return captured, error
+
+
+def test_watchdog_runs_inside_task(monkeypatch, tmp_path):
+    captured, error = _run_start(monkeypatch, tmp_path)
+
+    assert error is None
     assert captured["watchdog"].started is True
     assert captured["watchdog"].stopped is True
     assert captured["ibc"].terminated is True
     assert captured["ibc"].twsVersion == 1045
+
+
+def test_consecutive_startup_failures_give_up(monkeypatch, tmp_path):
+    # Three consecutive stops with no successful connect should hit the limit.
+    captured, error = _run_start(
+        monkeypatch,
+        tmp_path,
+        max_startup_retries=3,
+        event_script=["stopped", "stopped", "stopped"],
+    )
+
+    assert isinstance(error, RuntimeError)
+    assert "after 3 attempts" in str(error)
+    # The watchdog is still torn down cleanly on the way out.
+    assert captured["watchdog"].stopped is True
+    assert captured["ibc"].terminated is True
+
+
+def test_fewer_failures_than_limit_then_success(monkeypatch, tmp_path):
+    # Two pre-start failures (below the limit of 3) followed by a successful
+    # connect must not give up.
+    _captured, error = _run_start(
+        monkeypatch,
+        tmp_path,
+        max_startup_retries=3,
+        event_script=["stopped", "stopped", "started"],
+    )
+
+    assert error is None
+
+
+def test_zero_retries_preserves_unlimited_retries(monkeypatch, tmp_path):
+    # maxStartupRetries = 0 must preserve the original unlimited-retry behavior:
+    # no number of startup failures should cause a give-up.
+    _captured, error = _run_start(
+        monkeypatch,
+        tmp_path,
+        max_startup_retries=0,
+        event_script=["stopped"] * 10,
+    )
+
+    assert error is None
+
+
+def test_default_config_uses_unlimited_retries(monkeypatch, tmp_path):
+    # With no override, the default (0) must not give up after repeated stops.
+    _captured, error = _run_start(
+        monkeypatch,
+        tmp_path,
+        event_script=["stopped"] * 10,
+    )
+
+    assert error is None
+
+
+def test_started_then_stopped_does_not_count_as_startup_failure(monkeypatch, tmp_path):
+    # A successful connect followed by a runtime stop (disconnect/timeout) must
+    # not consume a startup retry: here only a single cycle ever fails to start,
+    # which is below the limit of 2. Counting the runtime stop would wrongly
+    # trip the limit, so this distinguishes the fix from a naive
+    # increment-on-every-stop implementation.
+    _captured, error = _run_start(
+        monkeypatch,
+        tmp_path,
+        max_startup_retries=2,
+        event_script=["started", "stopped", "stopped"],
+    )
+
+    assert error is None
+
+
+def test_runtime_stop_resets_then_startup_failures_count(monkeypatch, tmp_path):
+    # A successful connect + runtime stop is not counted, but subsequent
+    # consecutive pre-start failures are, and still trip the limit.
+    captured, error = _run_start(
+        monkeypatch,
+        tmp_path,
+        max_startup_retries=2,
+        event_script=["started", "stopped", "stopped", "stopped"],
+    )
+
+    assert isinstance(error, RuntimeError)
+    assert "after 2 attempts" in str(error)
+    assert captured["watchdog"].stopped is True

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -179,6 +179,14 @@ port           = 7497
 probeTimeout   = 4
 readonly       = false
 retryDelay     = 2
+# Give up after this many consecutive startup failures (connection attempts
+# that never successfully connect), instead of retrying forever. This is useful
+# to bound 2FA/login retry loops, e.g. when IBKR Mobile 2FA is not completed and
+# the gateway would otherwise restart and re-prompt indefinitely. Once a
+# connection succeeds the counter resets, so runtime disconnects that recover do
+# not count toward the limit. 0 (the default) keeps the original behavior of
+# retrying indefinitely.
+maxStartupRetries = 0
 
   [runtime.watchdog.probeContract]
   currency = 'USD'

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -176,6 +176,7 @@ class WatchdogConfig(BaseModel):
     probeTimeout: int = Field(default=4)
     readonly: bool = Field(default=False)
     retryDelay: int = Field(default=2)
+    maxStartupRetries: int = Field(default=3)
     probeContract: "WatchdogConfig.ProbeContract" = Field(
         default_factory=lambda: WatchdogConfig.ProbeContract()
     )

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -176,7 +176,11 @@ class WatchdogConfig(BaseModel):
     probeTimeout: int = Field(default=4)
     readonly: bool = Field(default=False)
     retryDelay: int = Field(default=2)
-    maxStartupRetries: int = Field(default=3)
+    # Number of consecutive startup failures (connection attempts that never
+    # reach a successful connect) after which thetagang gives up instead of
+    # retrying forever. 0 (the default) preserves the original unlimited-retry
+    # behavior; set a positive value to bound 2FA/login retry loops.
+    maxStartupRetries: int = Field(default=0, ge=0)
     probeContract: "WatchdogConfig.ProbeContract" = Field(
         default_factory=lambda: WatchdogConfig.ProbeContract()
     )

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -134,13 +134,31 @@ def start(
 
         max_retries = watchdog_config.maxStartupRetries
         startup_failures = 0
+        # Tracks whether the current watchdog cycle reached a successful
+        # connect. ib_async emits exactly one stoppedEvent per connect cycle
+        # (in runAsync's finally block); startedEvent only fires mid-cycle once
+        # the connection succeeds. We use this flag to distinguish a stop that
+        # follows a successful connect (a runtime disconnect/timeout, which must
+        # not count toward the startup limit) from a stop in a cycle that never
+        # connected (a genuine startup failure).
+        started_this_cycle = False
 
         def on_watchdog_started(_w: Watchdog) -> None:
-            nonlocal startup_failures
+            nonlocal startup_failures, started_this_cycle
+            started_this_cycle = True
+            # A successful connect clears any accumulated startup failures so
+            # that later flapping does not eventually trip the limit.
             startup_failures = 0
 
         def on_watchdog_stopped(_w: Watchdog) -> None:
-            nonlocal startup_failures
+            nonlocal startup_failures, started_this_cycle
+            if started_this_cycle:
+                # Started successfully, then stopped later (disconnect, hard
+                # timeout, or restart). Not a startup failure; reset the flag
+                # for the next cycle.
+                started_this_cycle = False
+                return
+
             startup_failures += 1
             if max_retries > 0 and startup_failures >= max_retries:
                 log.error(
@@ -148,9 +166,7 @@ def start(
                 )
                 if not completion_future.done():
                     completion_future.set_exception(
-                        RuntimeError(
-                            f"Failed to connect after {max_retries} attempts"
-                        )
+                        RuntimeError(f"Failed to connect after {max_retries} attempts")
                     )
 
         watchdog.startedEvent += on_watchdog_started

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -132,6 +132,30 @@ def start(
             ibc, ib, probeContract=probeContract, **watchdog_config.to_dict()
         )
 
+        max_retries = watchdog_config.maxStartupRetries
+        startup_failures = 0
+
+        def on_watchdog_started(_w: Watchdog) -> None:
+            nonlocal startup_failures
+            startup_failures = 0
+
+        def on_watchdog_stopped(_w: Watchdog) -> None:
+            nonlocal startup_failures
+            startup_failures += 1
+            if max_retries > 0 and startup_failures >= max_retries:
+                log.error(
+                    f"Watchdog failed to start {max_retries} consecutive times, giving up"
+                )
+                if not completion_future.done():
+                    completion_future.set_exception(
+                        RuntimeError(
+                            f"Failed to connect after {max_retries} attempts"
+                        )
+                    )
+
+        watchdog.startedEvent += on_watchdog_started
+        watchdog.stoppedEvent += on_watchdog_stopped
+
         async def run_with_watchdog() -> None:
             watchdog.start()
             try:


### PR DESCRIPTION
## Summary

- Adds `maxStartupRetries` (default: 3) to `WatchdogConfig` in `config.py`
- Hooks into `watchdog.startedEvent` / `watchdog.stoppedEvent` in `thetagang.py` to count consecutive startup failures and terminate after N attempts
- Resets the counter on successful connect, so runtime disconnects that eventually recover do not accumulate toward the limit
- Set `maxStartupRetries = 0` in config to restore the previous unlimited retry behavior

## Motivation

When 2FA (IBKR Mobile) is not completed in time, the Watchdog kills and restarts the gateway indefinitely, sending repeated 2FA push notifications with no way to stop short of killing the process. This change makes the behavior bounded by default.