### PR TITLE
fix(regime): isolate managed option accounting

### DIFF
--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1325,51 +1325,161 @@ async def test_net_liq_base_also_excludes_state_owned_tail_puts(
 
 
 @pytest.mark.asyncio
-async def test_regime_rebalance_box_spread_borrowing_excluded_from_base(
-    portfolio_manager, mocker
+async def test_net_liq_ex_options_preserves_tail_ownership_outside_regime(
+    portfolio_manager_with_db, mocker
 ):
+    portfolio_manager = portfolio_manager_with_db
+    portfolio_manager.config.runtime.account.margin_usage = 1.2
+    portfolio_manager.config.strategies.tail_hedge = SimpleNamespace(
+        enabled=False,
+        targets=[_tail_target("CCC")],
+    )
+    tail_put = _option_position(
+        "CCC",
+        1,
+        market_value=10_000.0,
+        right="P",
+        con_id=703,
+        average_cost=10_001.0,
+        unrealized_pnl=-1.0,
+    )
+    _save_tail_state(
+        portfolio_manager,
+        _tail_state(symbol="CCC", puts=[tail_put]),
+    )
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 500)],
+        "BBB": [_stock_position("BBB", 300)],
+        "CCC": [tail_put],
+    }
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(
+        portfolio_manager,
+        mocker,
+        [100.0, 110.0, 100.0, 110.0],
+    )
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+    portfolio_manager.ibkr.open_trades = mocker.Mock(return_value=[])
+
+    _, orders = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+        _regime_account_summary("100000"),
+        portfolio_positions,
+    )
+
+    assert orders == [("AAA", "NYSE", 40), ("BBB", "NYSE", 240)]
+
+
+@pytest.mark.asyncio
+async def test_untracked_box_does_not_offset_tracked_option_exclusion(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager = portfolio_manager_with_db
     portfolio_manager.config.runtime.account.margin_usage = 1.2
     portfolio_manager.config.strategies.regime_rebalance.weight_base = (
         RegimeRebalanceBaseEnum.net_liq_ex_options
     )
-    portfolio_manager.config.strategies.regime_rebalance.soft_band = 0.0
     portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
     portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
 
     account_summary = {"NetLiquidation": SimpleNamespace(value="100000")}
-    portfolio_positions = {
-        "AAA": [_stock_position("AAA", 400)],
-        "BBB": [_stock_position("BBB", 400)],
-        "SHV": [_stock_position("SHV", 200, market_value=20000.0)],
-        "SPX": [
-            _option_position(
-                "SPX",
-                -1,
-                market_value=-12000.0,
-                strike=5000.0,
-                right="C",
-                expiry="20260716",
-            ),
-            _option_position(
-                "SPX",
-                1,
-                market_value=8000.0,
-                strike=5000.0,
-                right="P",
-                expiry="20260716",
-            ),
-        ],
-    }
-
     _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
     _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
     portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+    notice_mock = mocker.patch.object(regime_engine_module.log, "notice")
 
-    _, orders = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
-        account_summary, portfolio_positions
-    )
+    async def rebalance_snapshot(include_box: bool):
+        notice_mock.reset_mock()
+        portfolio_positions = {
+            "AAA": [
+                _stock_position("AAA", 540),
+                _option_position("AAA", 1, market_value=6000.0),
+            ],
+            "BBB": [
+                _stock_position("BBB", 540),
+                _option_position("BBB", 1, market_value=4000.0),
+            ],
+        }
+        if include_box:
+            portfolio_positions["SPX"] = [
+                _option_position(
+                    "SPX",
+                    -1,
+                    market_value=-1_200_000.0,
+                    strike=5000.0,
+                    right="C",
+                    expiry="20260716",
+                ),
+                _option_position(
+                    "SPX",
+                    1,
+                    market_value=2000.0,
+                    strike=5000.0,
+                    right="P",
+                    expiry="20260716",
+                ),
+                _option_position(
+                    "SPX",
+                    1,
+                    market_value=700_000.0,
+                    strike=5100.0,
+                    right="C",
+                    expiry="20260716",
+                ),
+                _option_position(
+                    "SPX",
+                    -1,
+                    market_value=-2000.0,
+                    strike=5100.0,
+                    right="P",
+                    expiry="20260716",
+                ),
+            ]
 
-    assert orders == [("AAA", "NYSE", 224), ("BBB", "NYSE", 224)]
+        (
+            _,
+            orders,
+        ) = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+            account_summary, portfolio_positions
+        )
+        base_message = next(
+            call.args[0]
+            for call in notice_mock.call_args_list
+            if call.args[0].startswith(
+                "Regime rebalancing base: mode=net_liq_ex_options"
+            )
+        )
+        gate = portfolio_manager.data_store.get_last_event_payload(
+            "regime_rebalance_gate"
+        )
+        summary = portfolio_manager.data_store.get_last_event_payload(
+            "regime_rebalance_summary"
+        )
+        return {
+            "base_message": base_message,
+            "rebalance_base": gate["flow"]["rebalance_base"],
+            "current_weights": {
+                item["symbol"]: item["current_weight"] for item in summary["summary"]
+            },
+            "soft_breach": gate["soft_breach"],
+            "hard_breach": gate["hard_breach"],
+            "orders": orders,
+        }
+
+    without_box = await rebalance_snapshot(include_box=False)
+    with_large_untracked_box = await rebalance_snapshot(include_box=True)
+
+    assert with_large_untracked_box == without_box
+    assert "excluded_options=[green]$10,000.00[/green]" in without_box["base_message"]
+    assert "margin_usage=[green]1.20[/green]" in without_box["base_message"]
+    assert "base=[green]$108,000.00[/green]" in without_box["base_message"]
+    assert without_box["rebalance_base"] == 108_000
+    assert without_box["current_weights"] == {
+        "AAA": pytest.approx(0.5),
+        "BBB": pytest.approx(0.5),
+    }
+    assert without_box["soft_breach"] is False
+    assert without_box["hard_breach"] is False
+    assert without_box["orders"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1385,10 +1385,8 @@ async def test_untracked_box_does_not_offset_tracked_option_exclusion(
     _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
     _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
     portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
-    notice_mock = mocker.patch.object(regime_engine_module.log, "notice")
 
     async def rebalance_snapshot(include_box: bool):
-        notice_mock.reset_mock()
         portfolio_positions = {
             "AAA": [
                 _stock_position("AAA", 540),
@@ -1441,13 +1439,6 @@ async def test_untracked_box_does_not_offset_tracked_option_exclusion(
         ) = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
             account_summary, portfolio_positions
         )
-        base_message = next(
-            call.args[0]
-            for call in notice_mock.call_args_list
-            if call.args[0].startswith(
-                "Regime rebalancing base: mode=net_liq_ex_options"
-            )
-        )
         gate = portfolio_manager.data_store.get_last_event_payload(
             "regime_rebalance_gate"
         )
@@ -1455,7 +1446,6 @@ async def test_untracked_box_does_not_offset_tracked_option_exclusion(
             "regime_rebalance_summary"
         )
         return {
-            "base_message": base_message,
             "rebalance_base": gate["flow"]["rebalance_base"],
             "current_weights": {
                 item["symbol"]: item["current_weight"] for item in summary["summary"]
@@ -1469,9 +1459,6 @@ async def test_untracked_box_does_not_offset_tracked_option_exclusion(
     with_large_untracked_box = await rebalance_snapshot(include_box=True)
 
     assert with_large_untracked_box == without_box
-    assert "excluded_options=[green]$10,000.00[/green]" in without_box["base_message"]
-    assert "margin_usage=[green]1.20[/green]" in without_box["base_message"]
-    assert "base=[green]$108,000.00[/green]" in without_box["base_message"]
     assert without_box["rebalance_base"] == 108_000
     assert without_box["current_weights"] == {
         "AAA": pytest.approx(0.5),
@@ -1480,6 +1467,73 @@ async def test_untracked_box_does_not_offset_tracked_option_exclusion(
     assert without_box["soft_breach"] is False
     assert without_box["hard_breach"] is False
     assert without_box["orders"] == []
+
+
+@pytest.mark.asyncio
+async def test_zero_weight_option_does_not_reduce_net_liq_base(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager = portfolio_manager_with_db
+    portfolio_manager.config.runtime.account.margin_usage = 1.2
+    portfolio_manager.config.strategies.regime_rebalance.choppiness_min = 0.0
+    portfolio_manager.config.strategies.regime_rebalance.efficiency_max = 1.0
+    portfolio_manager.config.portfolio.symbols["CCC"] = SimpleNamespace(
+        weight=0.0,
+        primary_exchange="NYSE",
+    )
+    portfolio_manager.config.strategies.regime_rebalance.symbols.append("CCC")
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="100000")}
+    _mock_regime_tickers(portfolio_manager, mocker, aaa_price=100.0, bbb_price=100.0)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    async def rebalance_snapshot(include_zero_weight_option: bool):
+        portfolio_positions = {
+            "AAA": [_stock_position("AAA", 600)],
+            "BBB": [_stock_position("BBB", 600)],
+        }
+        if include_zero_weight_option:
+            portfolio_positions["CCC"] = [
+                _option_position("CCC", 1, market_value=50_000.0)
+            ]
+
+        (
+            _,
+            orders,
+        ) = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+            account_summary, portfolio_positions
+        )
+        gate = portfolio_manager.data_store.get_last_event_payload(
+            "regime_rebalance_gate"
+        )
+        summary = portfolio_manager.data_store.get_last_event_payload(
+            "regime_rebalance_summary"
+        )
+        return {
+            "rebalance_base": gate["flow"]["rebalance_base"],
+            "current_weights": {
+                item["symbol"]: item["current_weight"] for item in summary["summary"]
+            },
+            "soft_breach": gate["soft_breach"],
+            "hard_breach": gate["hard_breach"],
+            "orders": orders,
+        }
+
+    without_zero_weight_option = await rebalance_snapshot(
+        include_zero_weight_option=False
+    )
+    with_zero_weight_option = await rebalance_snapshot(include_zero_weight_option=True)
+
+    assert with_zero_weight_option == without_zero_weight_option
+    assert without_zero_weight_option["rebalance_base"] == 120_000
+    assert without_zero_weight_option["current_weights"] == {
+        "AAA": pytest.approx(0.5),
+        "BBB": pytest.approx(0.5),
+    }
+    assert without_zero_weight_option["soft_breach"] is False
+    assert without_zero_weight_option["hard_breach"] is False
+    assert without_zero_weight_option["orders"] == []
 
 
 @pytest.mark.asyncio

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1614,8 +1614,6 @@ class RegimeRebalanceEngine:
                 "Regime-aware rebalancing enabled but no symbols are configured."
             )
             return (table, to_trade)
-        configured_regime_symbols = set(symbols)
-
         missing_symbols = [symbol for symbol in symbols if symbol not in symbol_configs]
         if missing_symbols:
             log.error(
@@ -1639,6 +1637,7 @@ class RegimeRebalanceEngine:
             raise ValueError(
                 "Regime-aware rebalancing requires positive target weights."
             )
+        managed_regime_symbols = set(symbols)
 
         stock_positions = [
             position
@@ -1710,7 +1709,7 @@ class RegimeRebalanceEngine:
             for positions in portfolio_positions.values():
                 for position in positions:
                     if isinstance(position.contract, Option) and (
-                        position.contract.symbol in configured_regime_symbols
+                        position.contract.symbol in managed_regime_symbols
                         or position.contract.conId in owned_tail_hedge_con_ids
                     ):
                         market_value = float(position.marketValue or 0.0)

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1614,6 +1614,7 @@ class RegimeRebalanceEngine:
                 "Regime-aware rebalancing enabled but no symbols are configured."
             )
             return (table, to_trade)
+        configured_regime_symbols = set(symbols)
 
         missing_symbols = [symbol for symbol in symbols if symbol not in symbol_configs]
         if missing_symbols:
@@ -1696,6 +1697,7 @@ class RegimeRebalanceEngine:
 
         last_rebalance = await self._get_last_regime_rebalance_time(symbols)
         tail_cohorts = self._load_tail_cohorts()
+        owned_tail_hedge_con_ids = {cohort.con_id for cohort in tail_cohorts}
 
         weight_base = regime_rebalance.weight_base
         regime_margin_usage = self._resolve_regime_margin_usage()
@@ -1703,9 +1705,14 @@ class RegimeRebalanceEngine:
             total_value = sum(current_values.values())
         elif weight_base == RegimeRebalanceBaseEnum.net_liq_ex_options:
             excluded_value = 0.0
+            # Regime checks receive the combined account map for tail ownership.
+            # Ignore unrelated financing options, but retain state-owned tail puts.
             for positions in portfolio_positions.values():
                 for position in positions:
-                    if isinstance(position.contract, Option):
+                    if isinstance(position.contract, Option) and (
+                        position.contract.symbol in configured_regime_symbols
+                        or position.contract.conId in owned_tail_hedge_con_ids
+                    ):
                         market_value = float(position.marketValue or 0.0)
                         excluded_value += market_value
             net_liq = float(account_summary["NetLiquidation"].value)


### PR DESCRIPTION
## Summary

Restore regime-rebalance option accounting so unrelated financing positions cannot offset option value belonging to managed sleeves.

## User Impact

After the portfolio-state changes in #691, the regime stage received both tracked and untracked positions. A negative-value untracked box spread could then cancel positive-value managed overlays in `excluded_options`, inflate the margin-adjusted rebalance base, create false allocation drift, and trigger unintended stock orders.

In the observed run, roughly $34.2k of managed overlay value was nearly canceled by an unrelated SPX financing box, leaving only $4.2k excluded and increasing the rebalance base from roughly $112.6k to $148.6k.

## Root Cause

`net_liq_ex_options` summed every option in the combined account position map. The combined map is required for tail-hedge ownership reconciliation, but it also contains unrelated positions that must not participate in managed allocation accounting.

## Fix

- Exclude option market value only for configured regime symbols or state-owned tail-hedge contract IDs.
- Keep unrelated positions such as SPX financing boxes neutral to the rebalance calculation.
- Continue applying strategy margin usage after calculating the corrected options-excluded NLV.
- Preserve tail-hedge ownership even when a state-owned put is outside the regime symbol set.
- Add regression coverage proving a large untracked four-leg box has no effect on excluded option value, rebalance base, weights, drift detection, or generated orders.

## Validation

- `uv run --frozen pytest -q` — 452 passed
- `uv run --frozen pre-commit run --all-files` — passed
- Ruff lint and formatting — passed
- `ty check` — passed
- `uv-lock` — passed
