### PR TITLE
fix(regime): clarify inferred-capacity flow telemetry

### DIFF
--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -7,6 +7,7 @@ import pytest
 from ib_async import IB, Option, Stock
 
 import thetagang.portfolio_manager as pm_module
+import thetagang.strategies.regime_engine as regime_engine_module
 from thetagang.config import Config
 from thetagang.db import DataStore
 from thetagang.legacy_config import (
@@ -1761,10 +1762,10 @@ async def test_regime_rebalance_soft_band_blocked_by_regime(portfolio_manager, m
 
 @pytest.mark.asyncio
 async def test_regime_rebalance_flow_trades_require_regime_gate(
-    portfolio_manager, mocker
+    portfolio_manager_with_db, mocker
 ):
     _configure_flow_rebalance(
-        portfolio_manager,
+        portfolio_manager_with_db,
         choppiness_min=10.0,
         efficiency_max=0.01,
     )
@@ -1775,15 +1776,92 @@ async def test_regime_rebalance_flow_trades_require_regime_gate(
         "BBB": [_stock_position("BBB", 8)],
     }
 
-    _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
-    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
-    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+    _mock_regime_tickers(
+        portfolio_manager_with_db,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=100.0,
+    )
+    _mock_regime_history(
+        portfolio_manager_with_db,
+        mocker,
+        [100.0, 110.0, 100.0, 110.0],
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
+    info_mock = mocker.patch.object(regime_engine_module.log, "info")
 
-    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+    _, orders = await portfolio_manager_with_db.check_regime_rebalance_positions(
         account_summary, portfolio_positions
     )
 
     assert orders == []
+    payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_gate"
+    )
+    assert payload["telemetry_schema_version"] == 2
+    assert payload["legacy_field_aliases"] == {
+        "excess_cash": "unallocated_rebalance_capacity"
+    }
+    assert payload["unallocated_rebalance_capacity"] == pytest.approx(400.0)
+    assert payload["excess_cash"] == pytest.approx(400.0)
+    assert payload["choppiness_ok"] is False
+    assert payload["regime_ok"] is False
+    assert payload["shared_rebalance_gates_ok"] is False
+    assert payload["mode"] == "no"
+    assert payload["flow"] == {
+        "signal_kind": "inferred_unallocated_rebalance_capacity",
+        "external_flow_detection": "not_performed",
+        "capacity_source": "rebalance_base_minus_managed_sleeve_value",
+        "weight_base": "net_liq_ex_options",
+        "margin_usage": 1.0,
+        "rebalance_base": 2000,
+        "managed_sleeve_value": 1600.0,
+        "unallocated_rebalance_capacity": 400.0,
+        "direction": "buy",
+        "gate": True,
+        "decision_status": "blocked_by_shared_gates",
+        "shared_rebalance_gates_ok": False,
+        "shared_gate_blockers": ["regime"],
+        "rebalance_eligible": False,
+        "selected": False,
+        "was_active": False,
+        "will_be_active": True,
+        "start_threshold": 200.0,
+        "stop_threshold": 100.0,
+        "candidate_symbols": ["AAA", "BBB"],
+        "net_share_gap": 4,
+        "total_absolute_share_gap": 4,
+        "imbalance_ratio": 1.0,
+        "imbalance_tau": 0.7,
+        "directional_imbalance_ok": True,
+        "orders": [],
+        "reserved_cash_for_post_management": 0.0,
+    }
+    assert payload["deficit"] == {
+        "gate": False,
+        "was_active": False,
+        "will_be_active": False,
+        "start_threshold": 120.0,
+        "stop_threshold": 60.0,
+    }
+    summary_payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_summary"
+    )
+    assert summary_payload["telemetry_schema_version"] == 2
+    assert summary_payload["unallocated_rebalance_capacity"] == pytest.approx(400.0)
+    assert summary_payload["flow"] == payload["flow"]
+    assert summary_payload["deficit"] == payload["deficit"]
+    info_messages = [call.args[0] for call in info_mock.call_args_list]
+    flow_message = next(
+        message
+        for message in info_messages
+        if message.startswith("Regime rebalancing inferred-capacity flow:")
+    )
+    assert "decision=blocked_by_shared_gates" in flow_message
+    assert "shared_gate_blockers=regime" in flow_message
+    assert "was_active=False will_be_active=True" in flow_message
 
 
 @pytest.mark.asyncio
@@ -1857,6 +1935,13 @@ async def test_regime_rebalance_blocked_flow_preserves_hysteresis(
     assert portfolio_manager_with_db.data_store.get_last_event_payload(
         "regime_rebalance_state"
     ) == {"flow_active": True, "deficit_active": False}
+    blocked_payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_gate"
+    )
+    assert blocked_payload["flow"]["decision_status"] == "blocked_by_shared_gates"
+    assert blocked_payload["flow"]["shared_gate_blockers"] == ["ratio"]
+    assert blocked_payload["flow"]["was_active"] is False
+    assert blocked_payload["flow"]["will_be_active"] is True
 
     portfolio_manager_with_db.config.strategies.regime_rebalance.ratio_gate = None
 
@@ -2151,14 +2236,15 @@ async def test_regime_rebalance_flow_hysteresis_uses_db_state(
 
 @pytest.mark.asyncio
 async def test_regime_rebalance_deficit_rail_sells_overweights(
-    portfolio_manager, mocker
+    portfolio_manager_with_db, mocker
 ):
-    portfolio_manager.config.strategies.regime_rebalance.soft_band = 1.2
-    portfolio_manager.config.strategies.regime_rebalance.hard_band = 1.5
-    portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
-    portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
-    portfolio_manager.config.strategies.regime_rebalance.deficit_rail_start = 0.30
-    portfolio_manager.config.strategies.regime_rebalance.deficit_rail_stop = 0.10
+    regime_rebalance = portfolio_manager_with_db.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 1.2
+    regime_rebalance.hard_band = 1.5
+    regime_rebalance.choppiness_min = 0.0
+    regime_rebalance.efficiency_max = 1.0
+    regime_rebalance.deficit_rail_start = 0.30
+    regime_rebalance.deficit_rail_stop = 0.10
 
     account_summary = {"NetLiquidation": SimpleNamespace(value="1000")}
     portfolio_positions = {
@@ -2166,15 +2252,33 @@ async def test_regime_rebalance_deficit_rail_sells_overweights(
         "BBB": [SimpleNamespace(contract=Stock("BBB", "SMART", "USD"), position=5)],
     }
 
-    _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
-    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
-    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+    _mock_regime_tickers(
+        portfolio_manager_with_db,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=100.0,
+    )
+    _mock_regime_history(
+        portfolio_manager_with_db,
+        mocker,
+        [100.0, 110.0, 100.0, 110.0],
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
 
-    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+    _, orders = await portfolio_manager_with_db.check_regime_rebalance_positions(
         account_summary, portfolio_positions
     )
 
     assert orders == [("AAA", "NYSE", -4)]
+    payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_gate"
+    )
+    assert payload["mode"] == "deficit"
+    assert payload["flow"]["gate"] is False
+    assert payload["flow"]["decision_status"] == "superseded_by_deficit_rail"
+    assert payload["deficit"]["gate"] is True
 
 
 @pytest.mark.asyncio

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -627,9 +627,12 @@ daily_stddev_window = "30 D"
 # cooldown_days = 5
 # choppiness_min = 3.0
 # efficiency_max = 0.30
-# flow_trade_min = 0.025  # excess cash needed to start flow trades (fraction of base)
-# flow_trade_stop = 0.0125  # hysteresis stop once within this band (fraction of base)
-# flow_imbalance_tau = 0.70  # 0..1, higher requires more directional coherence
+# The flow rail infers unallocated capacity as the rebalance base minus the
+# managed sleeve value. It does not detect broker deposits or withdrawals.
+# Flow trades still require the regime, cooldown, and ratio gates to pass.
+# flow_trade_min = 0.025  # inferred capacity needed to activate (fraction of base)
+# flow_trade_stop = 0.0125  # active-state hysteresis stop (fraction of base)
+# flow_imbalance_tau = 0.70  # directional share-gap coherence, from 0 to 1
 # deficit_rail_start = 0.06  # deficit that triggers safety rail (fraction of base)
 # deficit_rail_stop = 0.03  # hysteresis stop once within this band (fraction of base)
 # order_history_lookback_days = 30  # look back this many calendar days for fills

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -659,9 +659,24 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
         table.add_row("", "Cooldown days", "=", f"{self.cooldown_days}")
         table.add_row("", "Choppiness min", "=", f"{ffmt(self.choppiness_min)}")
         table.add_row("", "Efficiency max", "=", f"{pfmt(self.efficiency_max)}")
-        table.add_row("", "Flow trade min", "=", f"{pfmt(self.flow_trade_min)}")
-        table.add_row("", "Flow trade stop", "=", f"{pfmt(self.flow_trade_stop)}")
-        table.add_row("", "Flow imbalance tau", "=", f"{ffmt(self.flow_imbalance_tau)}")
+        table.add_row(
+            "",
+            "Inferred-capacity flow start",
+            "=",
+            f"{pfmt(self.flow_trade_min)}",
+        )
+        table.add_row(
+            "",
+            "Inferred-capacity flow stop",
+            "=",
+            f"{pfmt(self.flow_trade_stop)}",
+        )
+        table.add_row(
+            "",
+            "Directional share-gap tau",
+            "=",
+            f"{ffmt(self.flow_imbalance_tau)}",
+        )
         table.add_row("", "Deficit rail start", "=", f"{pfmt(self.deficit_rail_start)}")
         table.add_row("", "Deficit rail stop", "=", f"{pfmt(self.deficit_rail_stop)}")
         table.add_row("", "Shares only", "=", f"{self.shares_only}")

--- a/thetagang/strategies/post_engine.py
+++ b/thetagang/strategies/post_engine.py
@@ -214,7 +214,8 @@ class PostStrategyEngine:
         if reserved_cash > 0:
             log.notice(
                 "Cash management: reserving "
-                f"{dfmt(reserved_cash)} for regime flow deployment."
+                f"{dfmt(reserved_cash)} for inferred-capacity regime "
+                "flow deployment."
             )
         try:
             amount = 0.0

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1097,79 +1097,105 @@ class RegimeRebalanceEngine:
             if ratio_gate is None or not ratio_enabled
             else bool(ratio_result and ratio_result.ok)
         )
-        soft_or_flow_rebalance_allowed = regime_ok and cooldown_ok and ratio_gate_ok
-        soft_rebalance = soft_breach and soft_or_flow_rebalance_allowed
+        shared_rebalance_gates_ok = regime_ok and cooldown_ok and ratio_gate_ok
+        soft_rebalance = soft_breach and shared_rebalance_gates_ok
         rebalance_fraction = 1.0
         if hard_rebalance:
             rebalance_fraction = regime_rebalance.hard_band_rebalance_fraction
 
         share_tolerance = 1
-        flow_active = False
-        deficit_active = False
+        flow_was_active = False
+        deficit_was_active = False
         if self.data_store:
             state = self.data_store.get_last_event_payload("regime_rebalance_state")
             if state:
-                flow_active = bool(state.get("flow_active", False))
-                deficit_active = bool(state.get("deficit_active", False))
+                flow_was_active = bool(state.get("flow_active", False))
+                deficit_was_active = bool(state.get("deficit_active", False))
 
-        excess_cash = total_value - invested_value
+        unallocated_rebalance_capacity = total_value - invested_value
         flow_trade_min_amount = total_value * regime_rebalance.flow_trade_min
         flow_trade_stop_amount = total_value * regime_rebalance.flow_trade_stop
         deficit_rail_start_amount = total_value * regime_rebalance.deficit_rail_start
         deficit_rail_stop_amount = total_value * regime_rebalance.deficit_rail_stop
         flow_gate = False
         deficit_gate = False
-        if excess_cash < 0:
-            deficit_amount = -excess_cash
+        if unallocated_rebalance_capacity < 0:
+            deficit_amount = -unallocated_rebalance_capacity
             deficit_gate = deficit_amount >= deficit_rail_start_amount or (
-                deficit_active and deficit_amount >= deficit_rail_stop_amount
+                deficit_was_active and deficit_amount >= deficit_rail_stop_amount
             )
             if not deficit_gate:
                 flow_gate = deficit_amount >= flow_trade_min_amount or (
-                    flow_active and deficit_amount >= flow_trade_stop_amount
+                    flow_was_active and deficit_amount >= flow_trade_stop_amount
                 )
         else:
-            flow_gate = excess_cash >= flow_trade_min_amount or (
-                flow_active and excess_cash >= flow_trade_stop_amount
+            flow_gate = unallocated_rebalance_capacity >= flow_trade_min_amount or (
+                flow_was_active
+                and unallocated_rebalance_capacity >= flow_trade_stop_amount
             )
-        flow_rebalance = flow_gate and soft_or_flow_rebalance_allowed
+        flow_rebalance_eligible = flow_gate and shared_rebalance_gates_ok
 
         allowed_symbols = {
             symbol for symbol in symbols if self.config.trading_is_allowed(symbol)
         }
+        flow_candidate_symbols = [
+            symbol
+            for symbol in symbols
+            if symbol in allowed_symbols and abs(share_gaps[symbol]) > share_tolerance
+        ]
+        flow_net_share_gap = sum(
+            share_gaps[symbol] for symbol in flow_candidate_symbols
+        )
+        flow_total_absolute_share_gap = sum(
+            abs(share_gaps[symbol]) for symbol in flow_candidate_symbols
+        )
+        flow_imbalance_ratio = (
+            flow_net_share_gap / flow_total_absolute_share_gap
+            if flow_total_absolute_share_gap > 0
+            else None
+        )
+
+        def directional_flow_is_allowed(amount: float) -> bool:
+            if flow_total_absolute_share_gap <= 0:
+                return False
+            if amount > 0:
+                return (
+                    flow_net_share_gap
+                    > regime_rebalance.flow_imbalance_tau
+                    * flow_total_absolute_share_gap
+                )
+            if amount < 0:
+                return (
+                    flow_net_share_gap
+                    < -regime_rebalance.flow_imbalance_tau
+                    * flow_total_absolute_share_gap
+                )
+            return False
+
+        flow_directional_imbalance_ok = directional_flow_is_allowed(
+            unallocated_rebalance_capacity
+        )
 
         def build_flow_orders(amount: float) -> Dict[str, int]:
             if amount == 0:
                 return {}
-            active_symbols = [
-                symbol
-                for symbol in symbols
-                if symbol in allowed_symbols
-                and abs(share_gaps[symbol]) > share_tolerance
-            ]
-            if not active_symbols:
+            if not flow_candidate_symbols:
                 return {}
-            net_gap = sum(share_gaps[symbol] for symbol in active_symbols)
-            tot_gap = sum(abs(share_gaps[symbol]) for symbol in active_symbols)
-            if tot_gap <= 0:
+            if flow_total_absolute_share_gap <= 0:
                 return {}
-
-            ok_buy = net_gap > regime_rebalance.flow_imbalance_tau * tot_gap
-            ok_sell = net_gap < -regime_rebalance.flow_imbalance_tau * tot_gap
-            if amount > 0 and not ok_buy:
-                return {}
-            if amount < 0 and not ok_sell:
+            if not directional_flow_is_allowed(amount):
                 return {}
 
             orders: Dict[str, int] = {}
             if amount > 0:
                 deficits = {
-                    symbol: max(share_gaps[symbol], 0) for symbol in active_symbols
+                    symbol: max(share_gaps[symbol], 0)
+                    for symbol in flow_candidate_symbols
                 }
                 total_deficit = sum(deficits.values())
                 if total_deficit <= 0:
                     return {}
-                for symbol in active_symbols:
+                for symbol in flow_candidate_symbols:
                     deficit = deficits[symbol]
                     if deficit <= 0:
                         continue
@@ -1189,12 +1215,13 @@ class RegimeRebalanceEngine:
             else:
                 need = -amount
                 excesses = {
-                    symbol: max(-share_gaps[symbol], 0) for symbol in active_symbols
+                    symbol: max(-share_gaps[symbol], 0)
+                    for symbol in flow_candidate_symbols
                 }
                 total_excess = sum(excesses.values())
                 if total_excess <= 0:
                     return {}
-                for symbol in active_symbols:
+                for symbol in flow_candidate_symbols:
                     excess = excesses[symbol]
                     if excess <= 0:
                         continue
@@ -1340,7 +1367,10 @@ class RegimeRebalanceEngine:
                         )
         elif deficit_gate:
             rebalance_mode = "deficit"
-            deficit_needed = max(0.0, -excess_cash - deficit_rail_stop_amount)
+            deficit_needed = max(
+                0.0,
+                -unallocated_rebalance_capacity - deficit_rail_stop_amount,
+            )
             deficit_orders = build_deficit_orders(
                 current_positions,
                 deficit_needed,
@@ -1352,13 +1382,45 @@ class RegimeRebalanceEngine:
                     if delta == 0:
                         continue
                     orders_by_symbol[symbol] = orders_by_symbol.get(symbol, 0) + delta
-        elif flow_rebalance:
+        elif flow_rebalance_eligible:
             rebalance_mode = "flow"
-            flow_orders = build_flow_orders(excess_cash)
+            flow_orders = build_flow_orders(unallocated_rebalance_capacity)
             for symbol, delta in flow_orders.items():
                 if delta == 0:
                     continue
                 orders_by_symbol[symbol] = orders_by_symbol.get(symbol, 0) + delta
+
+        flow_shared_gate_blockers = []
+        if not regime_ok:
+            flow_shared_gate_blockers.append("regime")
+        if not cooldown_ok:
+            flow_shared_gate_blockers.append("cooldown")
+        if not ratio_gate_ok:
+            flow_shared_gate_blockers.append("ratio")
+        if deficit_gate:
+            flow_decision_status = "superseded_by_deficit_rail"
+        elif not flow_gate:
+            flow_decision_status = "below_activation_threshold"
+        elif flow_shared_gate_blockers:
+            flow_decision_status = "blocked_by_shared_gates"
+        elif rebalance_mode != "flow":
+            flow_decision_status = f"superseded_by_{rebalance_mode}"
+        elif not flow_directional_imbalance_ok:
+            flow_decision_status = "blocked_by_directional_imbalance"
+        else:
+            flow_decision_status = "selected"
+        flow_direction = (
+            "buy"
+            if unallocated_rebalance_capacity > 0
+            else "sell"
+            if unallocated_rebalance_capacity < 0
+            else "flat"
+        )
+        deficit_active_next = (
+            deficit_gate_after if (hard_rebalance or soft_rebalance) else deficit_gate
+        )
+        flow_active_next = flow_gate and rebalance_mode in {"flow", "no"}
+
         regime_summary: List[Dict[str, Any]] = []
         net_liquidation_value = float(account_summary["NetLiquidation"].value)
         for symbol in symbols:
@@ -1511,7 +1573,7 @@ class RegimeRebalanceEngine:
                 f"band={band_status} "
                 f"regime={'ok' if regime_ok else 'no'} "
                 f"cooldown={'ok' if cooldown_ok else 'no'} "
-                f"flow={'on' if flow_gate else 'off'} "
+                f"inferred_flow={flow_decision_status} "
                 f"deficit={'on' if deficit_gate else 'off'}"
             )
 
@@ -1556,7 +1618,11 @@ class RegimeRebalanceEngine:
             )
 
         reserved_cash_for_post_management = 0.0
-        if rebalance_mode == "flow" and flow_gate and excess_cash > 0:
+        if (
+            rebalance_mode == "flow"
+            and flow_gate
+            and unallocated_rebalance_capacity > 0
+        ):
             buy_order_value = sum(
                 shares * market_prices[symbol]
                 for symbol, _primary_exchange, shares in to_trade
@@ -1564,13 +1630,14 @@ class RegimeRebalanceEngine:
             )
             if buy_order_value > 0:
                 reserved_cash_for_post_management = max(
-                    0.0, excess_cash - buy_order_value
+                    0.0, unallocated_rebalance_capacity - buy_order_value
                 )
             if reserved_cash_for_post_management > 0:
                 log.notice(
                     "Regime rebalancing: reserving "
                     f"{dfmt(reserved_cash_for_post_management)} "
-                    "from cash management for future flow deployment."
+                    "from cash management for future inferred-capacity "
+                    "flow deployment."
                 )
         self._reserve_cash_for_post_management(reserved_cash_for_post_management)
 
@@ -1586,20 +1653,87 @@ class RegimeRebalanceEngine:
                 )
             )
 
+        flow_telemetry = {
+            "signal_kind": "inferred_unallocated_rebalance_capacity",
+            "external_flow_detection": "not_performed",
+            "capacity_source": "rebalance_base_minus_managed_sleeve_value",
+            "weight_base": regime_rebalance.weight_base.value,
+            "margin_usage": regime_margin_usage,
+            "rebalance_base": total_value,
+            "managed_sleeve_value": invested_value,
+            "unallocated_rebalance_capacity": unallocated_rebalance_capacity,
+            "direction": flow_direction,
+            "gate": flow_gate,
+            "decision_status": flow_decision_status,
+            "shared_rebalance_gates_ok": shared_rebalance_gates_ok,
+            "shared_gate_blockers": flow_shared_gate_blockers,
+            "rebalance_eligible": flow_rebalance_eligible,
+            "selected": rebalance_mode == "flow",
+            "was_active": flow_was_active,
+            "will_be_active": flow_active_next,
+            "start_threshold": flow_trade_min_amount,
+            "stop_threshold": flow_trade_stop_amount,
+            "candidate_symbols": flow_candidate_symbols,
+            "net_share_gap": flow_net_share_gap,
+            "total_absolute_share_gap": flow_total_absolute_share_gap,
+            "imbalance_ratio": flow_imbalance_ratio,
+            "imbalance_tau": regime_rebalance.flow_imbalance_tau,
+            "directional_imbalance_ok": flow_directional_imbalance_ok,
+            "orders": to_trade if rebalance_mode == "flow" else [],
+            "reserved_cash_for_post_management": reserved_cash_for_post_management,
+        }
+        deficit_telemetry = {
+            "gate": deficit_gate,
+            "was_active": deficit_was_active,
+            "will_be_active": deficit_active_next,
+            "start_threshold": deficit_rail_start_amount,
+            "stop_threshold": deficit_rail_stop_amount,
+        }
+
         log.info(
             f"Regime rebalancing gates: max_relative_drift={pfmt(max_relative_drift)} "
             f"soft_band={pfmt(regime_rebalance.soft_band, 0)} "
             f"hard_band={pfmt(regime_rebalance.hard_band, 0)} "
             f"hard_breach={hard_breach} soft_breach={soft_breach} "
-            f"chop={ffmt(choppiness)} er={pfmt(efficiency)} "
-            f"cooldown_ok={cooldown_ok} mode={rebalance_mode} "
-            f"flow_gate={flow_gate} deficit_gate={deficit_gate} "
-            f"flow_active={flow_active} deficit_active={deficit_active} "
-            f"flow_min={pfmt(regime_rebalance.flow_trade_min)}({dfmt(flow_trade_min_amount)}) "
-            f"flow_stop={pfmt(regime_rebalance.flow_trade_stop)}({dfmt(flow_trade_stop_amount)}) "
-            f"deficit_start={pfmt(regime_rebalance.deficit_rail_start)}({dfmt(deficit_rail_start_amount)}) "
-            f"deficit_stop={pfmt(regime_rebalance.deficit_rail_stop)}({dfmt(deficit_rail_stop_amount)}) "
-            f"excess_cash={dfmt(excess_cash)}" + ratio_gate_log
+            f"chop={ffmt(choppiness)} chop_ok={chop_ok} "
+            f"er={pfmt(efficiency)} er_ok={er_ok} "
+            f"regime_ok={regime_ok} cooldown_ok={cooldown_ok} "
+            f"shared_gates_ok={shared_rebalance_gates_ok} "
+            f"mode={rebalance_mode}" + ratio_gate_log
+        )
+        log.info(
+            "Regime rebalancing inferred-capacity flow: "
+            "signal=inferred_unallocated_rebalance_capacity "
+            "external_flow_detection=not_performed "
+            f"weight_base={regime_rebalance.weight_base.value} "
+            f"margin_usage={ffmt(regime_margin_usage)} "
+            f"rebalance_base={dfmt(total_value)} "
+            f"managed_sleeves={dfmt(invested_value)} "
+            f"unallocated_capacity={dfmt(unallocated_rebalance_capacity)} "
+            f"direction={flow_direction} gate={flow_gate} "
+            f"decision={flow_decision_status} "
+            f"shared_gate_blockers="
+            f"{','.join(flow_shared_gate_blockers) or 'none'} "
+            f"eligible={flow_rebalance_eligible} "
+            f"was_active={flow_was_active} will_be_active={flow_active_next} "
+            f"start={pfmt(regime_rebalance.flow_trade_min)}"
+            f"({dfmt(flow_trade_min_amount)}) "
+            f"stop={pfmt(regime_rebalance.flow_trade_stop)}"
+            f"({dfmt(flow_trade_stop_amount)}) "
+            f"net_share_gap={ifmt(flow_net_share_gap)} "
+            f"total_abs_share_gap={ifmt(flow_total_absolute_share_gap)} "
+            f"imbalance_ratio={_ffmt_or_dash(flow_imbalance_ratio)} "
+            f"imbalance_tau={ffmt(regime_rebalance.flow_imbalance_tau)} "
+            f"directional_ok={flow_directional_imbalance_ok}"
+        )
+        log.info(
+            "Regime rebalancing deficit rail: "
+            f"gate={deficit_gate} was_active={deficit_was_active} "
+            f"will_be_active={deficit_active_next} "
+            f"start={pfmt(regime_rebalance.deficit_rail_start)}"
+            f"({dfmt(deficit_rail_start_amount)}) "
+            f"stop={pfmt(regime_rebalance.deficit_rail_stop)}"
+            f"({dfmt(deficit_rail_stop_amount)})"
         )
         if self.data_store:
             ratio_payload = None
@@ -1609,15 +1743,13 @@ class RegimeRebalanceEngine:
                     if ratio_result is not None
                     else {"enabled": ratio_enabled}
                 )
-            deficit_active_state = (
-                deficit_gate_after
-                if (hard_rebalance or soft_rebalance)
-                else deficit_gate
-            )
-            flow_active_state = flow_gate and rebalance_mode in {"flow", "no"}
             self.data_store.record_event(
                 "regime_rebalance_gate",
                 {
+                    "telemetry_schema_version": 2,
+                    "legacy_field_aliases": {
+                        "excess_cash": "unallocated_rebalance_capacity"
+                    },
                     "symbols": symbols,
                     "max_relative_drift": max_relative_drift,
                     "soft_band": regime_rebalance.soft_band,
@@ -1625,22 +1757,35 @@ class RegimeRebalanceEngine:
                     "hard_breach": hard_breach,
                     "soft_breach": soft_breach,
                     "choppiness": choppiness,
+                    "choppiness_ok": chop_ok,
                     "efficiency": efficiency,
+                    "efficiency_ok": er_ok,
+                    "regime_ok": regime_ok,
                     "cooldown_ok": cooldown_ok,
+                    "ratio_gate_ok": ratio_gate_ok,
+                    "shared_rebalance_gates_ok": shared_rebalance_gates_ok,
                     "flow_gate": flow_gate,
                     "deficit_gate": deficit_gate,
-                    "excess_cash": excess_cash,
+                    "unallocated_rebalance_capacity": unallocated_rebalance_capacity,
+                    # Retain the legacy key for historical telemetry queries.
+                    "excess_cash": unallocated_rebalance_capacity,
                     "reserved_cash_for_post_management": (
                         reserved_cash_for_post_management
                     ),
                     "mode": rebalance_mode,
                     "orders": to_trade,
                     "ratio_gate": ratio_payload,
+                    "flow": flow_telemetry,
+                    "deficit": deficit_telemetry,
                 },
             )
             self.data_store.record_event(
                 "regime_rebalance_summary",
                 {
+                    "telemetry_schema_version": 2,
+                    "legacy_field_aliases": {
+                        "excess_cash": "unallocated_rebalance_capacity"
+                    },
                     "symbols": symbols,
                     "total_value": total_value,
                     "hard_breach": hard_breach,
@@ -1649,20 +1794,24 @@ class RegimeRebalanceEngine:
                     "cooldown_ok": cooldown_ok,
                     "flow_gate": flow_gate,
                     "deficit_gate": deficit_gate,
-                    "excess_cash": excess_cash,
+                    "unallocated_rebalance_capacity": unallocated_rebalance_capacity,
+                    # Retain the legacy key for historical telemetry queries.
+                    "excess_cash": unallocated_rebalance_capacity,
                     "reserved_cash_for_post_management": (
                         reserved_cash_for_post_management
                     ),
                     "mode": rebalance_mode,
                     "summary": regime_summary,
                     "ratio_gate": ratio_payload,
+                    "flow": flow_telemetry,
+                    "deficit": deficit_telemetry,
                 },
             )
             self.data_store.record_event(
                 "regime_rebalance_state",
                 {
-                    "flow_active": flow_active_state,
-                    "deficit_active": deficit_active_state,
+                    "flow_active": flow_active_next,
+                    "deficit_active": deficit_active_next,
                 },
             )
             if volatility_details:


### PR DESCRIPTION
## Summary

Clarify that the regime flow rail operates on inferred unallocated rebalance capacity rather than detected external cash flow, and add enough runtime and SQLite telemetry to explain every flow decision.

## User Impact

Operators can now distinguish a capacity threshold from trade eligibility, see which shared gate blocked deployment, and compare the previous hysteresis state with the state that will be persisted. Trading behavior is unchanged, and the legacy `excess_cash` SQLite field remains available for existing queries.

## Root Cause

The existing `excess_cash`, `flow_gate`, and `flow_active` labels conflated inferred allocation capacity, current threshold state, and the previously persisted hysteresis latch. Gate events also omitted the capacity derivation, directional share-gap inputs, blocking gates, and next state, which made a regime-vetoed flow look like failed deposit detection.

## Fix

- Rename runtime and configuration output around inferred-capacity flow while leaving configuration keys compatible.
- Log the rebalance base, managed sleeve value, unallocated capacity, gate results, blockers, directional imbalance, and previous/next state separately.
- Add versioned structured `flow` and `deficit` data to the existing SQLite gate and summary events, with an explicit `external_flow_detection=not_performed` marker and legacy field alias.
- Report deficit-rail precedence explicitly instead of misclassifying it as a flow-threshold miss.
- Add SQLite-backed regression coverage for regime, ratio, hysteresis, and deficit-rail decisions.

## Validation

- Pre-commit hooks: Ruff check, Ruff format, `ty check`, whitespace and EOF checks
- `uv run --frozen --with pytest-cov pytest --cov=thetagang` — 278 passed, 74% total coverage
