### PR TITLE
fix: coordinate tail harvest and cash accounting

### DIFF
--- a/docs/tail-hedging.md
+++ b/docs/tail-hedging.md
@@ -28,9 +28,12 @@ flowchart TD
     R{"Regime stage: approved stock buy still short after ordinary funding?"}
     R -->|Yes| Q{"Profitable owned cohort available?"}
     R -->|No or stage disabled| A["Tail stage: load SQLite cohorts"]
-    Q -->|Yes| J["Queue at most one harvest per target and defer unfunded shares"]
+    Q -->|Yes| J["Submit at most one harvest per target in a bounded fill phase"]
     Q -->|No| A
-    J --> A
+    J --> K{"Every harvest fully filled?"}
+    K -->|No| S["Cancel incomplete orders and abort remaining stages"]
+    K -->|Yes| L["Refresh broker cash and positions, then replan regime orders"]
+    L --> A
     A --> B["Reconcile every open cohort with broker state"]
     B --> C{"Any cohort due to exit or target removed?"}
     C -->|Yes| X["Queue safe closes for due cohorts"]
@@ -103,15 +106,18 @@ live cohorts in steady state, but this is an expectation rather than a target
 count. Available expirations and entry filters determine the actual ladder.
 
 An unfilled sell order does not restore budget. After the broker position shows
-an actual reduction, ThetaGang credits the originating cohort using a
-recorded sell-limit value, capped at that cohort's entry cost. This makes
-remaining premium from a normal DTE exit available within the rolling annual
-budget without enlarging the next entry slice. A crash gain can reduce the
-cohort's net cost to zero, but it cannot create extra hedge budget.
+an actual reduction, ThetaGang credits the originating cohort, capped at that
+cohort's entry cost. A complete reduction with a usable IBKR average fill price
+uses that fill price less the configured estimated fee. Partial or ambiguous
+reconciliation keeps the conservative recovery value recorded when the order
+was created. This makes remaining premium from a normal DTE exit available
+within the rolling annual budget without enlarging the next entry slice. A
+crash gain can reduce the cohort's net cost to zero, but it cannot create extra
+hedge budget.
 
-Budget accounting uses submitted limit values and the configured fee estimate
-rather than an execution and commission ledger. Actual commissions and favorable
-fill-price improvement are therefore not reconciled after execution.
+Budget accounting is not an execution-and-commission ledger. It can reconcile
+the average fill price for a complete sale, but actual commissions are still
+represented by `runtime.orders.estimated_fee_per_contract`.
 
 Within the nearest eligible expiration, each liquid and affordable candidate
 receives two model-free catastrophe scores. For every configured drawdown,
@@ -145,20 +151,32 @@ shortfall can trigger a harvest.
 
 Only active, state-owned puts without a conflicting order are eligible. The
 live sell quote, after the configured estimated sell fee, must exceed both the
-IBKR average cost and the configured all-in entry basis. Estimated net proceeds
-are used for funding and budget recovery.
+IBKR average cost and the configured all-in entry basis. The submitted limit
+also carries a fee-aware floor above that cost basis, so the bounded reprice
+cannot turn a profitable harvest into an estimated loss.
 
 ThetaGang uses the earliest-expiring useful cohort and sells the fewest whole
 contracts needed. It sells at most one cohort per target in a run. The part of
 the stock buy covered by normal funding stays in the current run. Shares assigned
-to the shortfall are deferred, even if the chosen cohort can fund only some of
-them. Estimated put proceeds are never spent immediately. After the sale fills
-and IBKR reports the cash, a later run makes a new rebalance decision.
+to the shortfall are deferred during preliminary planning. ThetaGang then submits
+the harvest as a bounded first phase, waits once at the original limit, and may
+reprice once toward the midpoint without crossing the profit floor. Every harvest
+must fully fill. Otherwise, ThetaGang cancels incomplete orders and aborts the
+remaining stages without submitting dependent stock or cash-fund orders.
+
+After complete fills, ThetaGang refreshes IBKR account and portfolio state and
+recalculates the regime rebalance in the same run from prior-run smoothing state.
+Only cash in that refreshed broker snapshot can fund the dependent stock orders;
+the preliminary quote is never treated as cash. If the refreshed state supports
+fewer shares, the second plan retains only the ordinarily funded amount. Pending
+sale credits can prevent cash management from queuing a duplicate cash-fund
+liquidation, but they cannot fund a new cash-fund purchase.
 
 If any cohort for the symbol still has unresolved recovery state, a new harvest
-is deferred for that invocation. The later tail stage reconciles the prior sale;
-a subsequent invocation may sell another cohort if a fresh broker snapshot still
-shows both a hard-underweight allocation and a cash shortfall.
+is deferred for that planning pass. The later tail stage reconciles the sale and
+its actual average fill when available. A subsequent invocation may sell another
+cohort if a fresh broker snapshot still shows both a hard-underweight allocation
+and a cash shortfall.
 
 Entry evaluations record premium, estimated fees, catastrophe payouts and
 score, order size, open interest, and the quantity/open-interest ratio. Harvest

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -65,6 +65,20 @@ def test_tail_hedge_strategy_compiles_to_its_post_stage() -> None:
     assert config.runtime.orders.estimated_fee_per_contract == 1.0
 
 
+@pytest.mark.parametrize(
+    "price_update_delay",
+    [[30, 30], [60, 30], [-1, 30]],
+)
+def test_orders_reject_invalid_price_update_delay_ranges(
+    price_update_delay,
+) -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["runtime"]["orders"] = {"price_update_delay": price_update_delay}
+
+    with pytest.raises(ValueError, match="price_update_delay"):
+        Config(**data)
+
+
 def test_tail_hedge_rejects_removed_strike_ratio() -> None:
     data = _base_config({"strategies": ["tail_hedge"]})
     data["strategies"]["tail_hedge"] = {

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -659,6 +659,58 @@ def test_get_last_event_payload_uses_event_insertion_order(tmp_path) -> None:
     assert data_store.get_last_event_payload("ordered_event") == {"sequence": 2}
 
 
+def test_get_last_event_payload_can_exclude_current_run(tmp_path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'state.db'}"
+    config_path = str(tmp_path / "thetagang.toml")
+    previous_store = DataStore(
+        db_url,
+        config_path,
+        dry_run=False,
+        config_text="test",
+    )
+    previous_store.record_event("example_state", {"sequence": 1})
+    current_store = DataStore(
+        db_url,
+        config_path,
+        dry_run=False,
+        config_text="test",
+    )
+    current_store.record_event("example_state", {"sequence": 2})
+
+    assert current_store.get_last_event_payload("example_state") == {"sequence": 2}
+    assert current_store.get_last_event_payload(
+        "example_state",
+        exclude_current_run=True,
+    ) == {"sequence": 1}
+
+
+def test_discard_current_run_events_preserves_prior_and_unrelated_events(
+    tmp_path,
+) -> None:
+    db_url = f"sqlite:///{tmp_path / 'state.db'}"
+    config_path = str(tmp_path / "thetagang.toml")
+    previous_store = DataStore(
+        db_url,
+        config_path,
+        dry_run=False,
+        config_text="test",
+    )
+    previous_store.record_event("example_state", {"sequence": 1})
+    current_store = DataStore(
+        db_url,
+        config_path,
+        dry_run=False,
+        config_text="test",
+    )
+    current_store.record_event("example_state", {"sequence": 2})
+    current_store.record_event("diagnostic", {"kept": True})
+
+    current_store.discard_current_run_events({"example_state"})
+
+    assert current_store.get_last_event_payload("example_state") == {"sequence": 1}
+    assert current_store.get_last_event_payload("diagnostic") == {"kept": True}
+
+
 def test_event_state_can_fail_closed(tmp_path, monkeypatch) -> None:
     data_store = DataStore(
         f"sqlite:///{tmp_path / 'state.db'}",

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from ib_async import (
@@ -37,6 +38,7 @@ def mock_ib(mocker):
     mock.orderStatusEvent.__iadd__ = mocker.Mock(
         return_value=None
     )  # Allow += operation
+    mock.client = mocker.Mock()
     mock.wrapper = mocker.Mock()
     mock.wrapper.accountValues = {}
     mock.wrapper.ticker2ReqId = {"mktData": {}}
@@ -116,6 +118,26 @@ async def test_cached_account_value_prefers_finite_base_value(ibkr, mock_ib):
     assert ibkr.cached_account_value("ACC123", "TotalCashValue") == 1000.0
     mock_ib.accountValues.assert_called_once_with("ACC123")
     mock_ib.accountSummaryAsync.assert_not_called()
+
+
+async def test_refresh_account_restarts_full_snapshot_subscription(ibkr, mock_ib):
+    mock_ib.reqAccountUpdatesAsync = AsyncMock()
+    mock_ib.accountValues.return_value = []
+
+    await ibkr.refresh_account("ACC123")
+
+    mock_ib.client.reqAccountUpdates.assert_called_once_with(False, "ACC123")
+    mock_ib.reqAccountUpdatesAsync.assert_awaited_once_with("ACC123")
+
+
+async def test_refresh_account_rejects_not_ready_snapshot(ibkr, mock_ib):
+    mock_ib.reqAccountUpdatesAsync = AsyncMock()
+    mock_ib.accountValues.return_value = [
+        AccountValue("ACC123", "AccountReady", "false", "", "")
+    ]
+
+    with pytest.raises(RuntimeError, match="not ready"):
+        await ibkr.refresh_account("ACC123")
 
 
 async def test_cached_account_value_prefers_empty_model_base_aggregate(ibkr, mock_ib):

--- a/tests/test_legacy_config.py
+++ b/tests/test_legacy_config.py
@@ -4,6 +4,7 @@ from thetagang.legacy_config import (
     AccountConfig,
     LegacyConfig,
     OptionChainsConfig,
+    OrdersConfig,
     RegimeRebalanceConfig,
     RollWhenConfig,
     SymbolConfig,
@@ -53,6 +54,7 @@ class RegimeRebalanceConfigFactory(ModelFactory[RegimeRebalanceConfig]):
 class LegacyConfigFactory(ModelFactory[LegacyConfig]):
     @classmethod
     def build(cls, factory_use_construct: bool = False, **kwargs):
+        kwargs.setdefault("orders", OrdersConfig())
         kwargs.setdefault(
             "regime_rebalance",
             RegimeRebalanceConfigFactory.build(soft_band=0.10, hard_band=0.50),

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -936,6 +936,41 @@ class TestPortfolioManager:
         assert 0 < reprice.await_args.kwargs["timeout"] <= 5
         portfolio_manager.ibkr.cancel_order.assert_not_called()
 
+    def test_tail_harvest_fill_check_accepts_normalized_filled_status(
+        self, portfolio_manager
+    ):
+        trade = SimpleNamespace(
+            order=SimpleNamespace(totalQuantity=1),
+            orderStatus=SimpleNamespace(
+                status="FILLED",
+                filled=1,
+                remaining=float("nan"),
+            ),
+        )
+
+        assert portfolio_manager._trade_fully_filled(trade) is True
+
+    @pytest.mark.parametrize(
+        ("filled", "requested"),
+        [(float("nan"), 1), (float("inf"), 1), (1, float("inf"))],
+    )
+    def test_tail_harvest_fill_check_rejects_non_finite_quantities(
+        self,
+        portfolio_manager,
+        filled,
+        requested,
+    ):
+        trade = SimpleNamespace(
+            order=SimpleNamespace(totalQuantity=requested),
+            orderStatus=SimpleNamespace(
+                status="Filled",
+                filled=filled,
+                remaining=0,
+            ),
+        )
+
+        assert portfolio_manager._trade_fully_filled(trade) is False
+
     @pytest.mark.asyncio
     async def test_tail_harvest_reprice_preserves_profit_floor(
         self, portfolio_manager, mocker

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -3,11 +3,12 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
-from ib_async import IB, LimitOrder, Option, Stock, Ticker
+from ib_async import IB, AccountValue, LimitOrder, Option, Stock, Ticker
 
 from thetagang.db import DataStore
 from thetagang.portfolio_manager import PortfolioManager
 from thetagang.strategies.tail_hedge_state import (
+    TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
     TailHedgeCohort,
     TailHedgeState,
     TailHedgeStateStore,
@@ -34,6 +35,7 @@ def mock_config(mocker):
     config.runtime.ib_async.api_response_wait_time = 1
     config.runtime.orders = mocker.Mock()
     config.runtime.orders.exchange = "SMART"
+    config.runtime.orders.estimated_fee_per_contract = 0.0
     config.strategies.cash_management = mocker.Mock()
     config.strategies.cash_management.cash_fund = "MMDA1"
     return config
@@ -881,6 +883,269 @@ class TestPortfolioManager:
         await pm.manage()
 
     @pytest.mark.asyncio
+    async def test_tail_harvest_phase_reprices_then_fills(
+        self, portfolio_manager, mocker
+    ):
+        portfolio_manager.config.runtime.orders.price_update_delay = [1, 2]
+        contract = Option("SPY", "20271217", 300, "P", "SMART", conId=123)
+        order = tail_order(
+            portfolio_manager,
+            "SELL",
+            1,
+            "tg:tail-harvest:SPY:123",
+        )
+        status = SimpleNamespace(status="Submitted", filled=0.5, remaining=0.5)
+        trade = SimpleNamespace(
+            contract=contract,
+            order=order,
+            orderStatus=status,
+            isDone=lambda: status.status == "Filled",
+        )
+        trades = []
+        portfolio_manager.trades = mocker.Mock()
+        portfolio_manager.trades.records.side_effect = lambda: trades
+        portfolio_manager.submit_orders = mocker.Mock(
+            side_effect=lambda _records: trades.append(trade)
+        )
+        portfolio_manager.ibkr.wait_for_submitting_orders = mocker.AsyncMock()
+        portfolio_manager.ibkr.wait_for_orders_complete = mocker.AsyncMock(
+            return_value=[trade]
+        )
+        portfolio_manager.ibkr.cancel_order = mocker.Mock()
+
+        async def fill_on_reprice(_idx, _trade, **_kwargs):
+            status.status = "Filled"
+            status.filled = 1.0
+            status.remaining = 0.0
+            return True
+
+        reprice = mocker.patch.object(
+            portfolio_manager,
+            "_reprice_trade",
+            side_effect=fill_on_reprice,
+        )
+
+        filled = await portfolio_manager._execute_tail_harvest_phase(
+            [(contract, order, None)],
+            timeout=5,
+        )
+
+        assert filled is True
+        reprice.assert_awaited_once()
+        assert reprice.await_args.args == (0, trade)
+        assert 0 < reprice.await_args.kwargs["timeout"] <= 5
+        portfolio_manager.ibkr.cancel_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tail_harvest_reprice_preserves_profit_floor(
+        self, portfolio_manager, mocker
+    ):
+        contract = Option("SPY", "20271217", 300, "P", "SMART", conId=123)
+        order = tail_order(
+            portfolio_manager,
+            "SELL",
+            1,
+            "tg:tail-harvest:SPY:123",
+        )
+        order.lmtPrice = 2.0
+        setattr(order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR, 1.5)
+        trade = SimpleNamespace(contract=contract, order=order)
+        ticker = mocker.Mock(spec=Ticker)
+        ticker.midpoint.return_value = 0.5
+        portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock(
+            return_value=ticker
+        )
+        portfolio_manager.trades = mocker.Mock()
+
+        repriced = await portfolio_manager._reprice_trade(0, trade)
+
+        assert repriced is True
+        portfolio_manager.trades.submit_order.assert_called_once()
+        submitted_order = portfolio_manager.trades.submit_order.call_args.args[1]
+        assert submitted_order.lmtPrice == pytest.approx(1.5)
+
+    @pytest.mark.asyncio
+    async def test_tail_harvest_phase_cancels_and_fails_closed(
+        self, portfolio_manager, mocker
+    ):
+        portfolio_manager.config.runtime.orders.price_update_delay = [1, 2]
+        contract = Option("SPY", "20271217", 300, "P", "SMART", conId=123)
+        order = tail_order(
+            portfolio_manager,
+            "SELL",
+            1,
+            "tg:tail-harvest:SPY:123",
+        )
+        status = SimpleNamespace(status="Submitted", filled=0.5, remaining=0.5)
+        trade = SimpleNamespace(
+            contract=contract,
+            order=order,
+            orderStatus=status,
+            isDone=lambda: False,
+        )
+        trades = []
+        portfolio_manager.trades = mocker.Mock()
+        portfolio_manager.trades.records.side_effect = lambda: trades
+        portfolio_manager.submit_orders = mocker.Mock(
+            side_effect=lambda _records: trades.append(trade)
+        )
+        portfolio_manager.ibkr.wait_for_submitting_orders = mocker.AsyncMock()
+        portfolio_manager.ibkr.wait_for_orders_complete = mocker.AsyncMock(
+            side_effect=[[trade], [trade], []]
+        )
+        portfolio_manager.ibkr.cancel_order = mocker.Mock()
+        mocker.patch.object(
+            portfolio_manager,
+            "_reprice_trade",
+            new=mocker.AsyncMock(return_value=True),
+        )
+
+        filled = await portfolio_manager._execute_tail_harvest_phase(
+            [(contract, order, None)],
+            timeout=1,
+        )
+
+        assert filled is False
+        portfolio_manager.ibkr.cancel_order.assert_called_once_with(order)
+        assert portfolio_manager.ibkr.wait_for_orders_complete.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_regime_stage_recalculates_after_filled_tail_harvest(
+        self, portfolio_manager, mocker
+    ):
+        portfolio_manager.config.strategies.regime_rebalance.enabled = True
+        portfolio_manager.data_store = mocker.Mock()
+        contract = Option("SPY", "20271217", 300, "P", "SMART", conId=123)
+        harvest_order = tail_order(
+            portfolio_manager,
+            "SELL",
+            1,
+            "tg:tail-harvest:SPY:123",
+        )
+        initial_summary = {"TotalCashValue": SimpleNamespace(value="0")}
+        refreshed_summary = {
+            "NetLiquidation": AccountValue(
+                "TEST123", "NetLiquidation", "10000.0", "BASE", ""
+            ),
+            "TotalCashValue": AccountValue(
+                "TEST123", "TotalCashValue", "2000.0", "BASE", ""
+            ),
+        }
+        refreshed_positions = {"SPY": []}
+        checks = 0
+
+        async def check_regime(_summary, _positions, **_kwargs):
+            nonlocal checks
+            checks += 1
+            if checks == 1:
+                portfolio_manager.orders.add_order(contract, harvest_order, None)
+                return mocker.Mock(), [("SPY", "NYSE", 1)]
+            return mocker.Mock(), [("SPY", "NYSE", 2)]
+
+        portfolio_manager.equity_engine.check_regime_rebalance_positions = (
+            mocker.AsyncMock(side_effect=check_regime)
+        )
+        execute = mocker.patch.object(
+            portfolio_manager.equity_engine,
+            "execute_regime_rebalance_orders",
+            new=mocker.AsyncMock(),
+        )
+        execute_harvest = mocker.patch.object(
+            portfolio_manager,
+            "_execute_tail_harvest_phase",
+            new=mocker.AsyncMock(return_value=True),
+        )
+        portfolio_manager.ibkr.refresh_account = mocker.AsyncMock()
+        portfolio_manager.ibkr.account_summary = mocker.AsyncMock(return_value=[])
+        portfolio_manager.ibkr.cached_account_value = mocker.Mock(
+            side_effect=lambda _account, tag: {
+                "NetLiquidation": 10000.0,
+                "TotalCashValue": 2000.0,
+            }[tag]
+        )
+        portfolio_manager.get_portfolio_positions = mocker.Mock(
+            return_value=refreshed_positions
+        )
+
+        result = await portfolio_manager._run_regime_rebalance_stage(
+            initial_summary,
+            {"SPY": []},
+        )
+
+        assert result == (refreshed_summary, refreshed_positions)
+        execute_harvest.assert_awaited_once_with([(contract, harvest_order, None)])
+        portfolio_manager.data_store.discard_current_run_events.assert_called_once_with(
+            {"regime_rebalance_state", "volatility_weight_state"}
+        )
+        portfolio_manager.ibkr.refresh_account.assert_awaited_once_with("TEST123")
+        assert (
+            portfolio_manager.equity_engine.check_regime_rebalance_positions.call_args_list[
+                1
+            ].kwargs["exclude_current_run_state"]
+            is True
+        )
+        execute.assert_awaited_once_with([("SPY", "NYSE", 2)])
+        assert portfolio_manager.orders.records() == []
+
+    @pytest.mark.asyncio
+    async def test_regime_stage_aborts_when_tail_harvest_does_not_fill(
+        self, portfolio_manager, mocker
+    ):
+        portfolio_manager.config.strategies.regime_rebalance.enabled = True
+        contract = Option("SPY", "20271217", 300, "P", "SMART", conId=123)
+        harvest_order = tail_order(
+            portfolio_manager,
+            "SELL",
+            1,
+            "tg:tail-harvest:SPY:123",
+        )
+
+        async def check_regime(_summary, _positions, **_kwargs):
+            portfolio_manager.orders.add_order(contract, harvest_order, None)
+            return mocker.Mock(), [("SPY", "NYSE", 1)]
+
+        portfolio_manager.equity_engine.check_regime_rebalance_positions = (
+            mocker.AsyncMock(side_effect=check_regime)
+        )
+        execute = mocker.patch.object(
+            portfolio_manager.equity_engine,
+            "execute_regime_rebalance_orders",
+            new=mocker.AsyncMock(),
+        )
+        mocker.patch.object(
+            portfolio_manager,
+            "_execute_tail_harvest_phase",
+            new=mocker.AsyncMock(return_value=False),
+        )
+
+        with pytest.raises(RuntimeError, match="did not fully fill"):
+            await portfolio_manager._run_regime_rebalance_stage(
+                {"TotalCashValue": SimpleNamespace(value="0")},
+                {"SPY": []},
+            )
+
+        execute.assert_not_awaited()
+        assert portfolio_manager.orders.records() == []
+
+    @pytest.mark.asyncio
+    async def test_manage_does_not_submit_other_orders_after_harvest_abort(
+        self, portfolio_manager, mocker
+    ):
+        portfolio_manager.run_stage_order = ["equity_regime_rebalance"]
+        portfolio_manager.initialize_account = mocker.Mock()
+        portfolio_manager.summarize_account = mocker.AsyncMock(return_value=({}, {}))
+        portfolio_manager.options_trading_enabled = mocker.Mock(return_value=False)
+        portfolio_manager._run_regime_rebalance_stage = mocker.AsyncMock(
+            side_effect=RuntimeError("Tail-harvest execution did not fully fill")
+        )
+        portfolio_manager.submit_orders = mocker.Mock()
+
+        with pytest.raises(RuntimeError, match="did not fully fill"):
+            await portfolio_manager.manage()
+
+        portfolio_manager.submit_orders.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_adjust_prices_continues_if_midpoint_market_data_missing(
         self, portfolio_manager, mocker
     ):
@@ -1471,8 +1736,8 @@ class TestPortfolioManager:
 
         # Expected:
         # Stock BUY: -150 * 100 * 1 = -15,000
-        # Unfilled SELL proceeds are unavailable until IBKR reports the cash.
-        assert pending_balance == -15000.0
+        # Option SELL: 2.50 * 5 * 100 = 1,250
+        assert pending_balance == -13750.0
 
     @pytest.mark.asyncio
     async def test_buy_only_minimum_shares_threshold(self, portfolio_manager, mocker):

--- a/tests/test_post_strategy_engine.py
+++ b/tests/test_post_strategy_engine.py
@@ -97,7 +97,7 @@ async def test_do_cashman_disabled_noops(mocker):
     order_ops.enqueue_order.assert_not_called()
 
 
-def test_pending_cash_ignores_all_unfilled_sale_proceeds(mocker):
+def test_pending_cash_includes_all_queued_order_cash_flows(mocker):
     engine, _ibkr, _order_ops, _scanner = _make_engine(mocker)
     stock = Stock("AAA", "SMART", "USD")
     tail_put = Option("AAA", "20270115", 100.0, "P", "SMART")
@@ -145,10 +145,181 @@ def test_pending_cash_ignores_all_unfilled_sale_proceeds(mocker):
         ),
     ]
 
-    assert engine.calc_pending_cash_balance() == -100.0
+    assert engine.calc_pending_cash_balance() == 450.0
 
 
-def test_pending_cash_uses_valid_remaining_quantity(
+def test_pending_cash_uses_signed_combo_order_value(mocker):
+    engine, _ibkr, _order_ops, _scanner = _make_engine(mocker)
+    combo = Contract(secType="BAG", symbol="AAA", multiplier="100")
+    engine.orders.records.return_value = [
+        (
+            combo,
+            SimpleNamespace(action="BUY", lmtPrice=-1.0, totalQuantity=1),
+            None,
+        ),
+        (
+            combo,
+            SimpleNamespace(action="SELL", lmtPrice=-0.5, totalQuantity=1),
+            None,
+        ),
+    ]
+
+    assert engine.pending_cash_components() == (50.0, 100.0)
+    assert engine.calc_pending_cash_balance() == 50.0
+
+
+def test_pending_option_cash_includes_estimated_per_contract_fees(mocker):
+    engine, _ibkr, _order_ops, _scanner = _make_engine(mocker)
+    engine.config.runtime.orders.estimated_fee_per_contract = 1.0
+    option = Option("AAA", "20270115", 100.0, "P", "SMART")
+    option.multiplier = "100"
+    engine.orders.records.return_value = [
+        (
+            option,
+            SimpleNamespace(action="BUY", lmtPrice=1.0, totalQuantity=2),
+            None,
+        ),
+        (
+            option,
+            SimpleNamespace(action="SELL", lmtPrice=2.0, totalQuantity=1),
+            None,
+        ),
+    ]
+
+    assert engine.pending_cash_components() == (202.0, 199.0)
+
+
+@pytest.mark.asyncio
+async def test_do_cashman_accounts_for_same_run_regime_sale_proceeds(mocker):
+    engine, ibkr, order_ops, _scanner = _make_engine(mocker)
+    engine.config.strategies.cash_management.enabled = True
+    engine.config.runtime.orders.estimated_fee_per_contract = 1.0
+    engine.config.strategies.cash_management.target_cash_balance = 5000.0
+    engine.config.strategies.cash_management.buy_threshold = 5000.0
+    engine.config.strategies.cash_management.sell_threshold = 5000.0
+    engine.config.strategies.cash_management.cash_fund = "SHV"
+    regime_sales = [
+        ("TQQQ", 72.10, 53),
+        ("IBIT", 36.61, 135),
+        ("BTAL", 12.11, 359),
+        ("CTA", 27.98, 123),
+    ]
+    engine.orders.records.return_value = [
+        (
+            Stock(symbol, "SMART", "USD"),
+            SimpleNamespace(
+                action="SELL",
+                lmtPrice=price,
+                totalQuantity=quantity,
+                orderRef=f"tg:regime-rebalance:{symbol}",
+            ),
+            None,
+        )
+        for symbol, price, quantity in regime_sales
+    ]
+
+    await engine.do_cashman(
+        {"TotalCashValue": SimpleNamespace(value="-11649")},
+        {
+            "SHV": [
+                SimpleNamespace(
+                    contract=Stock("SHV", "SMART", "USD"),
+                    position=138,
+                )
+            ]
+        },
+    )
+
+    assert engine.calc_pending_cash_balance() == pytest.approx(16552.68)
+    ibkr.get_ticker_for_stock.assert_not_called()
+    order_ops.create_limit_order.assert_not_called()
+    order_ops.enqueue_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_do_cashman_does_not_buy_cash_fund_from_queued_stock_sales(mocker):
+    engine, ibkr, order_ops, _scanner = _make_engine(mocker)
+    engine.config.strategies.cash_management.enabled = True
+    stock = Stock("AAA", "SMART", "USD")
+    engine.orders.records.return_value = [
+        (
+            stock,
+            SimpleNamespace(
+                action="SELL",
+                lmtPrice=100.0,
+                totalQuantity=20,
+                orderRef="tg:regime-rebalance:AAA",
+            ),
+            None,
+        )
+    ]
+
+    await engine.do_cashman(
+        {"TotalCashValue": SimpleNamespace(value="0")},
+        {},
+    )
+
+    assert engine.calc_pending_cash_balance() == 2000.0
+    ibkr.get_ticker_for_stock.assert_not_called()
+    order_ops.create_limit_order.assert_not_called()
+    order_ops.enqueue_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_do_cashman_sells_only_remaining_deficit_after_queued_stock_sales(
+    mocker,
+):
+    engine, ibkr, order_ops, _scanner = _make_engine(mocker)
+    engine.config.strategies.cash_management.enabled = True
+    engine.config.strategies.cash_management.target_cash_balance = 5000.0
+    engine.config.strategies.cash_management.buy_threshold = 5000.0
+    engine.config.strategies.cash_management.sell_threshold = 5000.0
+    engine.config.strategies.cash_management.cash_fund = "SHV"
+    engine.orders.records.return_value = [
+        (
+            Stock("AAA", "SMART", "USD"),
+            SimpleNamespace(
+                action="SELL",
+                lmtPrice=100.0,
+                totalQuantity=100,
+                orderRef="tg:regime-rebalance:AAA",
+            ),
+            None,
+        )
+    ]
+    ticker = SimpleNamespace(
+        contract=Stock("SHV", "SMART", "USD"),
+        ask=100.0,
+        bid=100.0,
+    )
+    ibkr.get_ticker_for_stock = AsyncMock(return_value=ticker)
+    ibkr.cached_account_value.return_value = -20000.0
+    ibkr.portfolio.return_value = [
+        SimpleNamespace(
+            contract=Stock("SHV", "SMART", "USD"),
+            position=200,
+        )
+    ]
+
+    await engine.do_cashman(
+        {"TotalCashValue": SimpleNamespace(value="-20000")},
+        {
+            "SHV": [
+                SimpleNamespace(
+                    contract=Stock("SHV", "SMART", "USD"),
+                    position=200,
+                )
+            ]
+        },
+    )
+
+    order_ops.create_limit_order.assert_called_once()
+    assert order_ops.create_limit_order.call_args.kwargs["action"] == "SELL"
+    assert order_ops.create_limit_order.call_args.kwargs["quantity"] == 150
+    order_ops.enqueue_order.assert_called_once_with(ticker.contract, "ORDER")
+
+
+def test_pending_cash_uses_valid_remaining_quantity_for_buys_and_sells(
     mocker,
 ):
     engine, ibkr, _order_ops, _scanner = _make_engine(mocker)
@@ -175,7 +346,28 @@ def test_pending_cash_uses_valid_remaining_quantity(
         trade(done=True),
     ]
 
-    assert engine.calc_pending_cash_balance() == -200.0
+    assert engine.calc_pending_cash_balance() == 0.0
+
+
+def test_pending_cash_uses_working_stock_sell_remaining_quantity(mocker):
+    engine, ibkr, _order_ops, _scanner = _make_engine(mocker)
+    stock = Stock("AAA", "SMART", "USD")
+    ibkr.open_trades.return_value = [
+        SimpleNamespace(
+            contract=stock,
+            order=SimpleNamespace(
+                account="TEST123",
+                action="SELL",
+                orderType="LMT",
+                lmtPrice=100.0,
+                totalQuantity=3,
+            ),
+            orderStatus=SimpleNamespace(remaining=1),
+            isDone=lambda: False,
+        )
+    ]
+
+    assert engine.pending_cash_components() == (0.0, 100.0)
 
 
 @pytest.mark.parametrize("remaining", [float("nan"), 0.0])
@@ -202,13 +394,14 @@ def test_pending_cash_rejects_ambiguous_remaining_quantity(mocker, remaining):
 
 
 @pytest.mark.asyncio
-async def test_market_buy_blocks_cash_management(mocker):
+@pytest.mark.parametrize("action", ["BUY", "SELL"])
+async def test_market_order_blocks_cash_management(mocker, action):
     engine, ibkr, order_ops, _scanner = _make_engine(mocker)
     engine.config.strategies.cash_management.enabled = True
     ibkr.open_trades.return_value = [
         SimpleNamespace(
             contract=Stock("AAA", "SMART", "USD"),
-            order=MarketOrder("BUY", 1, account="TEST123"),
+            order=MarketOrder(action, 1, account="TEST123"),
             orderStatus=SimpleNamespace(remaining=1),
             isDone=lambda: False,
         )
@@ -235,6 +428,33 @@ def test_order_cash_notional_rejects_overflow():
 
     with pytest.raises(ValueError, match="finite"):
         order_cash_notional(option, order)
+
+
+@pytest.mark.parametrize(
+    ("price", "quantity"),
+    [(0.0, 1), (1.0, 0)],
+)
+def test_pending_cash_rejects_unpriceable_queued_limit_order(
+    mocker,
+    price,
+    quantity,
+):
+    engine, _ibkr, _order_ops, _scanner = _make_engine(mocker)
+    engine.orders.records.return_value = [
+        (
+            Stock("AAA", "SMART", "USD"),
+            SimpleNamespace(
+                action="BUY",
+                orderType="LMT",
+                lmtPrice=price,
+                totalQuantity=quantity,
+            ),
+            None,
+        )
+    ]
+
+    with pytest.raises(RuntimeError, match="cannot be priced safely"):
+        engine.pending_cash_components()
 
 
 @pytest.mark.asyncio

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -26,6 +26,7 @@ from thetagang.strategies.regime_engine import (
 from thetagang.strategies.tail_hedge_state import (
     TAIL_HEDGE_CLOSE_ORDER_REF,
     TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX,
+    TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
     TailHedgeCohort,
     TailHedgeState,
 )
@@ -905,6 +906,17 @@ async def test_regime_rebalance_volatility_weight_smooths_from_previous_state(
         "volatility_weight_state"
     )
     assert payload["symbols"]["AAA"]["target_weight"] == pytest.approx(0.25)
+    assert payload["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.375)
+
+    await portfolio_manager_with_db.regime_engine.check_regime_rebalance_positions(
+        account_summary,
+        portfolio_positions,
+        exclude_current_run_state=True,
+    )
+
+    payload = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "volatility_weight_state"
+    )
     assert payload["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.375)
 
 
@@ -3456,11 +3468,13 @@ async def test_harvest_persists_recovery_intent(
     )
 
     assert orders == []
+    queued_order = portfolio_manager.orders.records()[0][1]
+    assert getattr(queued_order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR) == pytest.approx(0.51)
     store = portfolio_manager.regime_engine._tail_state_store
     assert store is not None
     state = store.load()
     assert state.open_cohorts[0].pending_recovery_quantity == 1
-    assert state.open_cohorts[0].pending_recovery_per_contract == 120.0
+    assert state.open_cohorts[0].pending_recovery_per_contract == 51.0
     assert isinstance(state.open_cohorts[0].pending_recovery_enqueued_at, datetime)
     assert state.open_cohorts[0].pending_recovery_initial_quantity == 1
     telemetry = portfolio_manager.data_store.get_last_event_payload(

--- a/tests/test_tail_hedge_engine.py
+++ b/tests/test_tail_hedge_engine.py
@@ -23,6 +23,7 @@ from thetagang.strategies.tail_hedge_engine import (
     TailHedgeEngine,
 )
 from thetagang.strategies.tail_hedge_state import (
+    TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX,
     TailHedgeCohort,
     TailHedgeState,
     TailHedgeStateStore,
@@ -166,6 +167,7 @@ def _working_trade(
     remaining: float = 1,
     order_id: int = 17,
     observed_at: datetime | None = NOW,
+    avg_fill_price: float = 0.0,
 ):
     if action is None:
         action = "BUY" if order_ref == TAIL_HEDGE_ENTRY_ORDER_REF else "SELL"
@@ -182,6 +184,7 @@ def _working_trade(
             status=status,
             filled=filled,
             remaining=remaining,
+            avgFillPrice=avg_fill_price,
         ),
         log=([] if observed_at is None else [SimpleNamespace(time=observed_at)]),
         fills=[],
@@ -1103,6 +1106,88 @@ async def test_completed_exit_fill_waits_for_portfolio_cache(mocker):
     closed_state = _saved_states(data_store)[-1]
     assert closed_state.open_cohorts == []
     assert closed_state.cohorts[0].recovered_cost == 200.0
+
+
+@pytest.mark.asyncio
+async def test_completed_harvest_credits_actual_net_fill_proceeds(mocker):
+    engine, ibkr, order_ops, data_store = _make_engine(mocker)
+    engine.config.runtime.orders = SimpleNamespace(estimated_fee_per_contract=1.0)
+    contract = _put_contract(dte=180)
+    pending = _entry(
+        contract,
+        days_ago=1,
+        cost=300.0,
+        quantity=2,
+        pending_recovery_quantity=2,
+        pending_recovery_per_contract=51.0,
+        pending_recovery_enqueued_at=NOW,
+        pending_recovery_initial_quantity=2,
+    )
+    data_store.load_tail_hedge_entries.return_value = _state_rows(_state(pending))
+    ibkr.trades.return_value = [
+        _working_trade(
+            contract,
+            build_tail_reduction_order_ref(
+                f"{TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX}:QQQ",
+                contract.conId,
+                NOW,
+            ),
+            status="Filled",
+            filled=2,
+            remaining=0,
+            avg_fill_price=1.2,
+        )
+    ]
+
+    await _manage(engine, {"QQQ": [_stock_position()]})
+
+    order_ops.enqueue_order.assert_not_called()
+    closed = _saved_states(data_store)[-1].cohorts[0]
+    assert closed.status == "closed"
+    assert closed.recovered_cost == 238.0
+
+
+@pytest.mark.asyncio
+async def test_partial_harvest_keeps_conservative_recovery_value(mocker):
+    engine, ibkr, order_ops, data_store = _make_engine(mocker)
+    engine.config.runtime.orders = SimpleNamespace(estimated_fee_per_contract=1.0)
+    contract = _put_contract(dte=180)
+    pending = _entry(
+        contract,
+        days_ago=1,
+        cost=300.0,
+        quantity=2,
+        pending_recovery_quantity=2,
+        pending_recovery_per_contract=51.0,
+        pending_recovery_enqueued_at=NOW,
+        pending_recovery_initial_quantity=2,
+    )
+    data_store.load_tail_hedge_entries.return_value = _state_rows(_state(pending))
+    trade = _working_trade(
+        contract,
+        build_tail_reduction_order_ref(
+            f"{TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX}:QQQ",
+            contract.conId,
+            NOW,
+        ),
+        status="Submitted",
+        filled=1,
+        remaining=1,
+        avg_fill_price=2.0,
+    )
+    ibkr.open_trades.return_value = [trade]
+    ibkr.trades.return_value = [trade]
+
+    await _manage(
+        engine,
+        {"QQQ": [_stock_position(), _put_position(contract, quantity=1)]},
+    )
+
+    order_ops.enqueue_order.assert_not_called()
+    reconciled = _saved_states(data_store)[-1].open_cohorts[0]
+    assert reconciled.quantity == 1
+    assert reconciled.recovered_cost == 51.0
+    assert reconciled.pending_recovery_quantity == 1
 
 
 @pytest.mark.asyncio

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -95,6 +95,15 @@ class OrdersConfig(BaseModel, DisplayMixin):
         default_factory=lambda: [30, 60], min_length=2, max_length=2
     )
 
+    @model_validator(mode="after")
+    def validate_price_update_delay(self) -> Self:
+        start, stop = self.price_update_delay
+        if start < 0 or stop <= start:
+            raise ValueError(
+                "orders.price_update_delay must be a non-negative increasing range"
+            )
+        return self
+
     def add_to_table(self, table: Table, section: str = "") -> None:
         table.add_section()
         table.add_row("[spring_green1]Order settings")

--- a/thetagang/db.py
+++ b/thetagang/db.py
@@ -411,11 +411,16 @@ class DataStore:
         *,
         symbol: Optional[str] = None,
         config_scoped: bool = True,
+        exclude_current_run: bool = False,
         raise_on_error: bool = False,
     ) -> Optional[Dict[str, Any]]:
         try:
             overlay_key = (event_type, symbol)
-            if self.dry_run and overlay_key in self._dry_run_event_overlay:
+            if (
+                self.dry_run
+                and not exclude_current_run
+                and overlay_key in self._dry_run_event_overlay
+            ):
                 payload = self._dry_run_event_overlay[overlay_key]
                 if not payload:
                     return None
@@ -435,6 +440,8 @@ class DataStore:
                     query = query.filter(Event.symbol == symbol)
                 if config_scoped:
                     query = query.filter(Run.config_path.in_(self._config_path_aliases))
+                if exclude_current_run:
+                    query = query.filter(Event.run_id != self.run_id)
                 event = query.order_by(Event.id.desc()).first()
                 payload = event.payload if event else None
             if not payload:
@@ -448,6 +455,25 @@ class DataStore:
             if raise_on_error:
                 raise RuntimeError(f"Failed to read event {event_type}") from exc
             return None
+
+    def discard_current_run_events(self, event_types: Iterable[str]) -> None:
+        """Discard uncommitted state events from only the active run."""
+        selected = {event_type for event_type in event_types if event_type}
+        if not selected:
+            return
+        try:
+            with self.session_scope() as session:
+                (
+                    session.query(Event)
+                    .filter(Event.run_id == self.run_id)
+                    .filter(Event.event_type.in_(selected))
+                    .delete(synchronize_session=False)
+                )
+            for key in list(self._dry_run_event_overlay):
+                if key[0] in selected:
+                    self._dry_run_event_overlay.pop(key, None)
+        except Exception as exc:
+            raise RuntimeError("Failed to discard uncommitted run state") from exc
 
     @staticmethod
     def _tail_hedge_entry_dict(entry: TailHedgeEntry) -> Dict[str, Any]:

--- a/thetagang/db.py
+++ b/thetagang/db.py
@@ -457,7 +457,7 @@ class DataStore:
             return None
 
     def discard_current_run_events(self, event_types: Iterable[str]) -> None:
-        """Discard uncommitted state events from only the active run."""
+        """Discard committed state events and overlays for the active run."""
         selected = {event_type for event_type in event_types if event_type}
         if not selected:
             return
@@ -473,7 +473,7 @@ class DataStore:
                 if key[0] in selected:
                     self._dry_run_event_overlay.pop(key, None)
         except Exception as exc:
-            raise RuntimeError("Failed to discard uncommitted run state") from exc
+            raise RuntimeError("Failed to discard active-run state") from exc
 
     @staticmethod
     def _tail_hedge_entry_dict(entry: TailHedgeEntry) -> Dict[str, Any]:

--- a/thetagang/ibkr.py
+++ b/thetagang/ibkr.py
@@ -119,6 +119,16 @@ class IBKR:
     async def account_summary(self, account: str) -> List[AccountValue]:
         return await self.ib.accountSummaryAsync(account)
 
+    async def refresh_account(self, account: str) -> None:
+        """Restart account updates and wait for a fresh full snapshot."""
+        self.ib.client.reqAccountUpdates(False, account)
+        await self.ib.reqAccountUpdatesAsync(account)
+        for value in self.ib.accountValues(account):
+            if str(getattr(value, "tag", "")).lower() == "accountready" and str(
+                getattr(value, "value", "")
+            ).lower() in {"false", "0"}:
+                raise RuntimeError("IBKR account snapshot is not ready")
+
     async def request_historical_data(
         self,
         contract: Contract,

--- a/thetagang/orders.py
+++ b/thetagang/orders.py
@@ -33,8 +33,9 @@ def order_cash_notional(
     quantity = float(getattr(order, "totalQuantity", 0) or 0)
     if (
         not math.isfinite(price)
+        or math.isclose(price, 0.0, abs_tol=1e-12)
         or not math.isfinite(quantity)
-        or quantity < 0
+        or quantity <= 0
         or not math.isfinite(multiplier)
         or multiplier <= 0
     ):
@@ -52,25 +53,34 @@ class PendingBuyCash(NamedTuple):
     ambiguous: bool
 
 
-def working_buy_cash(
+class PendingOrderCash(NamedTuple):
+    debit: float
+    credit: float
+    ambiguous: bool
+
+
+def working_order_cash(
     trades: Iterable[Any],
     *,
     account: str,
     qualified_contracts: Mapping[int, Contract] | None = None,
-) -> PendingBuyCash:
-    """Return unfilled active-account BUY debit and snapshot ambiguity."""
+    estimated_fee_per_contract: float = 0.0,
+) -> PendingOrderCash:
+    """Return remaining debits and credits for active-account working orders."""
     debit = 0.0
+    credit = 0.0
     ambiguous = False
     for trade in trades:
         order = getattr(trade, "order", None)
         contract = getattr(trade, "contract", None)
         is_done = getattr(trade, "isDone", None)
+        action = str(getattr(order, "action", "")).upper()
         if (
             order is None
             or contract is None
             or (callable(is_done) and is_done())
             or getattr(order, "account", None) != account
-            or str(getattr(order, "action", "")).upper() != "BUY"
+            or action not in {"BUY", "SELL"}
         ):
             continue
         try:
@@ -91,44 +101,133 @@ def working_buy_cash(
             ambiguous = True
             remaining = total_quantity
         try:
-            amount = max(
-                0.0,
-                order_cash_notional(contract, order, qualified_contracts)
-                * (remaining / total_quantity),
+            notional = order_cash_notional(contract, order, qualified_contracts)
+            fee = (
+                0.0
+                if contract.secType == "STK"
+                else float(estimated_fee_per_contract) * remaining
             )
+            if not math.isfinite(fee) or fee < 0:
+                raise ValueError("Estimated order fee must be finite and non-negative")
+            cash_change = (notional if action == "SELL" else -notional) * (
+                remaining / total_quantity
+            ) - fee
         except (TypeError, ValueError, OverflowError):
             ambiguous = True
             continue
-        if not math.isfinite(debit + amount):
+        if not math.isfinite(cash_change):
             ambiguous = True
             continue
-        debit += amount
-    return PendingBuyCash(debit, ambiguous)
+        debit += max(0.0, -cash_change)
+        credit += max(0.0, cash_change)
+    return PendingOrderCash(debit, credit, ambiguous)
+
+
+def queued_order_cash(
+    records: Iterable[tuple[Contract, Any, Any]],
+    qualified_contracts: Mapping[int, Contract] | None = None,
+    estimated_fee_per_contract: float = 0.0,
+) -> PendingOrderCash:
+    """Return debits and credits for locally queued orders."""
+    debit = 0.0
+    credit = 0.0
+    ambiguous = False
+    for contract, order, _intent_id in records:
+        action = str(getattr(order, "action", "")).upper()
+        if action not in {"BUY", "SELL"}:
+            continue
+        try:
+            notional = order_cash_notional(contract, order, qualified_contracts)
+            quantity = float(getattr(order, "totalQuantity", 0) or 0)
+            fee = (
+                0.0
+                if contract.secType == "STK"
+                else float(estimated_fee_per_contract) * quantity
+            )
+            if not math.isfinite(fee) or fee < 0:
+                raise ValueError("Estimated order fee must be finite and non-negative")
+            cash_change = (notional if action == "SELL" else -notional) - fee
+        except (TypeError, ValueError, OverflowError):
+            ambiguous = True
+            continue
+        if not math.isfinite(cash_change):
+            ambiguous = True
+            continue
+        debit += max(0.0, -cash_change)
+        credit += max(0.0, cash_change)
+    return PendingOrderCash(debit, credit, ambiguous)
+
+
+def pending_order_cash(
+    trades: Iterable[Any],
+    records: Iterable[tuple[Contract, Any, Any]],
+    *,
+    account: str,
+    qualified_contracts: Mapping[int, Contract] | None = None,
+    estimated_fee_per_contract: float = 0.0,
+) -> PendingOrderCash:
+    """Combine broker-working and locally queued order cash flows."""
+    working = working_order_cash(
+        trades,
+        account=account,
+        qualified_contracts=qualified_contracts,
+        estimated_fee_per_contract=estimated_fee_per_contract,
+    )
+    queued = queued_order_cash(
+        records,
+        qualified_contracts,
+        estimated_fee_per_contract,
+    )
+    debit = working.debit + queued.debit
+    credit = working.credit + queued.credit
+    return PendingOrderCash(
+        debit if math.isfinite(debit) else 0.0,
+        credit if math.isfinite(credit) else 0.0,
+        working.ambiguous
+        or queued.ambiguous
+        or not math.isfinite(debit)
+        or not math.isfinite(credit),
+    )
+
+
+def working_buy_cash(
+    trades: Iterable[Any],
+    *,
+    account: str,
+    qualified_contracts: Mapping[int, Contract] | None = None,
+    estimated_fee_per_contract: float = 0.0,
+) -> PendingBuyCash:
+    """Return unfilled active-account BUY debit and snapshot ambiguity."""
+    pending = working_order_cash(
+        (
+            trade
+            for trade in trades
+            if str(getattr(getattr(trade, "order", None), "action", "")).upper()
+            == "BUY"
+        ),
+        account=account,
+        qualified_contracts=qualified_contracts,
+        estimated_fee_per_contract=estimated_fee_per_contract,
+    )
+    return PendingBuyCash(pending.debit, pending.ambiguous)
 
 
 def queued_buy_cash(
     records: Iterable[tuple[Contract, Any, Any]],
     qualified_contracts: Mapping[int, Contract] | None = None,
+    estimated_fee_per_contract: float = 0.0,
 ) -> PendingBuyCash:
     """Return queued BUY debit, marking orders without a usable limit ambiguous."""
-    debit = 0.0
-    ambiguous = False
-    for contract, order, _intent_id in records:
-        if str(getattr(order, "action", "")).upper() != "BUY":
-            continue
-        try:
-            amount = max(
-                0.0,
-                order_cash_notional(contract, order, qualified_contracts),
-            )
-        except (TypeError, ValueError, OverflowError):
-            ambiguous = True
-            continue
-        if not math.isfinite(debit + amount):
-            ambiguous = True
-            continue
-        debit += amount
-    return PendingBuyCash(debit, ambiguous)
+    pending = queued_order_cash(
+        (
+            record
+            for record in records
+            if str(getattr(record[1], "action", "")).upper() == "BUY"
+        ),
+        qualified_contracts,
+        estimated_fee_per_contract,
+    )
+    return PendingBuyCash(pending.debit, pending.ambiguous)
 
 
 def pending_buy_cash(
@@ -137,14 +236,20 @@ def pending_buy_cash(
     *,
     account: str,
     qualified_contracts: Mapping[int, Contract] | None = None,
+    estimated_fee_per_contract: float = 0.0,
 ) -> PendingBuyCash:
     """Combine broker-working and locally queued BUY reservations."""
     working = working_buy_cash(
         trades,
         account=account,
         qualified_contracts=qualified_contracts,
+        estimated_fee_per_contract=estimated_fee_per_contract,
     )
-    queued = queued_buy_cash(records, qualified_contracts)
+    queued = queued_buy_cash(
+        records,
+        qualified_contracts,
+        estimated_fee_per_contract,
+    )
     debit = working.debit + queued.debit
     return PendingBuyCash(
         debit if math.isfinite(debit) else 0.0,
@@ -163,6 +268,15 @@ class Orders:
 
     def records(self) -> List[Tuple[Contract, LimitOrder, Optional[int]]]:
         return self.__records
+
+    def remove_records(
+        self,
+        records: Iterable[Tuple[Contract, LimitOrder, Optional[int]]],
+    ) -> None:
+        record_ids = {id(record) for record in records}
+        self.__records[:] = [
+            record for record in self.__records if id(record) not in record_ids
+        ]
 
     def print_summary(self) -> None:
         if not self.__records:

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -56,6 +56,8 @@ from thetagang.strategies.runtime_services import (
 from thetagang.strategies.tail_hedge_state import (
     TAIL_HEDGE_CLOSE_ORDER_REF,
     TAIL_HEDGE_ENTRY_ORDER_REF,
+    TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX,
+    TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
     TailHedgeStateStore,
     is_tail_order_ref,
     is_tail_reduction_ref,
@@ -79,6 +81,8 @@ from .options import option_dte
 # Turn off some of the more annoying logging output from ib_async
 logging.getLogger("ib_async.ib").setLevel(logging.ERROR)
 logging.getLogger("ib_async.wrapper").setLevel(logging.CRITICAL)
+
+TAIL_HARVEST_FILL_TIMEOUT_SECONDS = 5 * 60
 
 
 class PortfolioManager:
@@ -636,6 +640,113 @@ class PortfolioManager:
 
         return (account_summary, portfolio_positions)
 
+    @staticmethod
+    def _is_tail_harvest_record(
+        record: Tuple[Contract, LimitOrder, Optional[int]],
+    ) -> bool:
+        order_ref = getattr(record[1], "orderRef", None)
+        return isinstance(order_ref, str) and order_ref.startswith(
+            f"{TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX}:"
+        )
+
+    async def _refresh_account_state(
+        self,
+    ) -> Tuple[Dict[str, AccountValue], Dict[str, List[PortfolioItem]]]:
+        await asyncio.wait_for(
+            self.ibkr.refresh_account(self.account_number),
+            timeout=self.config.runtime.ib_async.api_response_wait_time,
+        )
+        account_summary = account_summary_to_dict(
+            await self.ibkr.account_summary(self.account_number)
+        )
+        for tag in ("NetLiquidation", "TotalCashValue"):
+            value = self.ibkr.cached_account_value(self.account_number, tag)
+            account_summary[tag] = AccountValue(
+                self.account_number,
+                tag,
+                str(value),
+                "BASE",
+                "",
+            )
+        return account_summary, self.get_portfolio_positions()
+
+    async def _plan_regime_rebalance(
+        self,
+        account_summary: Dict[str, AccountValue],
+        portfolio_positions: Dict[str, List[PortfolioItem]],
+        *,
+        exclude_current_run_state: bool = False,
+    ) -> List[Tuple[str, str, int]]:
+        table, orders = await self.equity_engine.check_regime_rebalance_positions(
+            account_summary,
+            self.combine_position_maps(
+                portfolio_positions,
+                self.last_untracked_positions,
+            ),
+            exclude_current_run_state=exclude_current_run_state,
+        )
+        if self.config.strategies.regime_rebalance.enabled:
+            log.print(table)
+        return orders
+
+    async def _run_regime_rebalance_stage(
+        self,
+        account_summary: Dict[str, AccountValue],
+        portfolio_positions: Dict[str, List[PortfolioItem]],
+    ) -> Tuple[Dict[str, AccountValue], Dict[str, List[PortfolioItem]]]:
+        records_before = len(self.orders.records())
+        regime_orders = await self._plan_regime_rebalance(
+            account_summary,
+            portfolio_positions,
+        )
+        new_records = self.orders.records()[records_before:]
+        harvest_records = [
+            record for record in new_records if self._is_tail_harvest_record(record)
+        ]
+        if self.dry_run or not harvest_records:
+            if regime_orders:
+                await self.equity_engine.execute_regime_rebalance_orders(regime_orders)
+            return account_summary, portfolio_positions
+
+        if self.data_store:
+            self.data_store.discard_current_run_events(
+                {
+                    "regime_rebalance_state",
+                    "volatility_weight_state",
+                }
+            )
+        self.orders.remove_records(harvest_records)
+        if not await self._execute_tail_harvest_phase(harvest_records):
+            raise RuntimeError("Tail-harvest execution did not fully fill")
+
+        account_summary, portfolio_positions = await self._refresh_account_state()
+        records_before = len(self.orders.records())
+        regime_orders = await self._plan_regime_rebalance(
+            account_summary,
+            portfolio_positions,
+            exclude_current_run_state=True,
+        )
+        extra_harvests = [
+            record
+            for record in self.orders.records()[records_before:]
+            if self._is_tail_harvest_record(record)
+        ]
+        if extra_harvests:
+            self.orders.remove_records(extra_harvests)
+            for contract, _order, _intent_id in extra_harvests:
+                con_id = getattr(contract, "conId", 0)
+                if type(con_id) is int and con_id > 0:
+                    self._update_tail_recovery_submission(con_id, None)
+            log.error(
+                "Tail harvest proceeds were insufficient after execution; "
+                "aborting remaining stages safely."
+            )
+            raise RuntimeError("Tail-harvest proceeds were insufficient")
+
+        if regime_orders:
+            await self.equity_engine.execute_regime_rebalance_orders(regime_orders)
+        return account_summary, portfolio_positions
+
     async def manage(self) -> None:
         had_error = False
         try:
@@ -725,21 +836,22 @@ class PortfolioManager:
                         portfolio_positions,
                         options_enabled,
                     )
+                elif stage_id == "equity_regime_rebalance":
+                    (
+                        account_summary,
+                        portfolio_positions,
+                    ) = await self._run_regime_rebalance_stage(
+                        account_summary,
+                        portfolio_positions,
+                    )
                 elif stage_id in {
-                    "equity_regime_rebalance",
                     "equity_buy_rebalance",
                     "equity_sell_rebalance",
                 }:
-                    equity_positions = portfolio_positions
-                    if stage_id == "equity_regime_rebalance":
-                        equity_positions = self.combine_position_maps(
-                            portfolio_positions,
-                            self.last_untracked_positions,
-                        )
                     await run_equity_rebalance_stages(
                         self._equity_strategy_deps({stage_id}),
                         account_summary,
-                        equity_positions,
+                        portfolio_positions,
                     )
                 elif stage_id in post_stage_ids:
                     post_positions = portfolio_positions
@@ -983,7 +1095,136 @@ class PortfolioManager:
             log.error(f"No pending tail-entry state found for conId {con_id}.")
         return released
 
-    def submit_orders(self) -> None:
+    @staticmethod
+    def _trade_fully_filled(trade: Any) -> bool:
+        status = str(getattr(getattr(trade, "orderStatus", None), "status", ""))
+        try:
+            filled = float(getattr(trade.orderStatus, "filled", 0) or 0)
+            remaining = float(getattr(trade.orderStatus, "remaining", 0) or 0)
+            requested = float(getattr(trade.order, "totalQuantity", 0) or 0)
+        except (AttributeError, TypeError, ValueError):
+            return False
+        return status == "Filled" and (
+            requested > 0
+            and filled >= requested
+            and math.isclose(remaining, 0.0, abs_tol=1e-9)
+        )
+
+    async def _cancel_incomplete_trades(self, trades: List[Any]) -> None:
+        canceled_trades = []
+        for trade in trades:
+            if self._trade_fully_filled(trade) or trade.isDone():
+                continue
+            log.warning(
+                f"{trade.contract.symbol}: Canceling incomplete tail harvest "
+                f"after bounded fill attempt."
+            )
+            self.ibkr.cancel_order(trade.order)
+            canceled_trades.append(trade)
+        if not canceled_trades:
+            return
+        still_working = await self.ibkr.wait_for_orders_complete(
+            canceled_trades,
+            max(
+                1,
+                min(60, self.config.runtime.ib_async.api_response_wait_time),
+            ),
+        )
+        if still_working:
+            log.error(
+                "Tail-harvest cancellation was not confirmed before shutdown; "
+                "no dependent orders will be submitted."
+            )
+
+    async def _execute_tail_harvest_phase(
+        self,
+        order_records: List[Tuple[Contract, LimitOrder, Optional[int]]],
+        timeout: int = TAIL_HARVEST_FILL_TIMEOUT_SECONDS,
+    ) -> bool:
+        if not order_records:
+            return True
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        trade_start = len(self.trades.records())
+        self.submit_orders(order_records)
+        trade_indices = list(range(trade_start, len(self.trades.records())))
+        phase_trades = [self.trades.records()[idx] for idx in trade_indices]
+        if len(phase_trades) != len(order_records):
+            await self._cancel_incomplete_trades(phase_trades)
+            log.error("Unable to submit every tail-harvest order; aborting safely.")
+            return False
+
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            await self._cancel_incomplete_trades(phase_trades)
+            log.error("Tail-harvest fill deadline expired; aborting safely.")
+            return False
+        submit_timeout = max(1, math.ceil(min(60.0, remaining)))
+        try:
+            await self.ibkr.wait_for_submitting_orders(
+                phase_trades,
+                submit_timeout,
+            )
+        except RuntimeError as exc:
+            await self._cancel_incomplete_trades(phase_trades)
+            log.error(f"Tail-harvest submission did not settle: {exc}")
+            return False
+
+        delay = random.randrange(
+            self.config.runtime.orders.price_update_delay[0],
+            self.config.runtime.orders.price_update_delay[1],
+        )
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            await self._cancel_incomplete_trades(phase_trades)
+            log.error("Tail-harvest fill deadline expired; aborting safely.")
+            return False
+        first_wait = max(1, math.ceil(min(float(delay), remaining)))
+        incomplete = await self.ibkr.wait_for_orders_complete(
+            phase_trades,
+            first_wait,
+        )
+
+        if incomplete and loop.time() < deadline:
+            incomplete_ids = {id(trade) for trade in incomplete}
+            for idx in trade_indices:
+                trade = self.trades.records()[idx]
+                if id(trade) in incomplete_ids:
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        break
+                    await self._reprice_trade(idx, trade, timeout=remaining)
+
+        phase_trades = [self.trades.records()[idx] for idx in trade_indices]
+        incomplete = [
+            trade for trade in phase_trades if not self._trade_fully_filled(trade)
+        ]
+        remaining = deadline - loop.time()
+        if incomplete and remaining > 0:
+            await self.ibkr.wait_for_orders_complete(
+                incomplete,
+                max(1, math.ceil(remaining)),
+            )
+
+        phase_trades = [self.trades.records()[idx] for idx in trade_indices]
+        if all(self._trade_fully_filled(trade) for trade in phase_trades):
+            log.notice("Tail-harvest orders filled; recalculating regime rebalance.")
+            return True
+
+        await self._cancel_incomplete_trades(phase_trades)
+        log.error(
+            f"Tail-harvest orders did not fully fill within {timeout} seconds; "
+            "aborting remaining stages safely."
+        )
+        return False
+
+    def submit_orders(
+        self,
+        order_records: Optional[
+            List[Tuple[Contract, LimitOrder, Optional[int]]]
+        ] = None,
+    ) -> None:
         open_trades = self.ibkr.open_trades()
         commitments = self._working_option_commitments(open_trades)
         working_option_con_ids = {con_id for con_id, _action in commitments}
@@ -1001,14 +1242,16 @@ class PortfolioManager:
             and type(getattr(trade.contract, "conId", None)) is int
             and trade.contract.conId > 0
         }
-        order_records = self.orders.records()
+        queued_records = self.orders.records()
+        if order_records is None:
+            order_records = queued_records
         working_stock_symbols = working_stock_order_symbols(
             open_trades,
             self.account_number,
         )
         working_stock_symbols |= {
             contract.symbol
-            for contract, order, _intent_id in order_records
+            for contract, order, _intent_id in queued_records
             if isinstance(contract, Stock)
             and getattr(order, "account", None) == self.account_number
             and str(getattr(order, "action", "")).upper() in {"BUY", "SELL"}
@@ -1147,6 +1390,99 @@ class PortfolioManager:
                 submitted_tail_entries.add(int(contract.conId))
         self.trades.print_summary()
 
+    async def _reprice_trade(
+        self,
+        idx: int,
+        trade: Any,
+        *,
+        timeout: Optional[float] = None,
+    ) -> bool:
+        response_timeout = self.config.runtime.ib_async.api_response_wait_time
+        if timeout is not None:
+            response_timeout = min(response_timeout, timeout)
+        try:
+            ticker = await asyncio.wait_for(
+                self.ibkr.get_ticker_for_contract(
+                    trade.contract,
+                    required_fields=[TickerField.MIDPOINT],
+                    optional_fields=[TickerField.MARKET_PRICE],
+                ),
+                timeout=response_timeout,
+            )
+
+            contract, order = trade.contract, trade.order
+            updated_price = np.sign(float(order.lmtPrice or 0)) * max(
+                [
+                    (
+                        self.config.runtime.orders.minimum_credit
+                        if order.action == "BUY" and float(order.lmtPrice or 0) <= 0.0
+                        else 0.0
+                    ),
+                    math.fabs(
+                        round(
+                            (float(order.lmtPrice or 0) + ticker.midpoint()) / 2.0,
+                            2,
+                        )
+                    ),
+                ]
+            )
+            minimum_limit_price = getattr(
+                order,
+                TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
+                None,
+            )
+            if (
+                order.action == "SELL"
+                and isinstance(minimum_limit_price, (int, float))
+                and math.isfinite(float(minimum_limit_price))
+            ):
+                updated_price = max(updated_price, float(minimum_limit_price))
+
+            if trade.contract.symbol == "VIX":
+                updated_price = self.order_ops.round_vix_price(updated_price)
+
+            if would_increase_spread(order, updated_price):
+                log.warning(
+                    f"Skipping order for {contract.symbol}"
+                    f" with old lmtPrice={dfmt(float(order.lmtPrice or 0))} "
+                    f"updated lmtPrice={dfmt(updated_price)}, because updated "
+                    "price would increase spread"
+                )
+                return False
+
+            if float(order.lmtPrice or 0) != updated_price and np.sign(
+                float(order.lmtPrice or 0)
+            ) == np.sign(updated_price):
+                log.info(
+                    f"{contract.symbol}: Resubmitting {order.action} "
+                    f"{contract.secType} order with old "
+                    f"lmtPrice={dfmt(float(order.lmtPrice or 0))} "
+                    f"updated lmtPrice={dfmt(updated_price)}"
+                )
+                updated_order = copy.deepcopy(cast(LimitOrder, order))
+                updated_order.lmtPrice = float(updated_price)
+                self.trades.submit_order(contract, updated_order, idx)
+                log.info(f"{contract.symbol}: Order updated, order={updated_order}")
+        except (
+            asyncio.TimeoutError,
+            RuntimeError,
+            RequiredFieldValidationError,
+        ) as exc:
+            log.warning(
+                f"Couldn't generate midpoint price for {trade.contract}, "
+                "skipping repricing"
+            )
+            if self.data_store:
+                self.data_store.record_event(
+                    "order_price_adjustment_skipped",
+                    {
+                        "symbol": getattr(trade.contract, "symbol", ""),
+                        "secType": getattr(trade.contract, "secType", ""),
+                        "reason": type(exc).__name__,
+                    },
+                )
+        return True
+
     async def adjust_prices(self) -> None:
         if (
             all(
@@ -1180,88 +1516,8 @@ class PortfolioManager:
         ]
 
         for idx, trade in unfilled:
-            try:
-                # Bound midpoint price requests so repricing never blocks run termination.
-                ticker = await asyncio.wait_for(
-                    self.ibkr.get_ticker_for_contract(
-                        trade.contract,
-                        required_fields=[TickerField.MIDPOINT],
-                        optional_fields=[TickerField.MARKET_PRICE],
-                    ),
-                    timeout=self.config.runtime.ib_async.api_response_wait_time,
-                )
-
-                (contract, order) = (trade.contract, trade.order)
-                updated_price = np.sign(float(order.lmtPrice or 0)) * max(
-                    [
-                        (
-                            self.config.runtime.orders.minimum_credit
-                            if order.action == "BUY"
-                            and float(order.lmtPrice or 0) <= 0.0
-                            else 0.0
-                        ),
-                        math.fabs(
-                            round(
-                                (float(order.lmtPrice or 0) + ticker.midpoint()) / 2.0,
-                                2,
-                            )
-                        ),
-                    ]
-                )
-
-                if trade.contract.symbol == "VIX":
-                    # Round VIX prices according to contract specifications
-                    updated_price = self.order_ops.round_vix_price(updated_price)
-
-                # We only want to tighten spreads, not widen them. If the
-                # resulting price change would increase the spread, we'll
-                # skip it.
-                if would_increase_spread(order, updated_price):
-                    log.warning(
-                        f"Skipping order for {contract.symbol}"
-                        f" with old lmtPrice={dfmt(float(order.lmtPrice or 0))} updated lmtPrice={dfmt(updated_price)}, because updated price would increase spread"
-                    )
-                    return
-
-                # Check if the updated price is actually any different
-                # before proceeding, and make sure the signs match so we
-                # don't switch a credit to a debit or vice versa.
-                if float(order.lmtPrice or 0) != updated_price and np.sign(
-                    float(order.lmtPrice or 0)
-                ) == np.sign(updated_price):
-                    log.info(
-                        f"{contract.symbol}: Resubmitting {order.action} {contract.secType} order with old lmtPrice={dfmt(float(order.lmtPrice or 0))} updated lmtPrice={dfmt(updated_price)}"
-                    )
-
-                    # IB requires a new order object here. Copy the complete
-                    # order so account routing and execution metadata survive
-                    # the price update.
-                    order = copy.deepcopy(cast(LimitOrder, order))
-                    order.lmtPrice = float(updated_price)
-
-                    # resubmit the order and it will be placed back to the
-                    # original position in the queue
-                    self.trades.submit_order(contract, order, idx)
-
-                    log.info(f"{contract.symbol}: Order updated, order={order}")
-            except (
-                asyncio.TimeoutError,
-                RuntimeError,
-                RequiredFieldValidationError,
-            ) as exc:
-                log.warning(
-                    f"Couldn't generate midpoint price for {trade.contract}, skipping repricing"
-                )
-                if self.data_store:
-                    self.data_store.record_event(
-                        "order_price_adjustment_skipped",
-                        {
-                            "symbol": getattr(trade.contract, "symbol", ""),
-                            "secType": getattr(trade.contract, "secType", ""),
-                            "reason": type(exc).__name__,
-                        },
-                    )
-                continue
+            if not await self._reprice_trade(idx, trade):
+                return
 
     async def get_write_threshold(
         self, ticker: Ticker, right: str

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -1097,17 +1097,27 @@ class PortfolioManager:
 
     @staticmethod
     def _trade_fully_filled(trade: Any) -> bool:
-        status = str(getattr(getattr(trade, "orderStatus", None), "status", ""))
+        status = str(
+            getattr(getattr(trade, "orderStatus", None), "status", "")
+        ).casefold()
         try:
             filled = float(getattr(trade.orderStatus, "filled", 0) or 0)
             remaining = float(getattr(trade.orderStatus, "remaining", 0) or 0)
             requested = float(getattr(trade.order, "totalQuantity", 0) or 0)
         except (AttributeError, TypeError, ValueError):
             return False
-        return status == "Filled" and (
-            requested > 0
-            and filled >= requested
-            and math.isclose(remaining, 0.0, abs_tol=1e-9)
+        if (
+            status != "filled"
+            or not math.isfinite(requested)
+            or requested <= 0
+            or not math.isfinite(filled)
+            or filled < requested
+        ):
+            return False
+        return not math.isfinite(remaining) or math.isclose(
+            remaining,
+            0.0,
+            abs_tol=1e-9,
         )
 
     async def _cancel_incomplete_trades(self, trades: List[Any]) -> None:

--- a/thetagang/strategies/equity.py
+++ b/thetagang/strategies/equity.py
@@ -21,7 +21,11 @@ class EquityStrategyDeps:
 
 class RegimeRebalanceService(Protocol):
     async def check_regime_rebalance_positions(
-        self, account_summary: AccountSummary, portfolio_positions: PortfolioBySymbol
+        self,
+        account_summary: AccountSummary,
+        portfolio_positions: PortfolioBySymbol,
+        *,
+        exclude_current_run_state: bool = False,
     ) -> Any: ...
 
     async def execute_regime_rebalance_orders(self, orders: List[Any]) -> None: ...

--- a/thetagang/strategies/equity_engine.py
+++ b/thetagang/strategies/equity_engine.py
@@ -109,9 +109,13 @@ class EquityRebalanceEngine:
         self,
         account_summary: Dict[str, AccountValue],
         portfolio_positions: Dict[str, List[PortfolioItem]],
+        *,
+        exclude_current_run_state: bool = False,
     ) -> Tuple[Table, List[Tuple[str, str, int]]]:
         return await self.regime_engine.check_regime_rebalance_positions(
-            account_summary, portfolio_positions
+            account_summary,
+            portfolio_positions,
+            exclude_current_run_state=exclude_current_run_state,
         )
 
     async def check_buy_only_positions(

--- a/thetagang/strategies/post_engine.py
+++ b/thetagang/strategies/post_engine.py
@@ -11,7 +11,7 @@ from thetagang.config import Config
 from thetagang.db import DataStore
 from thetagang.fmt import dfmt
 from thetagang.ibkr import IBKR
-from thetagang.orders import Orders, pending_buy_cash
+from thetagang.orders import Orders, pending_order_cash
 from thetagang.trading_operations import (
     NoValidContractsError,
     OptionChainScanner,
@@ -60,16 +60,27 @@ class PostStrategyEngine:
             return 0.0
         return max(0.0, self._get_reserved_cash_for_post_management())
 
-    def calc_pending_cash_balance(self) -> float:
-        pending = pending_buy_cash(
+    def pending_cash_components(self) -> tuple[float, float]:
+        pending = pending_order_cash(
             self.ibkr.open_trades(),
             self.orders.records(),
             account=self.config.runtime.account.number,
             qualified_contracts=self.qualified_contracts,
+            estimated_fee_per_contract=float(
+                getattr(
+                    self.config.runtime.orders,
+                    "estimated_fee_per_contract",
+                    0.0,
+                )
+            ),
         )
         if pending.ambiguous:
-            raise RuntimeError("Pending BUY cash cannot be priced safely")
-        return -pending.debit
+            raise RuntimeError("Pending order cash cannot be priced safely")
+        return pending.debit, pending.credit
+
+    def calc_pending_cash_balance(self) -> float:
+        pending_debit, pending_credit = self.pending_cash_components()
+        return pending_credit - pending_debit
 
     def _cash_fund_order_pending(self, symbol: str) -> bool:
         account = self.config.runtime.account.number
@@ -242,14 +253,21 @@ class PostStrategyEngine:
 
         def amount_to_manage(summary: Dict[str, AccountValue]) -> float:
             cash_balance = math.floor(float(summary["TotalCashValue"].value))
-            effective_cash_balance = cash_balance + self.calc_pending_cash_balance()
+            (
+                pending_debit,
+                pending_credit,
+            ) = self.pending_cash_components()
+            cash_after_pending_debits = cash_balance - pending_debit
             sweepable_cash_balance = (
-                effective_cash_balance - self.reserved_cash_for_post_management()
+                cash_after_pending_debits - self.reserved_cash_for_post_management()
             )
+            # Pending credits can prevent duplicate liquidation, but cannot fund
+            # a new cash-fund purchase until they settle.
             if sweepable_cash_balance > target_cash_balance + buy_threshold:
                 return sweepable_cash_balance - target_cash_balance
-            if effective_cash_balance < target_cash_balance - sell_threshold:
-                return effective_cash_balance - target_cash_balance
+            projected_cash_balance = cash_after_pending_debits + pending_credit
+            if projected_cash_balance < target_cash_balance - sell_threshold:
+                return projected_cash_balance - target_cash_balance
             return 0.0
 
         reserved_cash = self.reserved_cash_for_post_management()

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -23,6 +23,7 @@ from thetagang.orders import PendingBuyCash, pending_buy_cash
 from thetagang.strategies.runtime_services import resolve_symbol_configs
 from thetagang.strategies.tail_hedge_state import (
     TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX,
+    TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
     TailHedgeCohort,
     TailHedgeStateStore,
     build_tail_reduction_order_ref,
@@ -273,6 +274,13 @@ class RegimeRebalanceEngine:
             self.ibkr.open_trades(),
             self.order_ops.orders.records(),
             account=self.config.runtime.account.number,
+            estimated_fee_per_contract=float(
+                getattr(
+                    self.config.runtime.orders,
+                    "estimated_fee_per_contract",
+                    0.0,
+                )
+            ),
         )
 
     def _ordinary_rebalance_shortfall(
@@ -630,12 +638,31 @@ class RegimeRebalanceEngine:
             or state_cohort.has_pending_recovery
         ):
             return False
+        multiplier = float(candidate.contract.multiplier)
+        minimum_profitable_price = (
+            math.floor(
+                (
+                    candidate.cost_basis_per_contract
+                    + candidate.estimated_fee_per_contract
+                )
+                / multiplier
+                * 100
+            )
+            + 1
+        ) / 100
+        minimum_net_proceeds = round(
+            minimum_profitable_price * multiplier
+            - candidate.estimated_fee_per_contract,
+            2,
+        )
         # Candidate sizing was refreshed from the live portfolio after quotes.
         # A prior external reduction is not proceeds from this unsubmitted sale.
         state_cohort.quantity = min(state_cohort.quantity, candidate.quantity)
         state_cohort.begin_recovery(
             quantity=quantity,
-            proceeds_per_contract=round(candidate.net_proceeds_per_contract, 2),
+            # Actual fill proceeds replace this conservative floor during
+            # tail-state reconciliation.
+            proceeds_per_contract=minimum_net_proceeds,
             enqueued_at=self._now(),
         )
         try:
@@ -658,6 +685,7 @@ class RegimeRebalanceEngine:
             ),
             transmit=True,
         )
+        setattr(order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR, minimum_profitable_price)
         self.order_ops.enqueue_order(candidate.contract, order)
         self._record_tail_harvest(
             "harvest_enqueued",
@@ -1327,13 +1355,18 @@ class RegimeRebalanceEngine:
         symbols: List[str],
         symbol_configs: Dict[str, Any],
         history_cache: Optional[RegimeHistoryCache] = None,
+        *,
+        exclude_current_run_state: bool = False,
     ) -> Tuple[Dict[str, float], Dict[str, Dict[str, float]]]:
         effective_weights = {
             symbol: float(symbol_configs[symbol].weight) for symbol in symbols
         }
         volatility_details: Dict[str, Dict[str, float]] = {}
         previous_state = (
-            self.data_store.get_last_event_payload("volatility_weight_state")
+            self.data_store.get_last_event_payload(
+                "volatility_weight_state",
+                exclude_current_run=exclude_current_run_state,
+            )
             if self.data_store
             else None
         )
@@ -1591,6 +1624,8 @@ class RegimeRebalanceEngine:
         self,
         account_summary: Dict[str, AccountValue],
         portfolio_positions: Dict[str, List[PortfolioItem]],
+        *,
+        exclude_current_run_state: bool = False,
     ) -> Tuple[Table, List[Tuple[str, str, int]]]:
         symbol_configs = resolve_symbol_configs(
             self.config, context="regime rebalance check"
@@ -1748,6 +1783,7 @@ class RegimeRebalanceEngine:
             symbols,
             symbol_configs,
             history_cache,
+            exclude_current_run_state=exclude_current_run_state,
         )
         harvest_risk_ready_symbols = {
             symbol
@@ -1921,7 +1957,10 @@ class RegimeRebalanceEngine:
         flow_was_active = False
         deficit_was_active = False
         if self.data_store:
-            state = self.data_store.get_last_event_payload("regime_rebalance_state")
+            state = self.data_store.get_last_event_payload(
+                "regime_rebalance_state",
+                exclude_current_run=exclude_current_run_state,
+            )
             if state:
                 flow_was_active = bool(state.get("flow_active", False))
                 deficit_was_active = bool(state.get("deficit_active", False))

--- a/thetagang/strategies/tail_hedge_engine.py
+++ b/thetagang/strategies/tail_hedge_engine.py
@@ -88,6 +88,7 @@ class BrokerOrderProgress:
     filled: float
     observed_at: datetime | None
     intent_specific: bool = False
+    net_proceeds_per_contract: float | None = None
 
     @property
     def is_filled(self) -> bool:
@@ -420,7 +421,11 @@ class TailHedgeEngine:
             )
             if progress.is_filled and math.floor(progress.filled) == 0:
                 confirmed_quantity = cohort.pending_recovery_quantity or 0
-            credited = cohort.apply_recovery(confirmed_quantity)
+            credited = self._apply_recovery(
+                cohort,
+                confirmed_quantity,
+                progress,
+            )
             if credited > 0:
                 log.notice(
                     f"{cohort.symbol}: Credited {dfmt(credited)} of recovered tail "
@@ -498,7 +503,11 @@ class TailHedgeEngine:
             )
             cohort.estimated_cost = max(cohort.estimated_cost, settled_cost)
         if live_quantity < cohort.quantity and cohort.has_pending_recovery:
-            recovery_credited = cohort.apply_recovery(cohort.quantity - live_quantity)
+            recovery_credited = self._apply_recovery(
+                cohort,
+                cohort.quantity - live_quantity,
+                self._reduction_progress(cohort, account_trades),
+            )
             if recovery_credited > 0:
                 log.notice(
                     f"{cohort.symbol}: Credited {dfmt(recovery_credited)} of "
@@ -536,6 +545,21 @@ class TailHedgeEngine:
                 "without an observed position change; it can be retried."
             )
         return True
+
+    @staticmethod
+    def _apply_recovery(
+        cohort: TailHedgeCohort,
+        quantity: int,
+        progress: BrokerOrderProgress | None,
+    ) -> float:
+        if (
+            progress is not None
+            and progress.net_proceeds_per_contract is not None
+            and cohort.accounted_recovery_quantity == 0
+            and quantity == cohort.pending_recovery_quantity
+        ):
+            cohort.update_recovery_proceeds(progress.net_proceeds_per_contract)
+        return cohort.apply_recovery(quantity)
 
     @staticmethod
     def _entry_is_working(cohort: TailHedgeCohort, trades: List[Trade]) -> bool:
@@ -1330,11 +1354,29 @@ class TailHedgeEngine:
             filled = 0.0
         if not math.isfinite(filled) or filled < 0:
             filled = 0.0
+        net_proceeds_per_contract = None
+        if action == "SELL" and (filled > 0 or status.lower() == "filled"):
+            try:
+                average_fill_price = float(
+                    getattr(order_status, "avgFillPrice", 0.0) or 0.0
+                )
+                if not math.isfinite(average_fill_price) or average_fill_price <= 0:
+                    raise ValueError("Average fill price is unavailable")
+                net_proceeds = round(
+                    average_fill_price * self._multiplier(trade.contract)
+                    - self._estimated_fee_per_contract(),
+                    2,
+                )
+                if math.isfinite(net_proceeds) and net_proceeds >= 0:
+                    net_proceeds_per_contract = net_proceeds
+            except (RuntimeError, TypeError, ValueError):
+                pass
         return BrokerOrderProgress(
             status=status,
             filled=filled,
             observed_at=self._trade_time(trade),
             intent_specific=selected[3],
+            net_proceeds_per_contract=net_proceeds_per_contract,
         )
 
     @staticmethod

--- a/thetagang/strategies/tail_hedge_state.py
+++ b/thetagang/strategies/tail_hedge_state.py
@@ -11,6 +11,7 @@ from thetagang.options import contract_date_to_datetime
 TAIL_HEDGE_ENTRY_ORDER_REF = "tg:tail-hedge:entry"
 TAIL_HEDGE_CLOSE_ORDER_REF = "tg:tail-hedge:close"
 TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX = "tg:tail-harvest"
+TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR = "_thetagang_min_limit_price"
 
 _ORDER_REF_EPOCH = datetime(1970, 1, 1)
 
@@ -173,6 +174,12 @@ class TailHedgeCohort:
             raise RuntimeError("Tail-hedge state contains invalid recovery intent")
         self.pending_recovery_quantity = quantity
         self.pending_recovery_initial_quantity = quantity
+        self.validate()
+
+    def update_recovery_proceeds(self, proceeds_per_contract: float) -> None:
+        if not self.has_pending_recovery:
+            raise RuntimeError("Tail-hedge recovery intent is unavailable")
+        self.pending_recovery_per_contract = self._number(proceeds_per_contract)
         self.validate()
 
     def apply_recovery(self, quantity: int) -> float:


### PR DESCRIPTION
## Summary

Coordinate tail-harvest execution with regime rebalancing and cash management so one run accounts for dependent cash flows from a consistent broker snapshot.

## User Impact

Cash management no longer liquidates SHV solely because same-run regime sale proceeds were ignored. Tail-funded rebalances can complete in one run, while incomplete harvests fail closed without submitting dependent stock or cash-fund orders.

## Root Cause

Pending-cash accounting reserved only BUY debits, so queued SELL credits were invisible. Tail harvests and regime rebalancing were planned together but submitted only at the end, leaving no point to observe actual option-sale fills before sizing dependent orders. A second planning pass could also reuse preliminary same-run state, and recovery accounting could over-credit the original quoted proceeds after a lower repriced fill.

## Fix

- Model signed pending debits and credits for queued and working orders, including combo signs and configured option fees.
- Execute tail harvest sells as a bounded first phase, reprice once after the configured delay, require complete fills, and confirm cancellations on failure.
- Refresh IBKR account and portfolio state after fills, then recalculate regime orders in the same run.
- Keep tail repricing above a fee-aware profit floor and reconcile complete fills from actual average fill prices.
- Isolate preliminary regime state so the second pass does not double-apply smoothing and aborted harvests do not leave tentative state.
- Fail closed for ambiguous orders and non-ready IBKR account snapshots.
- Harden fill completion against broker status casing and non-finite quantities, and reject invalid price-update delay ranges at configuration load.
- Update the tail-hedging guide to document the same-run actual-cash flow, bounded failure behavior, and fill-price recovery accounting.

## Validation

- `uv lock --check`
- `uv run --frozen pytest -q` — 481 passed.
- `uv run --frozen --with pytest-cov pytest -q --cov=thetagang --cov-report=term-missing` — 481 passed, 79% coverage; existing resource warnings only.
- `uv run --frozen ruff format --check .`
- `uv run --frozen ruff check .`
- `uv run --frozen ty check`
- `uv run --frozen pre-commit run --all-files`
- `git diff --check`
- Exact regression for the observed SHV run: -$11,649 + $16,552.68 = $4,903.68, so no SHV sale within the configured $0–$10,000 band.
