### PR TITLE
fix(regime): deploy inferred capacity outside regime veto

### DIFF
--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1761,7 +1761,7 @@ async def test_regime_rebalance_soft_band_blocked_by_regime(portfolio_manager, m
 
 
 @pytest.mark.asyncio
-async def test_regime_rebalance_flow_trades_require_regime_gate(
+async def test_regime_rebalance_positive_flow_bypasses_regime_gate(
     portfolio_manager_with_db, mocker
 ):
     _configure_flow_rebalance(
@@ -1796,7 +1796,7 @@ async def test_regime_rebalance_flow_trades_require_regime_gate(
         account_summary, portfolio_positions
     )
 
-    assert orders == []
+    assert orders == [("AAA", "NYSE", 2), ("BBB", "NYSE", 2)]
     payload = portfolio_manager_with_db.data_store.get_last_event_payload(
         "regime_rebalance_gate"
     )
@@ -1809,9 +1809,10 @@ async def test_regime_rebalance_flow_trades_require_regime_gate(
     assert payload["choppiness_ok"] is False
     assert payload["regime_ok"] is False
     assert payload["shared_rebalance_gates_ok"] is False
-    assert payload["mode"] == "no"
+    assert payload["mode"] == "flow"
     assert payload["flow"] == {
         "signal_kind": "inferred_unallocated_rebalance_capacity",
+        "classification": "inferred_capacity_deployment",
         "external_flow_detection": "not_performed",
         "capacity_source": "rebalance_base_minus_managed_sleeve_value",
         "weight_base": "net_liq_ex_options",
@@ -1821,11 +1822,13 @@ async def test_regime_rebalance_flow_trades_require_regime_gate(
         "unallocated_rebalance_capacity": 400.0,
         "direction": "buy",
         "gate": True,
-        "decision_status": "blocked_by_shared_gates",
+        "decision_status": "selected",
         "shared_rebalance_gates_ok": False,
         "shared_gate_blockers": ["regime"],
-        "rebalance_eligible": False,
-        "selected": False,
+        "eligibility_gates_ok": True,
+        "eligibility_gate_blockers": [],
+        "rebalance_eligible": True,
+        "selected": True,
         "was_active": False,
         "will_be_active": True,
         "start_threshold": 200.0,
@@ -1836,7 +1839,7 @@ async def test_regime_rebalance_flow_trades_require_regime_gate(
         "imbalance_ratio": 1.0,
         "imbalance_tau": 0.7,
         "directional_imbalance_ok": True,
-        "orders": [],
+        "orders": [["AAA", "NYSE", 2], ["BBB", "NYSE", 2]],
         "reserved_cash_for_post_management": 0.0,
     }
     assert payload["deficit"] == {
@@ -1859,9 +1862,218 @@ async def test_regime_rebalance_flow_trades_require_regime_gate(
         for message in info_messages
         if message.startswith("Regime rebalancing inferred-capacity flow:")
     )
-    assert "decision=blocked_by_shared_gates" in flow_message
-    assert "shared_gate_blockers=regime" in flow_message
+    assert "classification=inferred_capacity_deployment" in flow_message
+    assert "decision=selected" in flow_message
+    assert "ordinary_gate_failures=regime" in flow_message
+    assert "eligibility_gate_blockers=none" in flow_message
+    assert "eligibility_gates_ok=True" in flow_message
     assert "was_active=False will_be_active=True" in flow_message
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_positive_flow_fills_unequal_price_target_gaps(
+    portfolio_manager, mocker
+):
+    _configure_flow_rebalance(
+        portfolio_manager,
+        choppiness_min=10.0,
+        efficiency_max=0.01,
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 8)],
+        "BBB": [_stock_position("BBB", 16)],
+    }
+
+    _mock_regime_tickers(
+        portfolio_manager,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=50.0,
+    )
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == [("AAA", "NYSE", 2), ("BBB", "NYSE", 4)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_positive_flow_scales_to_available_capacity(
+    portfolio_manager, mocker
+):
+    _configure_flow_rebalance(portfolio_manager)
+    portfolio_manager.config.portfolio.symbols["AAA"].weight = 0.6
+    portfolio_manager.config.portfolio.symbols["BBB"].weight = 0.6
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="1000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 4)],
+        "BBB": [_stock_position("BBB", 4)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == [("AAA", "NYSE", 1), ("BBB", "NYSE", 1)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_positive_flow_uses_volatility_adjusted_target(
+    portfolio_manager, mocker
+):
+    _configure_flow_rebalance(
+        portfolio_manager,
+        choppiness_min=10.0,
+        efficiency_max=0.01,
+    )
+    portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.90
+    portfolio_manager.config.strategies.regime_rebalance.hard_band = 0.95
+    portfolio_manager.config.portfolio.symbols[
+        "AAA"
+    ].volatility_weight = _volatility_weight(
+        target_vol=0.10,
+        min_weight=0.25,
+        max_weight=0.5,
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 2)],
+        "BBB": [_stock_position("BBB", 8)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 200.0, 100.0, 200.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == [("AAA", "NYSE", 3), ("BBB", "NYSE", 2)]
+    assert portfolio_manager.get_reserved_cash_for_post_management() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_cooldown_blocks_positive_flow(
+    portfolio_manager, mocker, monkeypatch
+):
+    _configure_flow_rebalance(portfolio_manager)
+    now = datetime(2024, 1, 5, 12, 0, 0)
+    _freeze_now(monkeypatch, now)
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 8)],
+        "BBB": [_stock_position("BBB", 8)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    bars = _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    last_fill_date = bars[-1].date
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                execution=SimpleNamespace(
+                    orderRef="tg:regime-rebalance:AAA", time=last_fill_date
+                ),
+                contract=SimpleNamespace(symbol="AAA"),
+                time=last_fill_date,
+            )
+        ]
+    )
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == []
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_directional_gate_blocks_positive_flow(
+    portfolio_manager_with_db, mocker
+):
+    _configure_flow_rebalance(portfolio_manager_with_db)
+    portfolio_manager_with_db.config.strategies.regime_rebalance.soft_band = 0.60
+    portfolio_manager_with_db.config.strategies.regime_rebalance.hard_band = 0.90
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 5)],
+        "BBB": [_stock_position("BBB", 12)],
+    }
+
+    _mock_regime_tickers(portfolio_manager_with_db, mocker)
+    _mock_regime_history(
+        portfolio_manager_with_db, mocker, [100.0, 110.0, 100.0, 110.0]
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
+
+    _, orders = await portfolio_manager_with_db.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == []
+    payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_gate"
+    )
+    assert payload["flow"]["decision_status"] == "blocked_by_directional_imbalance"
+    assert payload["flow"]["eligibility_gates_ok"] is False
+    assert payload["flow"]["eligibility_gate_blockers"] == ["directional_imbalance"]
+    assert payload["flow"]["rebalance_eligible"] is False
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_negative_flow_retains_regime_gate(
+    portfolio_manager_with_db, mocker
+):
+    _configure_flow_rebalance(
+        portfolio_manager_with_db,
+        choppiness_min=10.0,
+        efficiency_max=0.01,
+    )
+    regime_rebalance = portfolio_manager_with_db.config.strategies.regime_rebalance
+    regime_rebalance.deficit_rail_start = 0.50
+    regime_rebalance.deficit_rail_stop = 0.25
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="2000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 12)],
+        "BBB": [_stock_position("BBB", 12)],
+    }
+
+    _mock_regime_tickers(portfolio_manager_with_db, mocker)
+    _mock_regime_history(
+        portfolio_manager_with_db, mocker, [100.0, 110.0, 100.0, 110.0]
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
+
+    _, orders = await portfolio_manager_with_db.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == []
+    payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_gate"
+    )
+    assert payload["flow"]["classification"] == "inferred_capacity_reduction"
+    assert payload["flow"]["decision_status"] == "blocked_by_shared_gates"
+    assert payload["flow"]["eligibility_gate_blockers"] == ["regime"]
 
 
 @pytest.mark.asyncio
@@ -1940,6 +2152,8 @@ async def test_regime_rebalance_blocked_flow_preserves_hysteresis(
     )
     assert blocked_payload["flow"]["decision_status"] == "blocked_by_shared_gates"
     assert blocked_payload["flow"]["shared_gate_blockers"] == ["ratio"]
+    assert blocked_payload["flow"]["eligibility_gates_ok"] is False
+    assert blocked_payload["flow"]["eligibility_gate_blockers"] == ["ratio"]
     assert blocked_payload["flow"]["was_active"] is False
     assert blocked_payload["flow"]["will_be_active"] is True
 
@@ -2106,7 +2320,7 @@ async def test_regime_rebalance_cash_added_triggers_buys(portfolio_manager, mock
 
 
 @pytest.mark.asyncio
-async def test_regime_rebalance_cash_flow_reserves_unspent_deployable_cash(
+async def test_regime_rebalance_cash_flow_does_not_reserve_disabled_target_gaps(
     portfolio_manager, mocker
 ):
     portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.90
@@ -2133,8 +2347,41 @@ async def test_regime_rebalance_cash_flow_reserves_unspent_deployable_cash(
         account_summary, portfolio_positions
     )
 
-    assert orders == [("AAA", "NYSE", 43)]
-    assert portfolio_manager.get_reserved_cash_for_post_management() == 4100.0
+    assert orders == [("AAA", "NYSE", 42)]
+    assert portfolio_manager.get_reserved_cash_for_post_management() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_cash_flow_reserves_actionable_rounding_remainder(
+    portfolio_manager, mocker
+):
+    _configure_flow_rebalance(portfolio_manager)
+    portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.90
+    portfolio_manager.config.strategies.regime_rebalance.hard_band = 0.95
+    portfolio_manager.config.portfolio.symbols["AAA"].weight = 0.6
+    portfolio_manager.config.portfolio.symbols["BBB"].weight = 0.6
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="1000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 4)],
+        "BBB": [_stock_position("BBB", 2)],
+    }
+
+    _mock_regime_tickers(
+        portfolio_manager,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=150.0,
+    )
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == [("AAA", "NYSE", 1), ("BBB", "NYSE", 1)]
+    assert portfolio_manager.get_reserved_cash_for_post_management() == 50.0
 
 
 @pytest.mark.asyncio

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -629,7 +629,9 @@ daily_stddev_window = "30 D"
 # efficiency_max = 0.30
 # The flow rail infers unallocated capacity as the rebalance base minus the
 # managed sleeve value. It does not detect broker deposits or withdrawals.
-# Flow trades still require the regime, cooldown, and ratio gates to pass.
+# Positive inferred-capacity deployment bypasses the choppiness and efficiency
+# regime veto, but still requires the cooldown, ratio, and directional gates.
+# Negative inferred-capacity reductions retain all ordinary rebalance gates.
 # flow_trade_min = 0.025  # inferred capacity needed to activate (fraction of base)
 # flow_trade_stop = 0.0125  # active-state hysteresis stop (fraction of base)
 # flow_imbalance_tau = 0.70  # directional share-gap coherence, from 0 to 1

--- a/thetagang/strategies/post_engine.py
+++ b/thetagang/strategies/post_engine.py
@@ -214,8 +214,8 @@ class PostStrategyEngine:
         if reserved_cash > 0:
             log.notice(
                 "Cash management: reserving "
-                f"{dfmt(reserved_cash)} for inferred-capacity regime "
-                "flow deployment."
+                f"{dfmt(reserved_cash)} for remaining inferred-capacity "
+                "target gaps."
             )
         try:
             amount = 0.0

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1098,6 +1098,13 @@ class RegimeRebalanceEngine:
             else bool(ratio_result and ratio_result.ok)
         )
         shared_rebalance_gates_ok = regime_ok and cooldown_ok and ratio_gate_ok
+        shared_rebalance_gate_blockers = []
+        if not regime_ok:
+            shared_rebalance_gate_blockers.append("regime")
+        if not cooldown_ok:
+            shared_rebalance_gate_blockers.append("cooldown")
+        if not ratio_gate_ok:
+            shared_rebalance_gate_blockers.append("ratio")
         soft_rebalance = soft_breach and shared_rebalance_gates_ok
         rebalance_fraction = 1.0
         if hard_rebalance:
@@ -1113,6 +1120,13 @@ class RegimeRebalanceEngine:
                 deficit_was_active = bool(state.get("deficit_active", False))
 
         unallocated_rebalance_capacity = total_value - invested_value
+        flow_classification = (
+            "inferred_capacity_deployment"
+            if unallocated_rebalance_capacity > 0
+            else "inferred_capacity_reduction"
+            if unallocated_rebalance_capacity < 0
+            else "none"
+        )
         flow_trade_min_amount = total_value * regime_rebalance.flow_trade_min
         flow_trade_stop_amount = total_value * regime_rebalance.flow_trade_stop
         deficit_rail_start_amount = total_value * regime_rebalance.deficit_rail_start
@@ -1133,7 +1147,14 @@ class RegimeRebalanceEngine:
                 flow_was_active
                 and unallocated_rebalance_capacity >= flow_trade_stop_amount
             )
-        flow_rebalance_eligible = flow_gate and shared_rebalance_gates_ok
+
+        flow_eligibility_gate_blockers = []
+        if flow_classification != "inferred_capacity_deployment" and not regime_ok:
+            flow_eligibility_gate_blockers.append("regime")
+        if not cooldown_ok:
+            flow_eligibility_gate_blockers.append("cooldown")
+        if not ratio_gate_ok:
+            flow_eligibility_gate_blockers.append("ratio")
 
         allowed_symbols = {
             symbol for symbol in symbols if self.config.trading_is_allowed(symbol)
@@ -1175,6 +1196,10 @@ class RegimeRebalanceEngine:
         flow_directional_imbalance_ok = directional_flow_is_allowed(
             unallocated_rebalance_capacity
         )
+        if flow_gate and not flow_directional_imbalance_ok:
+            flow_eligibility_gate_blockers.append("directional_imbalance")
+        flow_eligibility_gates_ok = not flow_eligibility_gate_blockers
+        flow_rebalance_eligible = flow_gate and flow_eligibility_gates_ok
 
         def build_flow_orders(amount: float) -> Dict[str, int]:
             if amount == 0:
@@ -1192,24 +1217,20 @@ class RegimeRebalanceEngine:
                     symbol: max(share_gaps[symbol], 0)
                     for symbol in flow_candidate_symbols
                 }
-                total_deficit = sum(deficits.values())
-                if total_deficit <= 0:
+                total_deficit_value = sum(
+                    deficit * market_prices[symbol]
+                    for symbol, deficit in deficits.items()
+                )
+                if total_deficit_value <= 0:
                     return {}
+                deployment_fraction = min(amount / total_deficit_value, 1.0)
                 for symbol in flow_candidate_symbols:
                     deficit = deficits[symbol]
                     if deficit <= 0:
                         continue
                     if not self.config.trading_is_allowed(symbol):
                         continue
-                    max_buy = max(
-                        (target_shares[symbol] + share_tolerance)
-                        - current_positions[symbol],
-                        0,
-                    )
-                    if max_buy <= 0:
-                        continue
-                    alloc = amount * (deficit / total_deficit)
-                    buy_shares = min(int(alloc // market_prices[symbol]), max_buy)
+                    buy_shares = math.floor(deficit * deployment_fraction)
                     if buy_shares > 0:
                         orders[symbol] = buy_shares
             else:
@@ -1390,23 +1411,16 @@ class RegimeRebalanceEngine:
                     continue
                 orders_by_symbol[symbol] = orders_by_symbol.get(symbol, 0) + delta
 
-        flow_shared_gate_blockers = []
-        if not regime_ok:
-            flow_shared_gate_blockers.append("regime")
-        if not cooldown_ok:
-            flow_shared_gate_blockers.append("cooldown")
-        if not ratio_gate_ok:
-            flow_shared_gate_blockers.append("ratio")
         if deficit_gate:
             flow_decision_status = "superseded_by_deficit_rail"
         elif not flow_gate:
             flow_decision_status = "below_activation_threshold"
-        elif flow_shared_gate_blockers:
+        elif not flow_directional_imbalance_ok:
+            flow_decision_status = "blocked_by_directional_imbalance"
+        elif flow_eligibility_gate_blockers:
             flow_decision_status = "blocked_by_shared_gates"
         elif rebalance_mode != "flow":
             flow_decision_status = f"superseded_by_{rebalance_mode}"
-        elif not flow_directional_imbalance_ok:
-            flow_decision_status = "blocked_by_directional_imbalance"
         else:
             flow_decision_status = "selected"
         flow_direction = (
@@ -1422,6 +1436,7 @@ class RegimeRebalanceEngine:
         flow_active_next = flow_gate and rebalance_mode in {"flow", "no"}
 
         regime_summary: List[Dict[str, Any]] = []
+        actionable_flow_buy_symbols: set[str] = set()
         net_liquidation_value = float(account_summary["NetLiquidation"].value)
         for symbol in symbols:
             target_weight = effective_weights[symbol]
@@ -1547,6 +1562,8 @@ class RegimeRebalanceEngine:
                     action = f"[yellow]Skip (below relative threshold {pfmt(min_percent_relative)})"
 
             if filtered_trade_shares != 0:
+                if rebalance_mode == "flow" and filtered_trade_shares > 0:
+                    actionable_flow_buy_symbols.add(symbol)
                 to_trade.append(
                     (
                         symbol,
@@ -1629,15 +1646,34 @@ class RegimeRebalanceEngine:
                 if shares > 0
             )
             if buy_order_value > 0:
-                reserved_cash_for_post_management = max(
+                remaining_capacity = max(
                     0.0, unallocated_rebalance_capacity - buy_order_value
+                )
+                buy_orders_by_symbol = {
+                    symbol: shares
+                    for symbol, _primary_exchange, shares in to_trade
+                    if shares > 0
+                }
+                remaining_target_gap_value = sum(
+                    max(
+                        target_shares[symbol]
+                        - current_positions[symbol]
+                        - buy_orders_by_symbol.get(symbol, 0),
+                        0,
+                    )
+                    * market_prices[symbol]
+                    for symbol in symbols
+                    if symbol in actionable_flow_buy_symbols
+                )
+                reserved_cash_for_post_management = min(
+                    remaining_capacity, remaining_target_gap_value
                 )
             if reserved_cash_for_post_management > 0:
                 log.notice(
                     "Regime rebalancing: reserving "
                     f"{dfmt(reserved_cash_for_post_management)} "
-                    "from cash management for future inferred-capacity "
-                    "flow deployment."
+                    "from cash management for remaining inferred-capacity "
+                    "target gaps."
                 )
         self._reserve_cash_for_post_management(reserved_cash_for_post_management)
 
@@ -1655,6 +1691,7 @@ class RegimeRebalanceEngine:
 
         flow_telemetry = {
             "signal_kind": "inferred_unallocated_rebalance_capacity",
+            "classification": flow_classification,
             "external_flow_detection": "not_performed",
             "capacity_source": "rebalance_base_minus_managed_sleeve_value",
             "weight_base": regime_rebalance.weight_base.value,
@@ -1666,7 +1703,9 @@ class RegimeRebalanceEngine:
             "gate": flow_gate,
             "decision_status": flow_decision_status,
             "shared_rebalance_gates_ok": shared_rebalance_gates_ok,
-            "shared_gate_blockers": flow_shared_gate_blockers,
+            "shared_gate_blockers": shared_rebalance_gate_blockers,
+            "eligibility_gates_ok": flow_eligibility_gates_ok,
+            "eligibility_gate_blockers": flow_eligibility_gate_blockers,
             "rebalance_eligible": flow_rebalance_eligible,
             "selected": rebalance_mode == "flow",
             "was_active": flow_was_active,
@@ -1710,10 +1749,14 @@ class RegimeRebalanceEngine:
             f"rebalance_base={dfmt(total_value)} "
             f"managed_sleeves={dfmt(invested_value)} "
             f"unallocated_capacity={dfmt(unallocated_rebalance_capacity)} "
+            f"classification={flow_classification} "
             f"direction={flow_direction} gate={flow_gate} "
             f"decision={flow_decision_status} "
-            f"shared_gate_blockers="
-            f"{','.join(flow_shared_gate_blockers) or 'none'} "
+            f"ordinary_gate_failures="
+            f"{','.join(shared_rebalance_gate_blockers) or 'none'} "
+            f"eligibility_gate_blockers="
+            f"{','.join(flow_eligibility_gate_blockers) or 'none'} "
+            f"eligibility_gates_ok={flow_eligibility_gates_ok} "
             f"eligible={flow_rebalance_eligible} "
             f"was_active={flow_was_active} will_be_active={flow_active_next} "
             f"start={pfmt(regime_rebalance.flow_trade_min)}"


### PR DESCRIPTION
## Summary

Separate positive inferred-capacity deployment from ordinary allocation-drift rebalancing so trend-regime metrics remain visible without vetoing new-capital deployment.

## User Impact

Large deposits or persistent unallocated capacity can now move toward the current effective sleeve targets when cooldown, ratio, and directional safety checks pass. Capital is no longer left undeployed solely because choppiness or efficiency indicates a trending market.

## Root Cause

Positive inferred-capacity flow reused the same combined regime, cooldown, and ratio predicate as soft drift rebalancing, even though its orders only buy underweight sleeves and do not fund losers by selling winners.

## Fix

- Classify positive deployment separately from negative inferred-capacity reduction.
- Bypass choppiness and efficiency only for positive deployment while retaining cooldown, ratio, directional, deficit, and execution-policy controls.
- Size positive flow orders from dollar target gaps and respect volatility-adjusted targets.
- Reserve cash only for remaining actionable target gaps after order filtering.
- Add explicit applied-gate telemetry and update the sample configuration guidance.

## Validation

- `uv run --frozen pytest -q` — 285 passed
- `uv run --frozen pytest tests/test_regime_rebalance.py tests/test_post_strategy_engine.py -q` — 86 passed
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen ty check`
