### PR TITLE
fix(regime): correct allocation units and weight bounds

### DIFF
--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -588,16 +588,16 @@ async def test_regime_rebalance_rejects_unreadable_cached_history(
 
 @pytest.mark.asyncio
 async def test_regime_rebalance_volatility_weight_scales_down_without_renormalizing(
-    portfolio_manager, mocker
+    portfolio_manager_with_db, mocker
 ):
-    portfolio_manager.config.portfolio.symbols[
+    portfolio_manager_with_db.config.portfolio.symbols[
         "AAA"
     ].volatility_weight = _volatility_weight(
         target_vol=0.10, min_weight=0.25, max_weight=0.5
     )
-    portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.0
-    portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
-    portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
+    portfolio_manager_with_db.config.strategies.regime_rebalance.soft_band = 0.0
+    portfolio_manager_with_db.config.strategies.regime_rebalance.choppiness_min = 0.0
+    portfolio_manager_with_db.config.strategies.regime_rebalance.efficiency_max = 1.0
 
     account_summary = {"NetLiquidation": SimpleNamespace(value="400")}
     portfolio_positions = {
@@ -605,15 +605,24 @@ async def test_regime_rebalance_volatility_weight_scales_down_without_renormaliz
         "BBB": [_stock_position("BBB", 2)],
     }
 
-    _mock_regime_tickers(portfolio_manager, mocker)
-    _mock_regime_history(portfolio_manager, mocker, [100.0, 200.0, 100.0, 200.0])
-    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+    _mock_regime_tickers(portfolio_manager_with_db, mocker)
+    _mock_regime_history(
+        portfolio_manager_with_db, mocker, [100.0, 200.0, 100.0, 200.0]
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
 
-    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+    _, orders = await portfolio_manager_with_db.check_regime_rebalance_positions(
         account_summary, portfolio_positions
     )
 
     assert orders == [("AAA", "NYSE", -1)]
+    payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "volatility_weight_state"
+    )
+    assert payload["total_effective_weight"] == pytest.approx(0.75)
+    assert payload["unallocated_target_weight"] == pytest.approx(0.25)
 
 
 @pytest.mark.asyncio
@@ -650,6 +659,11 @@ async def test_regime_rebalance_volatility_weight_restores_only_to_base_weight(
 async def test_regime_rebalance_volatility_weight_can_scale_above_base(
     portfolio_manager_with_db, mocker
 ):
+    portfolio_manager_with_db.config.portfolio.symbols["BBB"].weight = 0.4
+    portfolio_manager_with_db.config.portfolio.symbols["SHV"] = SimpleNamespace(
+        weight=0.1,
+        primary_exchange="NYSE",
+    )
     portfolio_manager_with_db.config.portfolio.symbols[
         "AAA"
     ].volatility_weight = _volatility_weight(
@@ -662,9 +676,9 @@ async def test_regime_rebalance_volatility_weight_can_scale_above_base(
     portfolio_manager_with_db.config.strategies.regime_rebalance.choppiness_min = 0.0
     portfolio_manager_with_db.config.strategies.regime_rebalance.efficiency_max = 1.0
 
-    account_summary = {"NetLiquidation": SimpleNamespace(value="400")}
+    account_summary = {"NetLiquidation": SimpleNamespace(value="500")}
     portfolio_positions = {
-        "AAA": [_stock_position("AAA", 2)],
+        "AAA": [_stock_position("AAA", 3)],
         "BBB": [_stock_position("BBB", 2)],
     }
 
@@ -685,6 +699,68 @@ async def test_regime_rebalance_volatility_weight_can_scale_above_base(
     )
     assert orders == []
     assert payload["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.6)
+    assert payload["total_effective_weight"] == pytest.approx(1.0)
+    assert payload["unallocated_target_weight"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_rejects_effective_weights_above_100(
+    portfolio_manager, mocker
+):
+    portfolio_manager.config.portfolio.symbols[
+        "AAA"
+    ].volatility_weight = _volatility_weight(
+        target_vol=0.32,
+        min_weight=0.25,
+        max_weight=0.6,
+        smoothing_factor=1.0,
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="1000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 5)],
+        "BBB": [_stock_position("BBB", 5)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 101.0, 102.0, 103.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    with pytest.raises(ValueError, match="must not exceed 100%"):
+        await portfolio_manager.check_regime_rebalance_positions(
+            account_summary, portfolio_positions
+        )
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_managed_stocks_rejects_unallocated_weight(
+    portfolio_manager, mocker
+):
+    portfolio_manager.config.strategies.regime_rebalance.weight_base = (
+        RegimeRebalanceBaseEnum.managed_stocks
+    )
+    portfolio_manager.config.portfolio.symbols[
+        "AAA"
+    ].volatility_weight = _volatility_weight(
+        target_vol=0.10,
+        min_weight=0.25,
+        max_weight=0.5,
+    )
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="400")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 2)],
+        "BBB": [_stock_position("BBB", 2)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 200.0, 100.0, 200.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    with pytest.raises(ValueError, match="weight_base is managed_stocks"):
+        await portfolio_manager.check_regime_rebalance_positions(
+            account_summary, portfolio_positions
+        )
 
 
 @pytest.mark.asyncio
@@ -1800,7 +1876,7 @@ async def test_regime_rebalance_positive_flow_bypasses_regime_gate(
     payload = portfolio_manager_with_db.data_store.get_last_event_payload(
         "regime_rebalance_gate"
     )
-    assert payload["telemetry_schema_version"] == 2
+    assert payload["telemetry_schema_version"] == 3
     assert payload["legacy_field_aliases"] == {
         "excess_cash": "unallocated_rebalance_capacity"
     }
@@ -1836,6 +1912,9 @@ async def test_regime_rebalance_positive_flow_bypasses_regime_gate(
         "candidate_symbols": ["AAA", "BBB"],
         "net_share_gap": 4,
         "total_absolute_share_gap": 4,
+        "net_value_gap": 400.0,
+        "total_absolute_value_gap": 400.0,
+        "imbalance_unit": "dollars",
         "imbalance_ratio": 1.0,
         "imbalance_tau": 0.7,
         "directional_imbalance_ok": True,
@@ -1852,7 +1931,7 @@ async def test_regime_rebalance_positive_flow_bypasses_regime_gate(
     summary_payload = portfolio_manager_with_db.data_store.get_last_event_payload(
         "regime_rebalance_summary"
     )
-    assert summary_payload["telemetry_schema_version"] == 2
+    assert summary_payload["telemetry_schema_version"] == 3
     assert summary_payload["unallocated_rebalance_capacity"] == pytest.approx(400.0)
     assert summary_payload["flow"] == payload["flow"]
     assert summary_payload["deficit"] == payload["deficit"]
@@ -1907,16 +1986,23 @@ async def test_regime_rebalance_positive_flow_scales_to_available_capacity(
     portfolio_manager, mocker
 ):
     _configure_flow_rebalance(portfolio_manager)
-    portfolio_manager.config.portfolio.symbols["AAA"].weight = 0.6
-    portfolio_manager.config.portfolio.symbols["BBB"].weight = 0.6
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 1.2
+    regime_rebalance.hard_band = 1.5
+    regime_rebalance.flow_imbalance_tau = 0.6
 
     account_summary = {"NetLiquidation": SimpleNamespace(value="1000")}
     portfolio_positions = {
-        "AAA": [_stock_position("AAA", 4)],
-        "BBB": [_stock_position("BBB", 4)],
+        "AAA": [_stock_position("AAA", 0)],
+        "BBB": [_stock_position("BBB", 12)],
     }
 
-    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_tickers(
+        portfolio_manager,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=50.0,
+    )
     _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
     portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
 
@@ -1924,7 +2010,92 @@ async def test_regime_rebalance_positive_flow_scales_to_available_capacity(
         account_summary, portfolio_positions
     )
 
-    assert orders == [("AAA", "NYSE", 1), ("BBB", "NYSE", 1)]
+    assert orders == [("AAA", "NYSE", 4)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_directional_gate_uses_dollar_gaps(
+    portfolio_manager_with_db, mocker
+):
+    _configure_flow_rebalance(
+        portfolio_manager_with_db,
+        flow_trade_min=0.005,
+        flow_trade_stop=0.0,
+    )
+    regime_rebalance = portfolio_manager_with_db.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 2.0
+    regime_rebalance.hard_band = 3.0
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="10000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 55)],
+        "BBB": [_stock_position("BBB", 440)],
+    }
+
+    _mock_regime_tickers(
+        portfolio_manager_with_db,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=10.0,
+    )
+    _mock_regime_history(
+        portfolio_manager_with_db, mocker, [100.0, 110.0, 100.0, 110.0]
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
+
+    _, orders = await portfolio_manager_with_db.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == []
+    payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "regime_rebalance_gate"
+    )
+    assert payload["flow"]["net_share_gap"] == 55
+    assert payload["flow"]["net_value_gap"] == pytest.approx(100.0)
+    assert payload["flow"]["total_absolute_value_gap"] == pytest.approx(1100.0)
+    assert payload["flow"]["imbalance_unit"] == "dollars"
+    assert payload["flow"]["imbalance_ratio"] == pytest.approx(1 / 11)
+    assert payload["flow"]["decision_status"] == "blocked_by_directional_imbalance"
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_negative_flow_sells_by_excess_value(
+    portfolio_manager, mocker
+):
+    _configure_flow_rebalance(
+        portfolio_manager,
+        flow_trade_min=0.05,
+        flow_trade_stop=0.025,
+    )
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 2.0
+    regime_rebalance.hard_band = 3.0
+    regime_rebalance.deficit_rail_start = 0.2
+    regime_rebalance.deficit_rail_stop = 0.1
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="10000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 55)],
+        "BBB": [_stock_position("BBB", 540)],
+    }
+
+    _mock_regime_tickers(
+        portfolio_manager,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=10.0,
+    )
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == [("AAA", "NYSE", -5), ("BBB", "NYSE", -40)]
 
 
 @pytest.mark.asyncio
@@ -2358,19 +2529,17 @@ async def test_regime_rebalance_cash_flow_reserves_actionable_rounding_remainder
     _configure_flow_rebalance(portfolio_manager)
     portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.90
     portfolio_manager.config.strategies.regime_rebalance.hard_band = 0.95
-    portfolio_manager.config.portfolio.symbols["AAA"].weight = 0.6
-    portfolio_manager.config.portfolio.symbols["BBB"].weight = 0.6
 
     account_summary = {"NetLiquidation": SimpleNamespace(value="1000")}
     portfolio_positions = {
-        "AAA": [_stock_position("AAA", 4)],
-        "BBB": [_stock_position("BBB", 2)],
+        "AAA": [_stock_position("AAA", 2)],
+        "BBB": [_stock_position("BBB", 4)],
     }
 
     _mock_regime_tickers(
         portfolio_manager,
         mocker,
-        aaa_price=100.0,
+        aaa_price=120.0,
         bbb_price=150.0,
     )
     _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
@@ -2380,8 +2549,8 @@ async def test_regime_rebalance_cash_flow_reserves_actionable_rounding_remainder
         account_summary, portfolio_positions
     )
 
-    assert orders == [("AAA", "NYSE", 1), ("BBB", "NYSE", 1)]
-    assert portfolio_manager.get_reserved_cash_for_post_management() == 50.0
+    assert orders == [("AAA", "NYSE", 1)]
+    assert portfolio_manager.get_reserved_cash_for_post_management() == 40.0
 
 
 @pytest.mark.asyncio
@@ -2552,6 +2721,40 @@ async def test_regime_rebalance_deficit_rail_sells_pro_rata(portfolio_manager, m
     )
 
     assert orders == [("AAA", "NYSE", -1), ("BBB", "NYSE", -1)]
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_deficit_rail_sells_by_overweight_value(
+    portfolio_manager, mocker
+):
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 2.0
+    regime_rebalance.hard_band = 3.0
+    regime_rebalance.choppiness_min = 0.0
+    regime_rebalance.efficiency_max = 1.0
+    regime_rebalance.deficit_rail_start = 0.10
+    regime_rebalance.deficit_rail_stop = 0.03
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="10000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 61)],
+        "BBB": [_stock_position("BBB", 601)],
+    }
+
+    _mock_regime_tickers(
+        portfolio_manager,
+        mocker,
+        aaa_price=100.0,
+        bbb_price=10.0,
+    )
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == [("AAA", "NYSE", -10), ("BBB", "NYSE", -81)]
 
 
 @pytest.mark.asyncio

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -634,11 +634,14 @@ daily_stddev_window = "30 D"
 # Negative inferred-capacity reductions retain all ordinary rebalance gates.
 # flow_trade_min = 0.025  # inferred capacity needed to activate (fraction of base)
 # flow_trade_stop = 0.0125  # active-state hysteresis stop (fraction of base)
-# flow_imbalance_tau = 0.70  # directional share-gap coherence, from 0 to 1
+# flow_imbalance_tau = 0.70  # directional dollar-gap coherence, from 0 to 1
 # deficit_rail_start = 0.06  # deficit that triggers safety rail (fraction of base)
 # deficit_rail_stop = 0.03  # hysteresis stop once within this band (fraction of base)
 # order_history_lookback_days = 30  # look back this many calendar days for fills
 # shares_only = false  # when true, disables all option writes/rolls
+# Effective symbol weights are absolute targets and are not renormalized. A total
+# below 100% remains outside the managed targets as cash (or the configured cash
+# fund); a total above 100% aborts. The managed_stocks base requires exactly 100%.
 #
 # # Optional regime stock execution policy, same shape as wheel:
 # [strategies.regime_rebalance.equity_rebalance.defaults]

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -673,7 +673,7 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
         )
         table.add_row(
             "",
-            "Directional share-gap tau",
+            "Directional dollar-gap tau",
             "=",
             f"{ffmt(self.flow_imbalance_tau)}",
         )

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -994,6 +994,34 @@ class RegimeRebalanceEngine:
             raise ValueError(
                 "Regime-aware rebalancing requires positive effective weights."
             )
+        if total_effective_weight > 1.0 + regime_rebalance.eps:
+            log.error(
+                "Regime-aware rebalancing effective weights exceed 100%: "
+                f"{pfmt(total_effective_weight)}."
+            )
+            raise ValueError(
+                "Regime-aware rebalancing effective weights must not exceed 100%."
+            )
+        if weight_base == RegimeRebalanceBaseEnum.managed_stocks and not math.isclose(
+            total_effective_weight,
+            1.0,
+            rel_tol=0.0,
+            abs_tol=regime_rebalance.eps,
+        ):
+            log.error(
+                "Regime-aware rebalancing managed_stocks weights must sum to 100%."
+            )
+            raise ValueError(
+                "Regime-aware rebalancing requires effective weights to sum to "
+                "100% when weight_base is managed_stocks."
+            )
+        unallocated_target_weight = max(0.0, 1.0 - total_effective_weight)
+        if unallocated_target_weight > regime_rebalance.eps:
+            log.notice(
+                "Regime-aware rebalancing leaving "
+                f"{pfmt(unallocated_target_weight)} outside managed targets for "
+                "cash reserves."
+            )
         normalized_effective_weights = {
             symbol: weight / total_effective_weight
             for symbol, weight in effective_weights.items()
@@ -1170,26 +1198,34 @@ class RegimeRebalanceEngine:
         flow_total_absolute_share_gap = sum(
             abs(share_gaps[symbol]) for symbol in flow_candidate_symbols
         )
+        flow_value_gaps = {
+            symbol: share_gaps[symbol] * market_prices[symbol]
+            for symbol in flow_candidate_symbols
+        }
+        flow_net_value_gap = sum(flow_value_gaps.values())
+        flow_total_absolute_value_gap = sum(
+            abs(value) for value in flow_value_gaps.values()
+        )
         flow_imbalance_ratio = (
-            flow_net_share_gap / flow_total_absolute_share_gap
-            if flow_total_absolute_share_gap > 0
+            flow_net_value_gap / flow_total_absolute_value_gap
+            if flow_total_absolute_value_gap > 0
             else None
         )
 
         def directional_flow_is_allowed(amount: float) -> bool:
-            if flow_total_absolute_share_gap <= 0:
+            if flow_total_absolute_value_gap <= 0:
                 return False
             if amount > 0:
                 return (
-                    flow_net_share_gap
+                    flow_net_value_gap
                     > regime_rebalance.flow_imbalance_tau
-                    * flow_total_absolute_share_gap
+                    * flow_total_absolute_value_gap
                 )
             if amount < 0:
                 return (
-                    flow_net_share_gap
+                    flow_net_value_gap
                     < -regime_rebalance.flow_imbalance_tau
-                    * flow_total_absolute_share_gap
+                    * flow_total_absolute_value_gap
                 )
             return False
 
@@ -1206,7 +1242,7 @@ class RegimeRebalanceEngine:
                 return {}
             if not flow_candidate_symbols:
                 return {}
-            if flow_total_absolute_share_gap <= 0:
+            if flow_total_absolute_value_gap <= 0:
                 return {}
             if not directional_flow_is_allowed(amount):
                 return {}
@@ -1235,16 +1271,16 @@ class RegimeRebalanceEngine:
                         orders[symbol] = buy_shares
             else:
                 need = -amount
-                excesses = {
-                    symbol: max(-share_gaps[symbol], 0)
+                excess_values = {
+                    symbol: max(-flow_value_gaps[symbol], 0.0)
                     for symbol in flow_candidate_symbols
                 }
-                total_excess = sum(excesses.values())
-                if total_excess <= 0:
+                total_excess_value = sum(excess_values.values())
+                if total_excess_value <= 0:
                     return {}
                 for symbol in flow_candidate_symbols:
-                    excess = excesses[symbol]
-                    if excess <= 0:
+                    excess_value = excess_values[symbol]
+                    if excess_value <= 0:
                         continue
                     if not self.config.trading_is_allowed(symbol):
                         continue
@@ -1255,7 +1291,7 @@ class RegimeRebalanceEngine:
                     )
                     if max_sell <= 0:
                         continue
-                    alloc = need * (excess / total_excess)
+                    alloc = need * (excess_value / total_excess_value)
                     sell_shares = min(
                         math.ceil(alloc / market_prices[symbol]), max_sell
                     )
@@ -1281,18 +1317,21 @@ class RegimeRebalanceEngine:
                 and symbol in allowed_symbols
             ]
             if overweight_symbols:
-                overages = {
-                    symbol: max(
-                        shares_state[symbol]
-                        - (target_shares[symbol] + share_tolerance),
-                        0,
+                overage_values = {
+                    symbol: (
+                        max(
+                            shares_state[symbol]
+                            - (target_shares[symbol] + share_tolerance),
+                            0,
+                        )
+                        * market_prices[symbol]
                     )
                     for symbol in overweight_symbols
                 }
-                total_over = sum(overages.values())
+                total_overage_value = sum(overage_values.values())
                 for symbol in overweight_symbols:
-                    over = overages[symbol]
-                    if over <= 0:
+                    overage_value = overage_values[symbol]
+                    if overage_value <= 0:
                         continue
                     max_sell = max(
                         shares_state[symbol]
@@ -1302,8 +1341,8 @@ class RegimeRebalanceEngine:
                     if max_sell <= 0:
                         continue
                     alloc = (
-                        initial_amount * (over / total_over)
-                        if total_over > 0
+                        initial_amount * (overage_value / total_overage_value)
+                        if total_overage_value > 0
                         else amount
                     )
                     alloc = min(alloc, amount)
@@ -1715,6 +1754,9 @@ class RegimeRebalanceEngine:
             "candidate_symbols": flow_candidate_symbols,
             "net_share_gap": flow_net_share_gap,
             "total_absolute_share_gap": flow_total_absolute_share_gap,
+            "net_value_gap": flow_net_value_gap,
+            "total_absolute_value_gap": flow_total_absolute_value_gap,
+            "imbalance_unit": "dollars",
             "imbalance_ratio": flow_imbalance_ratio,
             "imbalance_tau": regime_rebalance.flow_imbalance_tau,
             "directional_imbalance_ok": flow_directional_imbalance_ok,
@@ -1763,8 +1805,8 @@ class RegimeRebalanceEngine:
             f"({dfmt(flow_trade_min_amount)}) "
             f"stop={pfmt(regime_rebalance.flow_trade_stop)}"
             f"({dfmt(flow_trade_stop_amount)}) "
-            f"net_share_gap={ifmt(flow_net_share_gap)} "
-            f"total_abs_share_gap={ifmt(flow_total_absolute_share_gap)} "
+            f"net_value_gap={dfmt(flow_net_value_gap)} "
+            f"total_abs_value_gap={dfmt(flow_total_absolute_value_gap)} "
             f"imbalance_ratio={_ffmt_or_dash(flow_imbalance_ratio)} "
             f"imbalance_tau={ffmt(regime_rebalance.flow_imbalance_tau)} "
             f"directional_ok={flow_directional_imbalance_ok}"
@@ -1789,11 +1831,13 @@ class RegimeRebalanceEngine:
             self.data_store.record_event(
                 "regime_rebalance_gate",
                 {
-                    "telemetry_schema_version": 2,
+                    "telemetry_schema_version": 3,
                     "legacy_field_aliases": {
                         "excess_cash": "unallocated_rebalance_capacity"
                     },
                     "symbols": symbols,
+                    "total_effective_weight": total_effective_weight,
+                    "unallocated_target_weight": unallocated_target_weight,
                     "max_relative_drift": max_relative_drift,
                     "soft_band": regime_rebalance.soft_band,
                     "hard_band": regime_rebalance.hard_band,
@@ -1825,12 +1869,14 @@ class RegimeRebalanceEngine:
             self.data_store.record_event(
                 "regime_rebalance_summary",
                 {
-                    "telemetry_schema_version": 2,
+                    "telemetry_schema_version": 3,
                     "legacy_field_aliases": {
                         "excess_cash": "unallocated_rebalance_capacity"
                     },
                     "symbols": symbols,
                     "total_value": total_value,
+                    "total_effective_weight": total_effective_weight,
+                    "unallocated_target_weight": unallocated_target_weight,
                     "hard_breach": hard_breach,
                     "soft_breach": soft_breach,
                     "regime_ok": regime_ok,
@@ -1861,6 +1907,8 @@ class RegimeRebalanceEngine:
                 self.data_store.record_event(
                     "volatility_weight_state",
                     {
+                        "total_effective_weight": total_effective_weight,
+                        "unallocated_target_weight": unallocated_target_weight,
                         "symbols": {
                             symbol: {
                                 "base_weight": details["base_weight"],
@@ -1870,7 +1918,7 @@ class RegimeRebalanceEngine:
                                 "smoothing_factor": details["smoothing_factor"],
                             }
                             for symbol, details in volatility_details.items()
-                        }
+                        },
                     },
                 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1193,7 +1193,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13,<2" },
-    { name = "annotated-types", specifier = ">=0.7.0,<0.8" },
+    { name = "annotated-types", specifier = ">=0.7.0,<0.9" },
     { name = "click", specifier = ">=8.1.3,<9" },
     { name = "click-log", specifier = ">=0.4.0,<0.5" },
     { name = "exchange-calendars", specifier = ">=4.12" },
@@ -1214,7 +1214,7 @@ requires-dist = [
 dev = [
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pytest", specifier = ">=9.0.0,<10" },
-    { name = "pytest-asyncio", specifier = ">=0.23.0,<1.4" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0,<1.5" },
     { name = "pytest-mock", specifier = ">=3.14.0,<4" },
     { name = "pytest-watch", specifier = ">=4.2.0,<5" },
     { name = "ruff", specifier = ">=0.14.13" },


### PR DESCRIPTION
## Summary

Correct regime flow and deficit allocation so portfolio imbalances and required sales are measured in dollars, and make effective-weight reserve semantics explicit.

## User Impact

Portfolios whose sleeves have materially different share prices now distribute required sales according to capital overweights instead of raw share counts. Volatility overlays may deliberately leave part of net liquidation in cash or the configured cash fund when effective targets total less than 100%, while unsafe totals above 100% abort before orders are generated.

## Root Cause

Directional flow coherence, negative-flow sell allocation, and deficit-rail sell allocation used raw share gaps. Equal share counts can represent radically different capital amounts across symbols. Effective weights were treated as absolute targets in the main rebalance path, but their total was not bounded above and the intended handling of totals below 100% was implicit.

## Fix

- Convert share gaps and overages to dollar values using current market prices for flow gating and proportional sell allocation.
- Retain share-gap telemetry for diagnostics while adding dollar-gap telemetry and bumping the telemetry schema version.
- Reject effective target totals above 100% while allowing a deliberate reserve below 100% for net-liquidation-based targets.
- Require exactly 100% effective weight with the `managed_stocks` base to avoid recursively shrinking the target base.
- Document the no-renormalization policy and report the unallocated target weight in telemetry.
- Add regression coverage for unequal-priced sleeves, downward and upward volatility overlays, invalid weight totals, and reserve behavior.
- Refresh `uv.lock` project metadata so it agrees with current dependency bounds.

## Validation

- `uv lock --check`
- `uv run --frozen pytest -q` — 290 passed
- `uv run --frozen --with pytest-cov pytest --cov=thetagang -q` — 290 passed, 75% total coverage
- `uv run --frozen pytest -q tests/test_regime_rebalance.py` — 82 passed post-commit
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen ty check`
- `uv run --frozen pre-commit run --all-files`
