### PR TITLE
feat(orders): add configurable per-symbol option price strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,34 @@ Automatically adjust limit orders after initial delay:
 adjust_price_after_delay = true  # Adjusts to midpoint after delay
 ```
 
+#### Price Strategy
+By default, option order limit prices are derived from the midpoint/model
+price, which fills reliably. For less-liquid options you can instead quote off
+the bid/ask (or last) to capture more of the spread, at the cost of slower or
+missed fills. Configure a global default under `[runtime.orders]`:
+
+```toml
+[runtime.orders]
+sell_price = "ask"            # "midpoint" (default behavior), "latest", "bid", or "ask"
+buy_price = "bid"
+sell_price_adjustment = 0.0   # added to the chosen price; use negative to shave a cent
+buy_price_adjustment = 0.0
+```
+
+…and override it per symbol:
+
+```toml
+[portfolio.symbols.SPY]
+sell_price = "midpoint"       # keep tight, liquid names at the midpoint
+[portfolio.symbols.ABC]
+sell_price = "ask"            # quote illiquid names at the ask
+buy_price = "bid"
+```
+
+When `sell_price`/`buy_price` are unset (the default), pricing is unchanged. If
+the chosen bid/ask/last is unavailable, ThetaGang falls back to the midpoint/
+model price automatically.
+
 #### Algorithm Configuration
 Customize order execution algorithms:
 

--- a/tests/test_order_pricing.py
+++ b/tests/test_order_pricing.py
@@ -1,0 +1,130 @@
+from typing import Any, Dict, Optional
+
+from ib_async import Ticker
+
+from thetagang.config import MINIMUM_PRICE, Config
+
+
+def _ticker(
+    *,
+    bid: float = float("nan"),
+    ask: float = float("nan"),
+    last: float = float("nan"),
+) -> Ticker:
+    # Ticker price fields must be assigned as attributes (constructor kwargs are
+    # ignored). Ticker.midpoint() is derived from bid/ask, so tests that need a
+    # specific midpoint set bid == ask to that value.
+    ticker = Ticker()
+    ticker.bid = bid
+    ticker.ask = ask
+    ticker.last = last
+    # midpoint() requires positive bid/ask sizes (Ticker.hasBidAsk()).
+    ticker.bidSize = 1
+    ticker.askSize = 1
+    return ticker
+
+
+def _config(
+    *,
+    symbols: Optional[Dict[str, Any]] = None,
+    orders: Optional[Dict[str, Any]] = None,
+) -> Config:
+    cfg: Dict[str, Any] = {
+        "meta": {"schema_version": 2},
+        "run": {"strategies": ["wheel"]},
+        "runtime": {
+            "account": {"number": "DUX", "margin_usage": 0.5},
+            "option_chains": {"expirations": 4, "strikes": 10},
+        },
+        "portfolio": {"symbols": symbols or {"AAA": {"weight": 1.0}}},
+        "strategies": {
+            "wheel": {
+                "defaults": {
+                    "target": {"dte": 30, "minimum_open_interest": 5},
+                    "roll_when": {"dte": 7},
+                }
+            }
+        },
+    }
+    if orders is not None:
+        cfg["runtime"]["orders"] = orders
+    return Config(**cfg)
+
+
+def test_unset_preserves_fallback() -> None:
+    config = _config()
+    ticker = _ticker(bid=9.99, ask=9.99)
+    # Nothing configured -> the caller's existing price is returned unchanged.
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 2.5) == 2.5
+    assert config.get_order_limit_price("AAA", ticker, "BUY", 1.25) == 1.25
+
+
+def test_unknown_symbol_preserves_fallback() -> None:
+    config = _config()
+    ticker = _ticker(ask=9.99)
+    assert config.get_order_limit_price("VIX", ticker, "SELL", 3.0) == 3.0
+
+
+def test_symbol_sell_price_uses_ask() -> None:
+    config = _config(symbols={"AAA": {"weight": 1.0, "sell_price": "ask"}})
+    ticker = _ticker(bid=2.90, ask=3.10)
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 2.0) == 3.10
+
+
+def test_symbol_buy_price_uses_bid() -> None:
+    config = _config(symbols={"AAA": {"weight": 1.0, "buy_price": "bid"}})
+    ticker = _ticker(bid=2.90, ask=3.10)
+    assert config.get_order_limit_price("AAA", ticker, "BUY", 5.0) == 2.90
+
+
+def test_price_adjustment_is_applied() -> None:
+    config = _config(
+        symbols={
+            "AAA": {"weight": 1.0, "sell_price": "ask", "sell_price_adjustment": -0.05}
+        }
+    )
+    ticker = _ticker(ask=3.00)
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 2.0) == 2.95
+
+
+def test_adjustment_cannot_push_below_minimum_price() -> None:
+    config = _config(
+        symbols={
+            "AAA": {"weight": 1.0, "sell_price": "ask", "sell_price_adjustment": -1.0}
+        }
+    )
+    ticker = _ticker(ask=0.50)
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 2.0) == MINIMUM_PRICE
+
+
+def test_nan_chosen_price_falls_back() -> None:
+    config = _config(symbols={"AAA": {"weight": 1.0, "sell_price": "bid"}})
+    ticker = _ticker()  # bid is NaN
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 4.0) == 4.0
+
+
+def test_latest_falls_back_to_midpoint_when_unavailable() -> None:
+    config = _config(symbols={"AAA": {"weight": 1.0, "sell_price": "latest"}})
+    ticker = _ticker(bid=2.2, ask=2.2)  # last is NaN -> midpoint == 2.2
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 9.0) == 2.2
+
+
+def test_global_default_applies_when_symbol_unset() -> None:
+    config = _config(orders={"sell_price": "ask"})
+    ticker = _ticker(ask=3.30)
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 2.0) == 3.30
+
+
+def test_symbol_overrides_global_default() -> None:
+    config = _config(
+        symbols={"AAA": {"weight": 1.0, "sell_price": "midpoint"}},
+        orders={"sell_price": "ask"},
+    )
+    ticker = _ticker(bid=0.70, ask=3.30)  # midpoint == 2.0
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 9.0) == 2.0
+
+
+def test_global_price_adjustment_applies() -> None:
+    config = _config(orders={"sell_price": "ask", "sell_price_adjustment": -0.10})
+    ticker = _ticker(ask=3.00)
+    assert config.get_order_limit_price("AAA", ticker, "SELL", 2.0) == 2.90

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -99,6 +99,20 @@ price_update_delay = [30, 60]
 # order price. This doesn't apply to debit orders.
 minimum_credit = 0.05
 
+# Default price strategy used to derive option order limit prices. By default
+# (when left unset/commented out) ThetaGang uses the midpoint/model price, which
+# fills reliably but may leave money on the table for illiquid options. Set
+# `sell_price`/`buy_price` to one of "midpoint", "latest", "bid", or "ask" to
+# quote more aggressively: e.g. `sell_price = "ask"` and `buy_price = "bid"`
+# capture more of the spread at the cost of slower (or missed) fills. The
+# optional `*_price_adjustment` values are added to the chosen price (use a
+# negative number to shave a cent off to improve fill odds). These can be
+# overridden per symbol under `[portfolio.symbols.<SYMBOL>]`.
+# sell_price = "ask"
+# buy_price = "bid"
+# sell_price_adjustment = 0.0
+# buy_price_adjustment = 0.0
+
   [runtime.orders.algo]
   # By default we use adaptive orders with patient priority which gives reasonable
   # results. You can also experiment with TWAP or other options, however the

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
+from ib_async import Ticker, util as ib_util
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from rich import box
 from rich.console import Console, Group
@@ -32,6 +33,10 @@ from thetagang.config_models import (
     WriteWhenConfig,
 )
 from thetagang.fmt import dfmt, ffmt, pfmt
+
+# Floor applied to limit prices derived from a configured price strategy, so an
+# adjustment can never push the price to zero or negative.
+MINIMUM_PRICE = 0.01
 
 STAGE_KIND_BY_ID: dict[str, str] = {
     "options_write_puts": "options.write_puts",
@@ -558,6 +563,56 @@ class Config(BaseModel, DisplayMixin):
     def symbol_config(self, symbol: str) -> Optional[SymbolConfig]:
         return self.symbols.get(symbol)
 
+    def get_order_limit_price(
+        self, symbol: str, ticker: Ticker, action: str, fallback_price: float
+    ) -> float:
+        """Resolve an option order's limit price from the configured strategy.
+
+        The price strategy is resolved per symbol first, then falls back to the
+        global ``[runtime.orders]`` default. When neither is configured, or the
+        chosen price (bid/ask/last/midpoint) is unavailable, ``fallback_price``
+        is returned unchanged so the default pricing behavior is preserved.
+
+        ``action`` is the ib_async order action string ("BUY" or "SELL").
+        """
+        b_or_s = "sell" if action.upper() == "SELL" else "buy"
+
+        symbol_config = self.symbols.get(symbol)
+        price_base = (
+            getattr(symbol_config, f"{b_or_s}_price", None) if symbol_config else None
+        )
+        if price_base is None:
+            price_base = getattr(self.orders, f"{b_or_s}_price", None)
+        if price_base is None:
+            # No strategy configured: keep the caller's existing pricing.
+            return fallback_price
+
+        price_adjustment = (
+            getattr(symbol_config, f"{b_or_s}_price_adjustment", None)
+            if symbol_config
+            else None
+        )
+        if price_adjustment is None:
+            price_adjustment = getattr(self.orders, f"{b_or_s}_price_adjustment", 0.0)
+
+        if price_base == "midpoint":
+            price = ticker.midpoint()
+        elif price_base == "latest":
+            price = ticker.last
+            if ib_util.isNan(price):
+                price = ticker.midpoint()
+        elif price_base == "bid":
+            price = ticker.bid
+        elif price_base == "ask":
+            price = ticker.ask
+        else:  # pragma: no cover - guarded by the Literal type
+            return fallback_price
+
+        if ib_util.isNan(price) or price < 0:
+            return fallback_price
+
+        return max(MINIMUM_PRICE, price + price_adjustment)
+
     def get_target_delta(self, symbol: str, right: str) -> float:
         p_or_c = "calls" if right.upper().startswith("C") else "puts"
         symbol_config = self.symbols.get(symbol)
@@ -646,6 +701,7 @@ class Config(BaseModel, DisplayMixin):
         table.add_column("Put delta", justify="right")
         table.add_column("Put strike limit", justify="right")
         table.add_column("Put threshold", justify="right")
+        table.add_column("Sell/Buy price", justify="right")
 
         for symbol, sconfig in self.symbols.items():
             call_thresh = (
@@ -671,6 +727,10 @@ class Config(BaseModel, DisplayMixin):
                 ffmt(self.get_target_delta(symbol, "P")),
                 dfmt(sconfig.puts.strike_limit if sconfig.puts else None),
                 put_thresh,
+                "{}/{}".format(
+                    sconfig.sell_price or self.orders.sell_price or "default",
+                    sconfig.buy_price or self.orders.buy_price or "default",
+                ),
             )
         return table
 

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -92,6 +92,13 @@ class OrdersConfig(BaseModel, DisplayMixin):
     price_update_delay: List[int] = Field(
         default_factory=lambda: [30, 60], min_length=2, max_length=2
     )
+    # Default price strategy used to derive option order limit prices. When left
+    # unset (None), the existing midpoint/model-price behavior is preserved.
+    # Can be overridden per symbol via SymbolConfig.{sell,buy}_price.
+    sell_price: Optional[Literal["midpoint", "latest", "bid", "ask"]] = None
+    buy_price: Optional[Literal["midpoint", "latest", "bid", "ask"]] = None
+    sell_price_adjustment: float = Field(default=0.0)
+    buy_price_adjustment: float = Field(default=0.0)
 
     def add_to_table(self, table: Table, section: str = "") -> None:
         table.add_section()
@@ -100,6 +107,9 @@ class OrdersConfig(BaseModel, DisplayMixin):
         table.add_row("", "Params", "=", f"{self.algo.params}")
         table.add_row("", "Price update delay", "=", f"{self.price_update_delay}")
         table.add_row("", "Minimum credit", "=", f"{dfmt(self.minimum_credit)}")
+        if self.sell_price is not None or self.buy_price is not None:
+            table.add_row("", "Sell price", "=", self.sell_price or "default")
+            table.add_row("", "Buy price", "=", self.buy_price or "default")
 
 
 class IBAsyncConfig(BaseModel):
@@ -528,6 +538,13 @@ class SymbolConfig(BaseModel):
     puts: Optional["SymbolConfig.Puts"] = None
     volatility_weight: Optional["SymbolConfig.VolatilityWeight"] = None
     adjust_price_after_delay: bool = Field(default=False)
+    # Per-symbol overrides for the order price strategy. When unset, the global
+    # [runtime.orders] default applies; when that is also unset, the existing
+    # midpoint/model-price behavior is preserved.
+    sell_price: Optional[Literal["midpoint", "latest", "bid", "ask"]] = None
+    buy_price: Optional[Literal["midpoint", "latest", "bid", "ask"]] = None
+    sell_price_adjustment: Optional[float] = None
+    buy_price_adjustment: Optional[float] = None
     no_trading: Optional[bool] = None
     buy_only_rebalancing: Optional[bool] = None
     buy_only_min_threshold_shares: Optional[int] = Field(default=None, ge=1)

--- a/thetagang/strategies/options_engine.py
+++ b/thetagang/strategies/options_engine.py
@@ -376,7 +376,12 @@ class OptionsStrategyEngine:
             order = self.order_ops.create_limit_order(
                 action="SELL",
                 quantity=quantity,
-                limit_price=round(get_higher_price(sell_ticker), 2),
+                limit_price=round(
+                    self.config.get_order_limit_price(
+                        symbol, sell_ticker, "SELL", get_higher_price(sell_ticker)
+                    ),
+                    2,
+                ),
             )
             self.order_ops.enqueue_order(sell_ticker.contract, order)
 
@@ -405,7 +410,12 @@ class OptionsStrategyEngine:
             order = self.order_ops.create_limit_order(
                 action="SELL",
                 quantity=quantity,
-                limit_price=round(get_higher_price(sell_ticker), 2),
+                limit_price=round(
+                    self.config.get_order_limit_price(
+                        symbol, sell_ticker, "SELL", get_higher_price(sell_ticker)
+                    ),
+                    2,
+                ),
             )
             self.order_ops.enqueue_order(sell_ticker.contract, order)
 
@@ -1071,10 +1081,15 @@ class OptionsStrategyEngine:
                     optional_fields=[TickerField.MIDPOINT, TickerField.MARKET_PRICE],
                 )
                 is_short = position.position < 0
-                price = (
-                    round(get_lower_price(ticker), 2)
-                    if is_short
-                    else round(get_higher_price(ticker), 2)
+                action = "BUY" if is_short else "SELL"
+                fallback_price = (
+                    get_lower_price(ticker) if is_short else get_higher_price(ticker)
+                )
+                price = round(
+                    self.config.get_order_limit_price(
+                        position.contract.symbol, ticker, action, fallback_price
+                    ),
+                    2,
                 )
                 if not price or util.isNan(price) or math.isnan(price):
                     log.warning(
@@ -1087,7 +1102,7 @@ class OptionsStrategyEngine:
 
                 qty = abs(position.position)
                 order = self.order_ops.create_limit_order(
-                    action="BUY" if is_short else "SELL",
+                    action=action,
                     quantity=qty,
                     limit_price=price,
                     transmit=True,


### PR DESCRIPTION
## Summary

Adds an **opt-in, per-symbol option price strategy** so users can quote orders off the `midpoint`, `latest`, `bid`, or `ask` instead of the default midpoint/model price. Quoting off the bid/ask captures more of the spread on less-liquid options, at the cost of slower or missed fills.

- Configurable globally under `[runtime.orders]` and overridable per symbol under `[portfolio.symbols.<SYMBOL>]`.
- New `sell_price` / `buy_price` (`midpoint|latest|bid|ask`) plus optional `sell_price_adjustment` / `buy_price_adjustment` offsets.
- Resolution order: **symbol override → global default → preserve current behavior**.

## Backward compatibility

Fully backward compatible. When `sell_price`/`buy_price` are unset, each order site computes today's price (`get_higher_price`/`get_lower_price`) and passes it as a fallback; the resolver only overrides it when a strategy is explicitly configured **and** the chosen bid/ask/last is valid. If the chosen price is unavailable (NaN/negative), it falls back to the existing price. So existing configs behave exactly as before.

## Behavioral impact

- Routed through the four options-engine order sites: `write_calls`, `write_puts`, and both branches of `close_positions` (buy-to-close / sell-to-close).
- VIX call-hedge pricing (`post_engine.py`) is intentionally left unchanged.
- A `MINIMUM_PRICE` (0.01) floor prevents a negative adjustment from pushing the limit price to zero/negative.

## Config example

```toml
[runtime.orders]
sell_price = "ask"
buy_price = "bid"
sell_price_adjustment = 0.0
buy_price_adjustment = 0.0

[portfolio.symbols.ABC]
sell_price = "ask"   # quote illiquid names at the ask; overrides the global default
```

## Tests / validation

- `uv run pytest` → 289 passed (incl. 11 new tests in `tests/test_order_pricing.py` covering bid/ask/midpoint/latest, adjustments, the MINIMUM_PRICE floor, NaN fallback, global default, and symbol-overrides-global).
- `uv run ty check` → clean
- `uv run ruff check .` / `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)