### PR TITLE
feat(tail-hedge): harvest profitable puts by allocation band

### DIFF
--- a/docs/tail-hedging.md
+++ b/docs/tail-hedging.md
@@ -25,14 +25,14 @@ On each `tail_hedge` stage, ThetaGang:
 
 ```mermaid
 flowchart TD
-    R{"Regime stage: approved stock buy still short after ordinary funding?"}
-    R -->|Yes| Q{"Profitable owned cohort available?"}
+    R{"Regime stage: same-symbol hard-underweight buy approved?"}
+    R -->|Yes| Q{"Tail sleeve above harvest trigger?"}
     R -->|No or stage disabled| A["Tail stage: load SQLite cohorts"]
-    Q -->|Yes| J["Submit at most one harvest per target in a bounded fill phase"]
+    Q -->|Yes| J["Sell earliest-expiring profitable puts toward target band"]
     Q -->|No| A
     J --> K{"Every harvest fully filled?"}
     K -->|No| S["Cancel incomplete orders and abort remaining stages"]
-    K -->|Yes| L["Refresh broker cash and positions, then replan regime orders"]
+    K -->|Yes| L["Refresh broker state, then replan regime orders"]
     L --> A
     A --> B["Reconcile every open cohort with broker state"]
     B --> C{"Any cohort due to exit or target removed?"}
@@ -141,47 +141,72 @@ still apply.
 
 ## Selling puts during a drawdown
 
-When `regime_rebalance` is also running, ThetaGang can sell a profitable tail
-put to help fund a same-symbol stock buy. Harvesting never creates or enlarges
-the allocation: volatility and dynamic sizing must first produce an approved buy
-past the stock's hard-underweight band. Normal funding is applied first,
-including the configured cash reserve, queued buy debits, approved stock sales,
-and usable cash-fund value when cash management runs later. Only the remaining
-shortfall can trigger a harvest.
+When `regime_rebalance` is also running, ThetaGang can rotate part of a
+profitable tail hedge into a same-symbol stock buy. Harvesting never bypasses
+the allocation policy: volatility and dynamic sizing must first produce an
+approved buy past the stock's hard-underweight band.
 
-Only active, state-owned puts without a conflicting order are eligible. The
-live sell quote, after the configured estimated sell fee, must exceed both the
-IBKR average cost and the configured all-in entry basis. The submitted limit
-also carries a fee-aware floor above that cost basis, so the bounded reprice
-cannot turn a profitable harvest into an estimated loss.
+The second condition is a portfolio-level allocation band. The market value of
+all state-owned tail puts must be greater than `harvest_trigger_weight` of
+current net liquidation value. ThetaGang then sizes sales toward
+`harvest_target_weight`. The target sale budget is the value of the tail sleeve
+above that target, without consulting broker cash. The defaults
+trigger above 5% of NLV and target 3%. They are configurable policy values, not
+calibrated recommendations.
 
-ThetaGang uses the earliest-expiring useful cohort and sells the fewest whole
-contracts needed. It sells at most one cohort per target in a run. The part of
-the stock buy covered by normal funding stays in the current run. Shares assigned
-to the shortfall are deferred during preliminary planning. ThetaGang then submits
-the harvest as a bounded first phase, waits once at the original limit, and may
-reprice once toward the midpoint without crossing the profit floor. Every harvest
-must fully fill. Otherwise, ThetaGang cancels incomplete orders and aborts the
-remaining stages without submitting dependent stock or cash-fund orders.
+The separation between the trigger and target is the hysteresis. After a sale
+toward 3%, enough eligible fills normally leave no reason for another daily
+harvest in a flat or recovering market. A later sale requires the remaining
+sleeve to be above 5% again and the same-symbol hard-underweight buy to remain
+approved. No crash episode, trough, profit-tier, or recovery state is needed.
+
+IBKR cash balances, cash-fund holdings, queued cash debits, box-spread proceeds,
+and unrelated stock orders do not enter the trigger or sale budget. The only
+account total used is `NetLiquidation`, as the denominator of the hedge sleeve.
+The numerator contains only live, state-owned tail puts. The amount available
+for conversion is determined from the band, not from reported cash or the
+preliminary size of the stock order. After option quotes return, ThetaGang
+rechecks both the live sleeve and the latest available NLV before committing a
+sale, so the two sides of the ratio are not intentionally taken from different
+market moments.
+
+Only active, state-owned puts without a conflicting order are eligible.
+ThetaGang walks profitable cohorts by earliest expiration and sells only as
+many whole contracts as needed along that ordering to move the sleeve toward
+its target. Contract rounding may overshoot the target sale budget by less than
+one selected contract. Newly purchased or still-unprofitable cohorts
+remain invested rather than being used merely because the total sleeve crossed
+the trigger. The submitted limit carries both a fee-aware floor above the
+cohort's cost basis and a floor strictly above the price implied by the trigger.
+A hedge barely above the trigger therefore cannot be chased down to break-even
+or sold after it has fallen back to the upper-band boundary.
+
+ThetaGang submits a newly selected harvest as a bounded first phase, waits once
+at the original limit, and may reprice once toward the midpoint without crossing
+the higher of those two floors. Every harvest must fully fill. Otherwise,
+ThetaGang cancels incomplete orders and aborts the remaining stages without
+submitting stock or cash-fund orders from that plan.
 
 After complete fills, ThetaGang refreshes IBKR account and portfolio state and
 recalculates the regime rebalance in the same run from prior-run smoothing state.
-Only cash in that refreshed broker snapshot can fund the dependent stock orders;
-the preliminary quote is never treated as cash. If the refreshed state supports
-fewer shares, the second plan retains only the ordinarily funded amount. Pending
-sale credits can prevent cash management from queuing a duplicate cash-fund
-liquidation, but they cannot fund a new cash-fund purchase.
+The recalculated allocation, not estimated option proceeds, determines the stock
+order. The preliminary quote is never treated as a fill, and the preliminary
+stock order is never submitted ahead of the harvest. If any recalculated stock
+order cannot be prepared completely, ThetaGang aborts loudly before the final
+submission batch instead of treating the partial rebalance as successful.
 
-If any cohort for the symbol still has unresolved recovery state, a new harvest
-is deferred for that planning pass. The later tail stage reconciles the sale and
-its actual average fill when available. A subsequent invocation may sell another
-cohort if a fresh broker snapshot still shows both a hard-underweight allocation
-and a cash shortfall.
+If any state-owned tail reduction still has unresolved recovery state, a new
+portfolio harvest is blocked without changing an otherwise approved stock
+order. The later tail stage reconciles the sale and its actual average fill when
+available. This portfolio-wide lock prevents a pending sale in one target from
+being double-counted as excess available for another. ThetaGang runs only one
+bounded harvest phase per invocation.
 
 Entry evaluations record premium, estimated fees, catastrophe payouts and
 score, order size, open interest, and the quantity/open-interest ratio. Harvest
-events record blocks, estimated gross and net proceeds, fees, required proceeds,
-and excess proceeds. The same details are included in concise run logs.
+events record the sleeve value and weight, band settings, sale budget, estimated
+gross and net proceeds, fees, and the approved rebalance. The same details are
+included in concise run logs.
 
 ## State and safe shutdown
 
@@ -196,10 +221,13 @@ portfolio rebalancing, and cohort reconciliation all assume one process owns the
 account's run.
 
 State-owned puts are excluded from wheel management. With regime rebalancing,
-`net_liq` excludes those puts from its allocation base, `net_liq_ex_options`
-excludes all options, and `managed_stocks` uses managed stock value only.
-If ownership state cannot be read, wheel paths that need it fail closed instead
-of treating the puts as unowned.
+`net_liq` excludes those puts from its allocation base. `net_liq_ex_options`
+excludes options on active regime symbols plus state-owned tail puts, including
+tail puts outside the regime sleeve. It does not subtract unrelated financing
+or overlay options again: their cash and option liability are already netted in
+broker `NetLiquidation`. `managed_stocks` uses managed stock value only. If
+ownership state cannot be read, wheel paths that need it fail closed instead of
+treating the puts as unowned.
 
 Do not trade a state-owned put manually. IBKR combines manual and automated
 positions in the same contract, so ThetaGang cannot tell them apart.
@@ -229,6 +257,8 @@ estimated_fee_per_contract = 1.0
 [strategies.tail_hedge]
 enabled = true
 annual_budget = 0.005
+harvest_trigger_weight = 0.05
+harvest_target_weight = 0.03
 
 [[strategies.tail_hedge.targets]]
 symbol = "QQQ"
@@ -251,7 +281,7 @@ When tail hedging is enabled, each target symbol must also appear in
 `portfolio.symbols`. If regime rebalancing is enabled,
 `regime_rebalance.shares_only` must be `false`. Enable
 `regime_rebalance` and add it to `run.strategies` if you want profitable puts to
-fund hard-underweight buys.
+be monetized during hard-underweight buys.
 
 The values above show the configuration shape. They are not trading advice or
 calibrated defaults for every account.

--- a/docs/tail-hedging.md
+++ b/docs/tail-hedging.md
@@ -148,11 +148,11 @@ approved buy past the stock's hard-underweight band.
 
 The second condition is a portfolio-level allocation band. The market value of
 all state-owned tail puts must be greater than `harvest_trigger_weight` of
-current net liquidation value. ThetaGang then sizes sales toward
-`harvest_target_weight`. The target sale budget is the value of the tail sleeve
-above that target, without consulting broker cash. The defaults
-trigger above 5% of NLV and target 3%. They are configurable policy values, not
-calibrated recommendations.
+the configured regime-rebalancing base. ThetaGang then sizes sales toward
+`harvest_target_weight` of that same base. The target sale budget is the value
+of the tail sleeve above that target, without consulting broker cash. The
+defaults trigger above 5% of the regime base and target 3%. They are
+configurable policy values, not calibrated recommendations.
 
 The separation between the trigger and target is the hysteresis. After a sale
 toward 3%, enough eligible fills normally leave no reason for another daily
@@ -160,15 +160,27 @@ harvest in a flat or recovering market. A later sale requires the remaining
 sleeve to be above 5% again and the same-symbol hard-underweight buy to remain
 approved. No crash episode, trough, profit-tier, or recovery state is needed.
 
-IBKR cash balances, cash-fund holdings, queued cash debits, box-spread proceeds,
-and unrelated stock orders do not enter the trigger or sale budget. The only
-account total used is `NetLiquidation`, as the denominator of the hedge sleeve.
+Harvesting uses the exact same `weight_base` calculation as regime rebalancing.
+With the default `net_liq_ex_options`, options on active regime symbols and all
+state-owned tail puts are removed from broker `NetLiquidation`. Unrelated
+financing options, including SPX box-spread legs, remain netted against their
+cash proceeds inside `NetLiquidation`; cash-fund holdings also remain included.
+`net_liq` removes only state-owned tail puts, while `managed_stocks` uses only
+the managed regime stock value. For example, $100,000 of broker NLV containing
+$5,000 of state-owned tail puts produces a $95,000 regime base before any
+configured margin multiplier, so the tail sleeve weight is about 5.26%.
+
 The numerator contains only live, state-owned tail puts. The amount available
 for conversion is determined from the band, not from reported cash or the
 preliminary size of the stock order. After option quotes return, ThetaGang
-rechecks both the live sleeve and the latest available NLV before committing a
-sale, so the two sides of the ratio are not intentionally taken from different
-market moments.
+rechecks both the live sleeve and the latest available NLV and rebuilds the
+regime base before committing a sale, so the two sides of the ratio are not
+intentionally taken from different market moments.
+
+After a fill, excluded put value has become included cash, so the refreshed
+regime base can increase. The target weight is therefore a sale-sizing reference
+for the pre-sale snapshot, not a guarantee of the exact post-fill weight; whole
+contract rounding and refreshed marks can move the result slightly below it.
 
 Only active, state-owned puts without a conflicting order are eligible.
 ThetaGang walks profitable cohorts by earliest expiration and sells only as

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -62,6 +62,8 @@ def test_tail_hedge_strategy_compiles_to_its_post_stage() -> None:
     assert target.exit_dte == 30
     assert not hasattr(target, "strike_ratio")
     assert target.catastrophe_drawdowns == [0.40, 0.50, 0.60]
+    assert config.tail_hedge.harvest_trigger_weight == 0.05
+    assert config.tail_hedge.harvest_target_weight == 0.03
     assert config.runtime.orders.estimated_fee_per_contract == 1.0
 
 
@@ -109,6 +111,20 @@ def test_tail_hedge_catastrophe_drawdowns_are_ordered_fractions(
     }
 
     with pytest.raises(ValueError, match="catastrophe_drawdowns"):
+        Config(**data)
+
+
+@pytest.mark.parametrize("target", [0.05, 0.06])
+def test_tail_hedge_harvest_target_must_be_below_trigger(target) -> None:
+    data = _base_config({"strategies": ["tail_hedge"]})
+    data["strategies"]["tail_hedge"] = {
+        "enabled": True,
+        "harvest_trigger_weight": 0.05,
+        "harvest_target_weight": target,
+        "targets": [_tail_target()],
+    }
+
+    with pytest.raises(ValueError, match="harvest_target_weight"):
         Config(**data)
 
 

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -924,7 +924,6 @@ class TestPortfolioManager:
             "_reprice_trade",
             side_effect=fill_on_reprice,
         )
-
         filled = await portfolio_manager._execute_tail_harvest_phase(
             [(contract, order, None)],
             timeout=5,
@@ -1080,10 +1079,28 @@ class TestPortfolioManager:
         portfolio_manager.equity_engine.check_regime_rebalance_positions = (
             mocker.AsyncMock(side_effect=check_regime)
         )
+
+        async def prepare_regime_orders(orders):
+            for symbol, primary_exchange, quantity in orders:
+                contract = Stock(
+                    symbol,
+                    "SMART",
+                    "USD",
+                    primaryExchange=primary_exchange,
+                )
+                order = LimitOrder(
+                    "BUY" if quantity > 0 else "SELL",
+                    abs(quantity),
+                    100.0,
+                    account="TEST123",
+                    orderRef=f"tg:regime-rebalance:{symbol}",
+                )
+                portfolio_manager.orders.add_order(contract, order, None)
+
         execute = mocker.patch.object(
             portfolio_manager.equity_engine,
             "execute_regime_rebalance_orders",
-            new=mocker.AsyncMock(),
+            new=mocker.AsyncMock(side_effect=prepare_regime_orders),
         )
         execute_harvest = mocker.patch.object(
             portfolio_manager,
@@ -1119,8 +1136,75 @@ class TestPortfolioManager:
             ].kwargs["exclude_current_run_state"]
             is True
         )
+        assert (
+            portfolio_manager.equity_engine.check_regime_rebalance_positions.call_args_list[
+                1
+            ].kwargs["allow_tail_harvest"]
+            is False
+        )
         execute.assert_awaited_once_with([("SPY", "NYSE", 2)])
+        assert len(portfolio_manager.orders.records()) == 1
+
+    @pytest.mark.asyncio
+    async def test_regime_stage_fails_if_post_harvest_buy_is_not_prepared(
+        self, portfolio_manager, mocker
+    ):
+        portfolio_manager.config.strategies.regime_rebalance.enabled = True
+        portfolio_manager.data_store = mocker.Mock()
+        contract = Option("SPY", "20271217", 300, "P", "SMART", conId=123)
+        harvest_order = tail_order(
+            portfolio_manager,
+            "SELL",
+            1,
+            "tg:tail-harvest:SPY:123",
+        )
+        checks = 0
+
+        async def check_regime(_summary, _positions, **_kwargs):
+            nonlocal checks
+            checks += 1
+            if checks == 1:
+                portfolio_manager.orders.add_order(contract, harvest_order, None)
+            return mocker.Mock(), [("SPY", "NYSE", 1)]
+
+        portfolio_manager.equity_engine.check_regime_rebalance_positions = (
+            mocker.AsyncMock(side_effect=check_regime)
+        )
+
+        async def prepare_invalid_regime_order(_orders):
+            stock = Stock("SPY", "SMART", "USD", primaryExchange="NYSE")
+            order = LimitOrder(
+                "BUY",
+                1,
+                float("nan"),
+                account="TEST123",
+                orderRef="tg:regime-rebalance:SPY",
+            )
+            portfolio_manager.orders.add_order(stock, order, None)
+
+        portfolio_manager.equity_engine.execute_regime_rebalance_orders = (
+            mocker.AsyncMock(side_effect=prepare_invalid_regime_order)
+        )
+        mocker.patch.object(
+            portfolio_manager,
+            "_execute_tail_harvest_phase",
+            new=mocker.AsyncMock(return_value=True),
+        )
+        portfolio_manager.ibkr.refresh_account = mocker.AsyncMock()
+        portfolio_manager.ibkr.account_summary = mocker.AsyncMock(return_value=[])
+        portfolio_manager.ibkr.cached_account_value = mocker.Mock(return_value=10_000.0)
+        portfolio_manager.get_portfolio_positions = mocker.Mock(
+            return_value={"SPY": []}
+        )
+
+        with pytest.raises(RuntimeError, match="preparation was incomplete"):
+            await portfolio_manager._run_regime_rebalance_stage(
+                {"NetLiquidation": SimpleNamespace(value="10000")},
+                {"SPY": []},
+            )
+
         assert portfolio_manager.orders.records() == []
+        assert portfolio_manager.data_store.discard_current_run_events.call_count == 2
 
     @pytest.mark.asyncio
     async def test_regime_stage_aborts_when_tail_harvest_does_not_fill(

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1096,6 +1096,7 @@ class TestPortfolioManager:
                     orderRef=f"tg:regime-rebalance:{symbol}",
                 )
                 portfolio_manager.orders.add_order(contract, order, None)
+            return len(orders)
 
         execute = mocker.patch.object(
             portfolio_manager.equity_engine,
@@ -1136,12 +1137,6 @@ class TestPortfolioManager:
             ].kwargs["exclude_current_run_state"]
             is True
         )
-        assert (
-            portfolio_manager.equity_engine.check_regime_rebalance_positions.call_args_list[
-                1
-            ].kwargs["allow_tail_harvest"]
-            is False
-        )
         execute.assert_awaited_once_with([("SPY", "NYSE", 2)])
         assert len(portfolio_manager.orders.records()) == 1
 
@@ -1171,19 +1166,13 @@ class TestPortfolioManager:
             mocker.AsyncMock(side_effect=check_regime)
         )
 
-        async def prepare_invalid_regime_order(_orders):
-            stock = Stock("SPY", "SMART", "USD", primaryExchange="NYSE")
-            order = LimitOrder(
-                "BUY",
-                1,
-                float("nan"),
-                account="TEST123",
-                orderRef="tg:regime-rebalance:SPY",
-            )
-            portfolio_manager.orders.add_order(stock, order, None)
-
-        portfolio_manager.equity_engine.execute_regime_rebalance_orders = (
-            mocker.AsyncMock(side_effect=prepare_invalid_regime_order)
+        portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock(
+            return_value=mocker.Mock()
+        )
+        mocker.patch.object(
+            portfolio_manager.equity_engine,
+            "_midpoint_or_market_price",
+            return_value=float("nan"),
         )
         mocker.patch.object(
             portfolio_manager,

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -5,7 +5,7 @@ from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
-from ib_async import IB, AccountValue, MarketOrder, Option, Stock
+from ib_async import IB, AccountValue, Option, Stock
 
 import thetagang.portfolio_manager as pm_module
 import thetagang.strategies.regime_engine as regime_engine_module
@@ -246,10 +246,6 @@ def _mock_regime_broker(portfolio_manager, mocker, **history_mock_kwargs) -> Non
 def _enable_tail_hedge_stage(portfolio_manager) -> None:
     portfolio_manager.run_stage_flags["equity_regime_rebalance"] = True
     portfolio_manager.run_stage_flags["post_tail_hedge"] = True
-
-
-def _enable_cash_management_stage(portfolio_manager, enabled: bool = True) -> None:
-    portfolio_manager.run_stage_flags["post_cash_management"] = enabled
 
 
 def _stock_position(
@@ -3470,12 +3466,12 @@ async def test_harvest_persists_recovery_intent(
 
     assert orders == [("BBB", "NYSE", 1)]
     queued_order = portfolio_manager.orders.records()[0][1]
-    assert getattr(queued_order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR) == pytest.approx(1.01)
+    assert getattr(queued_order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR) == pytest.approx(0.95)
     store = portfolio_manager.regime_engine._tail_state_store
     assert store is not None
     state = store.load()
     assert state.open_cohorts[0].pending_recovery_quantity == 1
-    assert state.open_cohorts[0].pending_recovery_per_contract == 101.0
+    assert state.open_cohorts[0].pending_recovery_per_contract == 95.0
     assert isinstance(state.open_cohorts[0].pending_recovery_enqueued_at, datetime)
     assert state.open_cohorts[0].pending_recovery_initial_quantity == 1
     telemetry = portfolio_manager.data_store.get_last_event_payload(
@@ -3487,12 +3483,16 @@ async def test_harvest_persists_recovery_intent(
     assert telemetry["gross_proceeds"] == 120.0
     assert telemetry["estimated_fees"] == 0.0
     assert telemetry["net_proceeds"] == 120.0
-    assert telemetry["minimum_limit_price"] == 1.01
-    assert telemetry["minimum_net_proceeds_per_contract"] == 101.0
+    assert telemetry["minimum_limit_price"] == 0.95
+    assert telemetry["minimum_net_proceeds_per_contract"] == 95.0
     assert telemetry["rebalance_shares"] == 1
+    assert telemetry["net_liquidation"] == 2_000.0
+    assert telemetry["regime_rebalance_base"] == 1_880
+    assert telemetry["regime_weight_base"] == "net_liq_ex_options"
+    assert telemetry["excluded_option_value"] == 120.0
     assert telemetry["sleeve_value"] == 120.0
-    assert telemetry["sleeve_weight"] == pytest.approx(0.06)
-    assert telemetry["sale_budget"] == 60.0
+    assert telemetry["sleeve_weight"] == pytest.approx(120.0 / 1_880.0)
+    assert telemetry["sale_budget"] == pytest.approx(63.6)
     assert telemetry["harvest_trigger_weight"] == 0.05
     assert telemetry["harvest_target_weight"] == 0.03
 
@@ -3520,7 +3520,7 @@ async def test_harvest_band_does_not_trigger_at_upper_bound(
 
     await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        net_liquidation=2_000.0,
+        net_liquidation=2_100.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -3555,7 +3555,7 @@ async def test_harvest_band_sizes_contracts_by_market_value_not_net_cash(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        net_liquidation=4_000.0,
+        net_liquidation=4_240.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -3566,6 +3566,99 @@ async def test_harvest_band_sizes_contracts_by_market_value_not_net_cash(
     queued = portfolio_manager.orders.records()
     assert len(queued) == 1
     assert int(queued[0][1].totalQuantity) == 1
+
+
+@pytest.mark.asyncio
+async def test_harvest_reuses_regime_option_box_and_cash_fund_base(
+    portfolio_manager_with_db,
+    mocker,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    tail_put = _option_position(
+        "BBB",
+        1,
+        market_value=4_700.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=1_000.0,
+    )
+    tail_put.contract.multiplier = "100"
+    state = _tail_state(symbol="BBB", puts=[tail_put])
+    _set_live_tail_positions(portfolio_manager, [tail_put])
+    manual_regime_option = _option_position(
+        "AAA",
+        1,
+        market_value=5_000.0,
+        con_id=802,
+    )
+    cash_fund = _stock_position("SHV", 100, market_value=15_000.0)
+    box_legs = [
+        _option_position(
+            "SPX",
+            -1,
+            market_value=-1_200_000.0,
+            strike=5_000.0,
+            right="C",
+            expiry="20260716",
+            con_id=901,
+        ),
+        _option_position(
+            "SPX",
+            1,
+            market_value=2_000.0,
+            strike=5_000.0,
+            right="P",
+            expiry="20260716",
+            con_id=902,
+        ),
+        _option_position(
+            "SPX",
+            1,
+            market_value=700_000.0,
+            strike=5_100.0,
+            right="C",
+            expiry="20260716",
+            con_id=903,
+        ),
+        _option_position(
+            "SPX",
+            -1,
+            market_value=-2_000.0,
+            strike=5_100.0,
+            right="P",
+            expiry="20260716",
+            con_id=904,
+        ),
+    ]
+    portfolio_manager.ibkr.ib.portfolio.return_value = [
+        tail_put,
+        manual_regime_option,
+        cash_fund,
+        *box_legs,
+    ]
+    _set_tail_quotes(portfolio_manager, mocker, {801: 47.0})
+
+    await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 1)],
+        net_liquidation=100_000.0,
+        market_prices={"AAA": 100.0, "BBB": 100.0},
+        regime_summary=[{"symbol": "BBB"}],
+        hard_underweight_symbols={"BBB"},
+        cohorts=state.open_cohorts,
+    )
+
+    assert len(portfolio_manager.orders.records()) == 1
+    telemetry = portfolio_manager.data_store.get_last_event_payload(
+        TAIL_HEDGE_HARVEST_EVENT,
+        symbol="BBB",
+    )
+    assert telemetry is not None
+    assert telemetry["net_liquidation"] == 100_000.0
+    assert telemetry["excluded_option_value"] == 9_700.0
+    assert telemetry["regime_rebalance_base"] == 90_300
+    assert telemetry["sleeve_weight"] == pytest.approx(4_700.0 / 90_300.0)
 
 
 @pytest.mark.asyncio
@@ -3901,40 +3994,7 @@ async def test_harvest_does_not_queue_sell_when_recovery_intent_cannot_persist(
 
 
 @pytest.mark.asyncio
-async def test_cash_balance_does_not_gate_tail_harvest(
-    portfolio_manager_with_db,
-    mocker,
-):
-    portfolio_manager = portfolio_manager_with_db
-    _configure_tail_harvest(portfolio_manager, "BBB")
-    tail_put = _option_position(
-        "BBB",
-        1,
-        market_value=120.0,
-        right="P",
-        expiry="20261120",
-        con_id=801,
-        average_cost=50.0,
-    )
-    tail_put.contract.multiplier = "100"
-    _set_live_tail_positions(portfolio_manager, [tail_put], cash=1_000_000.0)
-    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
-
-    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
-        orders=[("BBB", "NYSE", 1)],
-        net_liquidation=2_000.0,
-        market_prices={"BBB": 100.0},
-        regime_summary=[{"symbol": "BBB"}],
-        hard_underweight_symbols={"BBB"},
-        cohorts=_tail_state(symbol="BBB", puts=[tail_put]).open_cohorts,
-    )
-
-    assert orders == [("BBB", "NYSE", 1)]
-    assert len(portfolio_manager.orders.records()) == 1
-
-
-@pytest.mark.asyncio
-async def test_ambiguous_unrelated_working_buy_does_not_block_tail_harvest(
+async def test_unrelated_working_stock_order_does_not_block_tail_harvest(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -3980,61 +4040,12 @@ async def test_ambiguous_unrelated_working_buy_does_not_block_tail_harvest(
 
 
 @pytest.mark.asyncio
-async def test_unrelated_market_buy_does_not_block_tail_harvest(
-    portfolio_manager_with_db,
-    mocker,
-):
-    portfolio_manager = portfolio_manager_with_db
-    _configure_tail_harvest(portfolio_manager, "BBB")
-    tail_put = _option_position(
-        "BBB",
-        1,
-        market_value=120.0,
-        right="P",
-        expiry="20261120",
-        con_id=801,
-        average_cost=50.0,
-    )
-    tail_put.contract.multiplier = "100"
-    _set_live_tail_positions(portfolio_manager, [tail_put])
-    portfolio_manager.ibkr.ib.openTrades.return_value = [
-        SimpleNamespace(
-            contract=Stock("AAA", "SMART", "USD"),
-            order=MarketOrder("BUY", 1, account="TEST123"),
-            orderStatus=SimpleNamespace(remaining=1),
-            isDone=lambda: False,
-        )
-    ]
-    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
-
-    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
-        orders=[("BBB", "NYSE", 1)],
-        net_liquidation=2_000.0,
-        market_prices={"BBB": 100.0},
-        regime_summary=[{"symbol": "BBB"}],
-        hard_underweight_symbols={"BBB"},
-        cohorts=_tail_state(symbol="BBB", puts=[tail_put]).open_cohorts,
-    )
-
-    assert orders == [("BBB", "NYSE", 1)]
-    assert len(portfolio_manager.orders.records()) == 1
-    portfolio_manager.ibkr.get_ticker_for_contract.assert_awaited_once()
-
-
-@pytest.mark.asyncio
 async def test_harvest_rereads_replacement_ib_async_cache_objects(
     portfolio_manager_with_db,
     mocker,
 ):
     portfolio_manager = portfolio_manager_with_db
     _configure_tail_harvest(portfolio_manager, "BBB")
-    _enable_cash_management_stage(portfolio_manager)
-    portfolio_manager.config.strategies.cash_management = SimpleNamespace(
-        enabled=True,
-        cash_fund="SHV",
-        target_cash_balance=0.0,
-    )
-
     live_put = _option_position(
         "BBB",
         1,
@@ -4047,18 +4058,12 @@ async def test_harvest_rereads_replacement_ib_async_cache_objects(
     live_put.contract.multiplier = "100"
     live_state = _tail_state(symbol="BBB", puts=[live_put])
     _save_tail_state(portfolio_manager, live_state)
-    cash_fund = _stock_position("SHV", 1, market_value=50.0)
-    cash_fund.contract.conId = 901
 
     live_ib = IB()
-    live_ib.wrapper.accountValues[("TEST123", "TotalCashValue", "BASE", "")] = (
-        AccountValue("TEST123", "TotalCashValue", "50", "BASE", "")
-    )
     live_ib.wrapper.accountValues[("TEST123", "NetLiquidation", "BASE", "")] = (
         AccountValue("TEST123", "NetLiquidation", "2000", "BASE", "")
     )
     live_ib.wrapper.portfolio["TEST123"][802] = live_put
-    live_ib.wrapper.portfolio["TEST123"][901] = cash_fund
     account_values = mocker.spy(live_ib, "accountValues")
     account_summary_async = mocker.spy(live_ib, "accountSummaryAsync")
     request_positions = mocker.spy(live_ib, "reqPositionsAsync")
@@ -4082,6 +4087,92 @@ async def test_harvest_rereads_replacement_ib_async_cache_objects(
     assert account_values.call_args_list == [mocker.call("TEST123")] * 2
     account_summary_async.assert_not_called()
     request_positions.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("late_working_sale", [False, True])
+async def test_harvest_revalidates_earlier_candidates_after_all_quotes(
+    portfolio_manager_with_db,
+    mocker,
+    late_working_sale,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "AAA", "BBB")
+    stale_put = _option_position(
+        "AAA",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    live_put = _option_position(
+        "BBB",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261218",
+        con_id=802,
+        average_cost=50.0,
+    )
+    stale_put.contract.multiplier = live_put.contract.multiplier = "100"
+    _set_live_tail_positions(portfolio_manager, [stale_put, live_put])
+
+    async def quote(contract, **_kwargs):
+        if contract.conId == 802:
+            portfolio_manager.ibkr.ib.portfolio.return_value = [live_put]
+            if late_working_sale:
+                portfolio_manager.ibkr.ib.openTrades.return_value = [
+                    SimpleNamespace(
+                        contract=stale_put.contract,
+                        order=SimpleNamespace(
+                            account="TEST123",
+                            action="SELL",
+                            orderRef=None,
+                        ),
+                        isDone=lambda: False,
+                    )
+                ]
+        return _option_ticker(1.20)
+
+    portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock(side_effect=quote)
+    store = portfolio_manager.regime_engine._tail_state_store
+    assert store is not None
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("AAA", "NYSE", 1), ("BBB", "NYSE", 1)],
+        net_liquidation=2_000.0,
+        market_prices={"AAA": 100.0, "BBB": 100.0},
+        regime_summary=[{"symbol": "AAA"}, {"symbol": "BBB"}],
+        hard_underweight_symbols={"AAA", "BBB"},
+        cohorts=store.load().open_cohorts,
+    )
+
+    assert orders == [("AAA", "NYSE", 1), ("BBB", "NYSE", 1)]
+    queued_con_ids = [
+        contract.conId
+        for contract, _order, _intent_id in portfolio_manager.orders.records()
+    ]
+    state = store.load()
+    stale_cohort = state.find_open_by_con_id(801)
+    live_cohort = state.find_open_by_con_id(802)
+    assert stale_cohort is not None and not stale_cohort.has_pending_recovery
+    assert live_cohort is not None
+    if late_working_sale:
+        assert queued_con_ids == []
+        assert not live_cohort.has_pending_recovery
+        telemetry = portfolio_manager.data_store.get_last_event_payload(
+            TAIL_HEDGE_HARVEST_EVENT,
+            symbol="BBB",
+        )
+        assert telemetry is not None
+        assert telemetry["outcome"] == "harvest_blocked"
+        assert telemetry["reason"] == "working_tail_sale"
+        assert telemetry["blocking_symbols"] == ["AAA"]
+    else:
+        assert queued_con_ids == [802]
+        assert live_cohort.has_pending_recovery
 
 
 @pytest.mark.asyncio
@@ -4133,6 +4224,43 @@ async def test_harvest_rechecks_band_after_quotes_before_saving_intent(
     store = portfolio_manager.regime_engine._tail_state_store
     assert store is not None
     assert not store.load().open_cohorts[0].has_pending_recovery
+
+
+@pytest.mark.asyncio
+async def test_harvest_rechecks_band_with_fresh_quote_value(
+    portfolio_manager_with_db,
+    mocker,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    tail_put = _option_position(
+        "BBB",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    tail_put.contract.multiplier = "100"
+    _set_live_tail_positions(portfolio_manager, [tail_put])
+    _set_tail_quotes(portfolio_manager, mocker, {801: 1.00})
+    store = portfolio_manager.regime_engine._tail_state_store
+    assert store is not None
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 1)],
+        net_liquidation=2_100.0,
+        market_prices={"BBB": 100.0},
+        regime_summary=[{"symbol": "BBB"}],
+        hard_underweight_symbols={"BBB"},
+        cohorts=store.load().open_cohorts,
+    )
+
+    assert orders == [("BBB", "NYSE", 1)]
+    assert portfolio_manager.orders.records() == []
+    cohort = store.load().find_open_by_con_id(801)
+    assert cohort is not None and not cohort.has_pending_recovery
 
 
 @pytest.mark.asyncio
@@ -4303,7 +4431,7 @@ async def test_harvest_keeps_full_rebalance_when_tranche_covers_only_part(
         average_cost=50.0,
     )
     tail_put.contract.multiplier = "100"
-    _set_live_tail_positions(portfolio_manager, [tail_put], cash=200.0)
+    _set_live_tail_positions(portfolio_manager, [tail_put])
     _set_tail_quotes(portfolio_manager, mocker, {801: 1.0})
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
@@ -4381,130 +4509,11 @@ async def test_harvest_ignores_cash_and_requires_hard_underweight(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    (
-        "cash_fund_value",
-        "sell_threshold",
-        "cash_stage_enabled",
-        "expected_stock_quantity",
-        "put_sales",
-    ),
-    [
-        (250.0, 100.0, True, 2, 2),
-        (50.0, 100.0, True, 2, 2),
-        (50.0, 200.0, True, 2, 2),
-        (250.0, 100.0, False, 2, 2),
-    ],
-)
-async def test_cash_fund_and_tolerance_do_not_affect_tail_harvest(
-    portfolio_manager_with_db,
-    mocker,
-    cash_fund_value,
-    sell_threshold,
-    cash_stage_enabled,
-    expected_stock_quantity,
-    put_sales,
-):
-    portfolio_manager = portfolio_manager_with_db
-    _configure_tail_harvest(portfolio_manager, "BBB")
-    _enable_cash_management_stage(portfolio_manager, cash_stage_enabled)
-    portfolio_manager.config.strategies.cash_management = SimpleNamespace(
-        enabled=True,
-        cash_fund="SHV",
-        target_cash_balance=50.0,
-        sell_threshold=sell_threshold,
-    )
-    tail_put = _option_position(
-        "BBB",
-        2,
-        market_value=240.0,
-        right="P",
-        expiry="20261120",
-        con_id=801,
-        average_cost=50.0,
-    )
-    tail_put.contract.multiplier = "100"
-    positions = {
-        "BBB": [tail_put],
-        "SHV": [_stock_position("SHV", 2, market_value=cash_fund_value)],
-    }
-    _set_live_tail_positions(
-        portfolio_manager,
-        [
-            position
-            for symbol_positions in positions.values()
-            for position in symbol_positions
-        ],
-    )
-    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
-
-    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
-        orders=[("BBB", "NYSE", 2)],
-        net_liquidation=2_000.0,
-        market_prices={"BBB": 100.0},
-        regime_summary=[{"symbol": "BBB"}],
-        hard_underweight_symbols={"BBB"},
-        cohorts=_tail_state(symbol="BBB", puts=[tail_put]).open_cohorts,
-    )
-
-    expected_orders = (
-        [("BBB", "NYSE", expected_stock_quantity)] if expected_stock_quantity else []
-    )
-    assert orders == expected_orders
-    queued_harvests = [
-        order
-        for contract, order, _intent_id in portfolio_manager.orders.records()
-        if isinstance(contract, Option)
-    ]
-    assert sum(int(order.totalQuantity) for order in queued_harvests) == put_sales
-
-
-@pytest.mark.asyncio
-async def test_fractional_cash_fund_value_does_not_affect_tail_harvest(
-    portfolio_manager_with_db,
-    mocker,
-):
-    portfolio_manager = portfolio_manager_with_db
-    _configure_tail_harvest(portfolio_manager, "BBB")
-    _enable_cash_management_stage(portfolio_manager)
-    portfolio_manager.config.strategies.cash_management = SimpleNamespace(
-        enabled=True,
-        cash_fund="SHV",
-        target_cash_balance=0.0,
-        sell_threshold=0.0,
-    )
-    tail_put = _option_position(
-        "BBB",
-        1,
-        market_value=120.0,
-        right="P",
-        expiry="20261120",
-        con_id=801,
-        average_cost=50.0,
-    )
-    tail_put.contract.multiplier = "100"
-    cash_fund = _stock_position("SHV", 1.5, market_value=150.0)
-    _set_live_tail_positions(portfolio_manager, [tail_put, cash_fund], cash=50.0)
-    _set_tail_quotes(portfolio_manager, mocker, {801: 1.2})
-
-    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
-        orders=[("BBB", "NYSE", 2)],
-        net_liquidation=2_000.0,
-        market_prices={"BBB": 100.0},
-        regime_summary=[{"symbol": "BBB"}],
-        hard_underweight_symbols={"BBB"},
-        cohorts=_tail_state(symbol="BBB", puts=[tail_put]).open_cohorts,
-    )
-
-    assert orders == [("BBB", "NYSE", 2)]
-    assert len(portfolio_manager.orders.records()) == 1
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
     ("source", "order_ref"),
     [
         ("broker", f"{TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX}:BBB:801"),
         ("broker", TAIL_HEDGE_CLOSE_ORDER_REF),
+        ("broker", None),
         ("local", TAIL_HEDGE_CLOSE_ORDER_REF),
     ],
 )
@@ -4526,7 +4535,7 @@ async def test_working_tail_sale_blocks_duplicate_without_changing_rebalance(
         average_cost=50.0,
     )
     tail_put.contract.multiplier = "100"
-    _set_live_tail_positions(portfolio_manager, [tail_put], cash=100.0)
+    _set_live_tail_positions(portfolio_manager, [tail_put])
     working_order = SimpleNamespace(
         account="TEST123",
         action="SELL",
@@ -4561,19 +4570,9 @@ async def test_working_tail_sale_blocks_duplicate_without_changing_rebalance(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("entry_limit_price", "expected_orders", "put_sales"),
-    [
-        (0.5, [("BBB", "NYSE", 1)], 1),
-        (float("nan"), [("BBB", "NYSE", 1)], 0),
-    ],
-)
-async def test_nan_live_cost_uses_only_a_finite_entry_limit_basis(
+async def test_nan_live_cost_uses_persisted_entry_limit_basis(
     portfolio_manager_with_db,
     mocker,
-    entry_limit_price,
-    expected_orders,
-    put_sales,
 ):
     portfolio_manager = portfolio_manager_with_db
     _configure_tail_harvest(portfolio_manager, "BBB")
@@ -4587,10 +4586,10 @@ async def test_nan_live_cost_uses_only_a_finite_entry_limit_basis(
         average_cost=float("nan"),
     )
     tail_put.contract.multiplier = "100"
-    cohorts = _tail_state(symbol="BBB", puts=[tail_put]).open_cohorts
-    cohorts[0].entry_limit_price = entry_limit_price
     _set_live_tail_positions(portfolio_manager, [tail_put])
     _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
+    store = portfolio_manager.regime_engine._tail_state_store
+    assert store is not None
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
@@ -4598,11 +4597,11 @@ async def test_nan_live_cost_uses_only_a_finite_entry_limit_basis(
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
-        cohorts=cohorts,
+        cohorts=store.load().open_cohorts,
     )
 
-    assert orders == expected_orders
-    assert len(portfolio_manager.orders.records()) == put_sales
+    assert orders == [("BBB", "NYSE", 1)]
+    assert len(portfolio_manager.orders.records()) == 1
 
 
 @pytest.mark.asyncio
@@ -4710,7 +4709,7 @@ async def test_harvest_combines_eligible_symbols_for_portfolio_band(
         average_cost=50.0,
     )
     aaa_put.contract.multiplier = bbb_put.contract.multiplier = "100"
-    _set_live_tail_positions(portfolio_manager, [aaa_put, bbb_put], cash=150.0)
+    _set_live_tail_positions(portfolio_manager, [aaa_put, bbb_put])
     _set_tail_quotes(portfolio_manager, mocker, {801: 1.20, 802: 1.20})
     cohorts = [
         *_tail_state(symbol="AAA", puts=[aaa_put]).open_cohorts,

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1249,6 +1249,45 @@ async def test_regime_rebalance_volatility_weight_state_payload_fields(
     }
 
 
+@pytest.mark.parametrize(
+    ("state_quantity", "live_quantity", "market_value", "expected_value"),
+    [
+        (1, 2, 240.0, 120.0),
+        (2, 1, 120.0, 120.0),
+        (1, float("nan"), 120.0, 0.0),
+        (1, 2, float("nan"), 0.0),
+    ],
+)
+def test_tail_hedge_market_value_counts_only_state_owned_quantity(
+    state_quantity,
+    live_quantity,
+    market_value,
+    expected_value,
+):
+    state_position = _option_position(
+        "BBB",
+        state_quantity,
+        market_value=120.0,
+        right="P",
+        con_id=801,
+        average_cost=50.0,
+    )
+    cohort = _tail_state(symbol="BBB", puts=[state_position]).open_cohorts[0]
+    live_position = _option_position(
+        "BBB",
+        live_quantity,
+        market_value=market_value,
+        right="P",
+        con_id=801,
+        average_cost=50.0,
+    )
+
+    assert regime_engine_module.RegimeRebalanceEngine._tail_hedge_market_value(
+        {"BBB": [live_position]},
+        [cohort],
+    ) == pytest.approx(expected_value)
+
+
 @pytest.mark.asyncio
 async def test_regime_rebalance_excludes_options_and_cash_fund_from_base(
     portfolio_manager, mocker

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -3396,6 +3396,8 @@ def _configure_tail_harvest(
 ) -> None:
     portfolio_manager.config.strategies.tail_hedge = SimpleNamespace(
         enabled=True,
+        harvest_trigger_weight=0.05,
+        harvest_target_weight=0.03,
         targets=[_tail_target(symbol) for symbol in symbols],
     )
     _enable_tail_hedge_stage(portfolio_manager)
@@ -3459,22 +3461,21 @@ async def test_harvest_persists_recovery_intent(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=payload.open_cohorts,
     )
 
-    assert orders == []
+    assert orders == [("BBB", "NYSE", 1)]
     queued_order = portfolio_manager.orders.records()[0][1]
-    assert getattr(queued_order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR) == pytest.approx(0.51)
+    assert getattr(queued_order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR) == pytest.approx(1.01)
     store = portfolio_manager.regime_engine._tail_state_store
     assert store is not None
     state = store.load()
     assert state.open_cohorts[0].pending_recovery_quantity == 1
-    assert state.open_cohorts[0].pending_recovery_per_contract == 51.0
+    assert state.open_cohorts[0].pending_recovery_per_contract == 101.0
     assert isinstance(state.open_cohorts[0].pending_recovery_enqueued_at, datetime)
     assert state.open_cohorts[0].pending_recovery_initial_quantity == 1
     telemetry = portfolio_manager.data_store.get_last_event_payload(
@@ -3486,8 +3487,85 @@ async def test_harvest_persists_recovery_intent(
     assert telemetry["gross_proceeds"] == 120.0
     assert telemetry["estimated_fees"] == 0.0
     assert telemetry["net_proceeds"] == 120.0
-    assert telemetry["required_proceeds"] == 100.0
-    assert telemetry["excess_proceeds"] == 20.0
+    assert telemetry["minimum_limit_price"] == 1.01
+    assert telemetry["minimum_net_proceeds_per_contract"] == 101.0
+    assert telemetry["rebalance_shares"] == 1
+    assert telemetry["sleeve_value"] == 120.0
+    assert telemetry["sleeve_weight"] == pytest.approx(0.06)
+    assert telemetry["sale_budget"] == 60.0
+    assert telemetry["harvest_trigger_weight"] == 0.05
+    assert telemetry["harvest_target_weight"] == 0.03
+
+
+@pytest.mark.asyncio
+async def test_harvest_band_does_not_trigger_at_upper_bound(
+    portfolio_manager_with_db,
+    mocker,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    tail_put = _option_position(
+        "BBB",
+        1,
+        market_value=100.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    tail_put.contract.multiplier = "100"
+    state = _tail_state(symbol="BBB", puts=[tail_put])
+    _set_live_tail_positions(portfolio_manager, [tail_put])
+    portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock()
+
+    await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 1)],
+        net_liquidation=2_000.0,
+        market_prices={"BBB": 100.0},
+        regime_summary=[{"symbol": "BBB"}],
+        hard_underweight_symbols={"BBB"},
+        cohorts=state.open_cohorts,
+    )
+
+    assert portfolio_manager.orders.records() == []
+    portfolio_manager.ibkr.get_ticker_for_contract.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_harvest_band_sizes_contracts_by_market_value_not_net_cash(
+    portfolio_manager_with_db,
+    mocker,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    portfolio_manager.config.runtime.orders.estimated_fee_per_contract = 1.0
+    tail_put = _option_position(
+        "BBB",
+        2,
+        market_value=240.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    tail_put.contract.multiplier = "100"
+    state = _tail_state(symbol="BBB", puts=[tail_put])
+    _set_live_tail_positions(portfolio_manager, [tail_put])
+    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 1)],
+        net_liquidation=4_000.0,
+        market_prices={"BBB": 100.0},
+        regime_summary=[{"symbol": "BBB"}],
+        hard_underweight_symbols={"BBB"},
+        cohorts=state.open_cohorts,
+    )
+
+    assert orders == [("BBB", "NYSE", 1)]
+    queued = portfolio_manager.orders.records()
+    assert len(queued) == 1
+    assert int(queued[0][1].totalQuantity) == 1
 
 
 @pytest.mark.asyncio
@@ -3534,22 +3612,21 @@ async def test_pending_recovery_serializes_same_symbol_harvests(
     assert store is not None
     first_orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [next_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=store.load().open_cohorts,
     )
 
-    assert first_orders == []
+    assert first_orders == [("BBB", "NYSE", 1)]
     assert portfolio_manager.orders.records() == []
     telemetry = portfolio_manager.data_store.get_last_event_payload(
         TAIL_HEDGE_HARVEST_EVENT,
         symbol="BBB",
     )
     assert telemetry is not None
-    assert telemetry["outcome"] == "harvest_deferred"
+    assert telemetry["outcome"] == "harvest_blocked"
     assert telemetry["reason"] == "pending_recovery"
 
     reconciled = store.load()
@@ -3563,19 +3640,87 @@ async def test_pending_recovery_serializes_same_symbol_harvests(
 
     next_orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [next_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=store.load().open_cohorts,
     )
 
-    assert next_orders == []
+    assert next_orders == [("BBB", "NYSE", 1)]
     assert [
         contract.conId
         for contract, _order, _intent_id in portfolio_manager.orders.records()
     ] == [802]
+
+
+@pytest.mark.asyncio
+async def test_pending_recovery_serializes_portfolio_wide_harvests(
+    portfolio_manager_with_db,
+    mocker,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "AAA", "BBB")
+    aaa_put = _option_position(
+        "AAA",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    bbb_put = _option_position(
+        "BBB",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261218",
+        con_id=802,
+        average_cost=50.0,
+    )
+    aaa_put.contract.multiplier = bbb_put.contract.multiplier = "100"
+    _save_tail_state(
+        portfolio_manager,
+        _tail_state(symbol="AAA", puts=[aaa_put]),
+        _tail_state(symbol="BBB", puts=[bbb_put]),
+    )
+    store = portfolio_manager.regime_engine._tail_state_store
+    assert store is not None
+    state = store.load()
+    bbb_cohort = state.find_open_by_con_id(802)
+    assert bbb_cohort is not None
+    bbb_cohort.begin_recovery(
+        quantity=1,
+        proceeds_per_contract=120.0,
+        enqueued_at=datetime.now() - timedelta(minutes=10),
+    )
+    store.save(state)
+    portfolio_manager.ibkr.ib.portfolio.return_value = [aaa_put, bbb_put]
+    portfolio_manager.ibkr.ib.openTrades.return_value = []
+    portfolio_manager.ibkr.ib.accountValues.return_value = []
+    portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock()
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("AAA", "NYSE", 1)],
+        net_liquidation=2_000.0,
+        market_prices={"AAA": 100.0},
+        regime_summary=[{"symbol": "AAA"}],
+        hard_underweight_symbols={"AAA"},
+        cohorts=store.load().open_cohorts,
+    )
+
+    assert orders == [("AAA", "NYSE", 1)]
+    assert portfolio_manager.orders.records() == []
+    portfolio_manager.ibkr.get_ticker_for_contract.assert_not_awaited()
+    telemetry = portfolio_manager.data_store.get_last_event_payload(
+        TAIL_HEDGE_HARVEST_EVENT,
+        symbol="AAA",
+    )
+    assert telemetry is not None
+    assert telemetry["outcome"] == "harvest_blocked"
+    assert telemetry["reason"] == "pending_recovery"
+    assert telemetry["blocking_symbols"] == ["BBB"]
 
 
 @pytest.mark.asyncio
@@ -3605,8 +3750,7 @@ async def test_harvest_profitability_includes_estimated_broker_fee(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=1_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -3659,15 +3803,14 @@ async def test_harvest_does_not_credit_a_pre_submission_position_change(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [live_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=payload.open_cohorts,
     )
 
-    assert orders == []
+    assert orders == [("BBB", "NYSE", 1)]
     await portfolio_manager.post_engine.tail_hedge_engine.manage(
         {"BBB": [live_put]},
         net_liquidation=200.0,
@@ -3678,7 +3821,7 @@ async def test_harvest_does_not_credit_a_pre_submission_position_change(
     cohort = store.load().open_cohorts[0]
     assert cohort.quantity == 2
     assert cohort.recovered_cost == 0.0
-    assert cohort.pending_recovery_quantity == 1
+    assert cohort.pending_recovery_quantity == 2
 
 
 @pytest.mark.asyncio
@@ -3705,8 +3848,7 @@ async def test_harvest_requires_fresh_persisted_ownership(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -3747,8 +3889,7 @@ async def test_harvest_does_not_queue_sell_when_recovery_intent_cannot_persist(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -3759,38 +3900,41 @@ async def test_harvest_does_not_queue_sell_when_recovery_intent_cannot_persist(
     assert portfolio_manager.orders.records() == []
 
 
-def test_partial_broker_working_buy_reserves_only_remaining_debit(
+@pytest.mark.asyncio
+async def test_cash_balance_does_not_gate_tail_harvest(
     portfolio_manager_with_db,
+    mocker,
 ):
     portfolio_manager = portfolio_manager_with_db
-    working_put = Option("AAA", "20270115", 50.0, "P", "SMART")
-    working_put.multiplier = "100"
-    portfolio_manager.ibkr.ib.openTrades.return_value = [
-        SimpleNamespace(
-            contract=working_put,
-            order=SimpleNamespace(
-                account="TEST123",
-                action="BUY",
-                lmtPrice=1.0,
-                totalQuantity=1,
-            ),
-            orderStatus=SimpleNamespace(remaining=0.25),
-            isDone=lambda: False,
-        )
-    ]
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    tail_put = _option_position(
+        "BBB",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    tail_put.contract.multiplier = "100"
+    _set_live_tail_positions(portfolio_manager, [tail_put], cash=1_000_000.0)
+    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
 
-    shortfall = portfolio_manager.regime_engine._ordinary_rebalance_shortfall(
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("500", cash="100"),
-        portfolio_positions={},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
+        regime_summary=[{"symbol": "BBB"}],
+        hard_underweight_symbols={"BBB"},
+        cohorts=_tail_state(symbol="BBB", puts=[tail_put]).open_cohorts,
     )
 
-    assert shortfall == 25.0
+    assert orders == [("BBB", "NYSE", 1)]
+    assert len(portfolio_manager.orders.records()) == 1
 
 
 @pytest.mark.asyncio
-async def test_ambiguous_working_buy_skips_tail_harvest(
+async def test_ambiguous_unrelated_working_buy_does_not_block_tail_harvest(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -3820,12 +3964,11 @@ async def test_ambiguous_working_buy_skips_tail_harvest(
             isDone=lambda: False,
         )
     ]
-    portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock()
+    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -3833,11 +3976,11 @@ async def test_ambiguous_working_buy_skips_tail_harvest(
     )
 
     assert orders == [("BBB", "NYSE", 1)]
-    assert portfolio_manager.orders.records() == []
+    assert len(portfolio_manager.orders.records()) == 1
 
 
 @pytest.mark.asyncio
-async def test_market_buy_skips_tail_harvest(
+async def test_unrelated_market_buy_does_not_block_tail_harvest(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -3862,12 +4005,11 @@ async def test_market_buy_skips_tail_harvest(
             isDone=lambda: False,
         )
     ]
-    portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock()
+    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -3875,8 +4017,8 @@ async def test_market_buy_skips_tail_harvest(
     )
 
     assert orders == [("BBB", "NYSE", 1)]
-    assert portfolio_manager.orders.records() == []
-    portfolio_manager.ibkr.get_ticker_for_contract.assert_not_awaited()
+    assert len(portfolio_manager.orders.records()) == 1
+    portfolio_manager.ibkr.get_ticker_for_contract.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -3905,21 +4047,15 @@ async def test_harvest_rereads_replacement_ib_async_cache_objects(
     live_put.contract.multiplier = "100"
     live_state = _tail_state(symbol="BBB", puts=[live_put])
     _save_tail_state(portfolio_manager, live_state)
-    stale_put = _option_position(
-        "BBB",
-        1,
-        market_value=60.0,
-        right="P",
-        expiry="20261120",
-        con_id=801,
-        average_cost=50.0,
-    )
     cash_fund = _stock_position("SHV", 1, market_value=50.0)
     cash_fund.contract.conId = 901
 
     live_ib = IB()
     live_ib.wrapper.accountValues[("TEST123", "TotalCashValue", "BASE", "")] = (
         AccountValue("TEST123", "TotalCashValue", "50", "BASE", "")
+    )
+    live_ib.wrapper.accountValues[("TEST123", "NetLiquidation", "BASE", "")] = (
+        AccountValue("TEST123", "NetLiquidation", "2000", "BASE", "")
     )
     live_ib.wrapper.portfolio["TEST123"][802] = live_put
     live_ib.wrapper.portfolio["TEST123"][901] = cash_fund
@@ -3931,26 +4067,157 @@ async def test_harvest_rereads_replacement_ib_async_cache_objects(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 2)],
-        account_summary=_regime_account_summary("500", cash="0"),
-        portfolio_positions={"BBB": [stale_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=live_state.open_cohorts,
     )
 
-    assert orders == [("BBB", "NYSE", 1)]
+    assert orders == [("BBB", "NYSE", 2)]
     assert [
         contract.conId
         for contract, _order, _intent_id in portfolio_manager.orders.records()
     ] == [802]
-    account_values.assert_called_once_with("TEST123")
+    assert account_values.call_args_list == [mocker.call("TEST123")] * 2
     account_summary_async.assert_not_called()
     request_positions.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_harvest_stages_one_shortest_tranche_during_large_shortfall(
+async def test_harvest_rechecks_band_after_quotes_before_saving_intent(
+    portfolio_manager_with_db,
+    mocker,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    before_quote = _option_position(
+        "BBB",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    after_quote = _option_position(
+        "BBB",
+        1,
+        market_value=80.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    before_quote.contract.multiplier = after_quote.contract.multiplier = "100"
+    state = _tail_state(symbol="BBB", puts=[before_quote])
+    _set_live_tail_positions(portfolio_manager, [before_quote])
+
+    async def quote(_contract, **_kwargs):
+        portfolio_manager.ibkr.ib.portfolio.return_value = [after_quote]
+        return _option_ticker(1.20)
+
+    portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock(side_effect=quote)
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 1)],
+        net_liquidation=2_000.0,
+        market_prices={"BBB": 100.0},
+        regime_summary=[{"symbol": "BBB"}],
+        hard_underweight_symbols={"BBB"},
+        cohorts=state.open_cohorts,
+    )
+
+    assert orders == [("BBB", "NYSE", 1)]
+    assert portfolio_manager.orders.records() == []
+    store = portfolio_manager.regime_engine._tail_state_store
+    assert store is not None
+    assert not store.load().open_cohorts[0].has_pending_recovery
+
+
+@pytest.mark.asyncio
+async def test_harvest_rechecks_net_liquidation_after_quotes(
+    portfolio_manager_with_db,
+    mocker,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    tail_put = _option_position(
+        "BBB",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    tail_put.contract.multiplier = "100"
+    state = _tail_state(symbol="BBB", puts=[tail_put])
+    _set_live_tail_positions(portfolio_manager, [tail_put])
+    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
+    portfolio_manager.ibkr.cached_net_liquidation = mocker.Mock(
+        side_effect=[2_000.0, 3_000.0]
+    )
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 1)],
+        net_liquidation=2_000.0,
+        market_prices={"BBB": 100.0},
+        regime_summary=[{"symbol": "BBB"}],
+        hard_underweight_symbols={"BBB"},
+        cohorts=state.open_cohorts,
+    )
+
+    assert orders == [("BBB", "NYSE", 1)]
+    assert portfolio_manager.orders.records() == []
+    assert portfolio_manager.ibkr.cached_net_liquidation.call_args_list == [
+        mocker.call("TEST123"),
+        mocker.call("TEST123"),
+    ]
+    store = portfolio_manager.regime_engine._tail_state_store
+    assert store is not None
+    assert not store.load().open_cohorts[0].has_pending_recovery
+
+
+@pytest.mark.asyncio
+async def test_harvest_uses_current_net_liquidation_for_initial_band_gate(
+    portfolio_manager_with_db,
+    mocker,
+):
+    portfolio_manager = portfolio_manager_with_db
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    tail_put = _option_position(
+        "BBB",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261120",
+        con_id=801,
+        average_cost=50.0,
+    )
+    tail_put.contract.multiplier = "100"
+    state = _tail_state(symbol="BBB", puts=[tail_put])
+    _set_live_tail_positions(portfolio_manager, [tail_put])
+    _set_tail_quotes(portfolio_manager, mocker, {801: 1.20})
+    portfolio_manager.ibkr.cached_net_liquidation = mocker.Mock(return_value=2_000.0)
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 1)],
+        net_liquidation=3_000.0,
+        market_prices={"BBB": 100.0},
+        regime_summary=[{"symbol": "BBB"}],
+        hard_underweight_symbols={"BBB"},
+        cohorts=state.open_cohorts,
+    )
+
+    assert orders == [("BBB", "NYSE", 1)]
+    assert len(portfolio_manager.orders.records()) == 1
+    assert portfolio_manager.ibkr.get_ticker_for_contract.await_count == 1
+    assert portfolio_manager.ibkr.cached_net_liquidation.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_harvest_sells_earliest_cohorts_toward_band_target(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -3991,8 +4258,7 @@ async def test_harvest_stages_one_shortest_tranche_during_large_shortfall(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 3)],
-        account_summary=_regime_account_summary("500", cash="0"),
-        portfolio_positions=positions,
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -4002,10 +4268,18 @@ async def test_harvest_stages_one_shortest_tranche_during_large_shortfall(
         ).open_cohorts,
     )
 
-    assert orders == []
+    assert orders == [("BBB", "NYSE", 3)]
     queued = portfolio_manager.orders.records()
-    assert [contract.conId for contract, _order, _intent_id in queued] == [801]
-    assert [int(order.totalQuantity) for _contract, order, _intent_id in queued] == [1]
+    assert [contract.conId for contract, _order, _intent_id in queued] == [
+        801,
+        802,
+        803,
+    ]
+    assert [int(order.totalQuantity) for _contract, order, _intent_id in queued] == [
+        1,
+        1,
+        1,
+    ]
     assert all(
         order.orderRef.startswith(f"{TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX}:BBB:")
         for _contract, order, _intent_id in queued
@@ -4013,7 +4287,7 @@ async def test_harvest_stages_one_shortest_tranche_during_large_shortfall(
 
 
 @pytest.mark.asyncio
-async def test_harvest_defers_all_unfunded_shares_when_tranche_covers_only_part(
+async def test_harvest_keeps_full_rebalance_when_tranche_covers_only_part(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -4034,15 +4308,14 @@ async def test_harvest_defers_all_unfunded_shares_when_tranche_covers_only_part(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 20)],
-        account_summary=_regime_account_summary("2500", cash="200"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=_tail_state(symbol="BBB", puts=[tail_put]).open_cohorts,
     )
 
-    assert orders == [("BBB", "NYSE", 2)]
+    assert orders == [("BBB", "NYSE", 20)]
     assert [
         int(order.totalQuantity)
         for _contract, order, _intent_id in portfolio_manager.orders.records()
@@ -4051,26 +4324,18 @@ async def test_harvest_defers_all_unfunded_shares_when_tranche_covers_only_part(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    (
-        "first_price",
-        "next_cash",
-        "still_hard",
-        "expected_orders",
-        "expected_sale",
-    ),
+    ("cash", "still_hard", "expected_sale"),
     [
-        (3.0, "300", True, [("BBB", "NYSE", 3)], []),
-        (1.0, "100", True, [("BBB", "NYSE", 1)], [802]),
-        (1.0, "0", False, [("BBB", "NYSE", 3)], []),
+        (300.0, True, [801, 802]),
+        (-500_000.0, True, [801, 802]),
+        (300.0, False, []),
     ],
 )
-async def test_harvest_next_run_uses_cash_then_rechecks_remaining_shortfall(
+async def test_harvest_ignores_cash_and_requires_hard_underweight(
     portfolio_manager_with_db,
     mocker,
-    first_price,
-    next_cash,
+    cash,
     still_hard,
-    expected_orders,
     expected_sale,
 ):
     portfolio_manager = portfolio_manager_with_db
@@ -4095,37 +4360,19 @@ async def test_harvest_next_run_uses_cash_then_rechecks_remaining_shortfall(
     )
     first_put.contract.multiplier = next_put.contract.multiplier = "100"
     cohorts = _tail_state(symbol="BBB", puts=[first_put, next_put]).open_cohorts
-    _set_live_tail_positions(portfolio_manager, [first_put, next_put])
-    _set_tail_quotes(portfolio_manager, mocker, {801: first_price, 802: 1.2})
+    _set_live_tail_positions(portfolio_manager, [first_put, next_put], cash=cash)
+    _set_tail_quotes(portfolio_manager, mocker, {801: 1.2, 802: 1.2})
 
-    first_orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 3)],
-        account_summary=_regime_account_summary("500", cash="0"),
-        portfolio_positions={"BBB": [first_put, next_put]},
-        market_prices={"BBB": 100.0},
-        regime_summary=[{"symbol": "BBB"}],
-        hard_underweight_symbols={"BBB"},
-        cohorts=cohorts,
-    )
-    assert first_orders == []
-    assert [
-        contract.conId
-        for contract, _order, _intent_id in portfolio_manager.orders.records()
-    ] == [801]
-
-    portfolio_manager.orders.records().clear()
-    _set_live_tail_positions(portfolio_manager, [next_put], cash=float(next_cash))
-    next_orders = await portfolio_manager.regime_engine._apply_tail_harvest(
-        orders=[("BBB", "NYSE", 3)],
-        account_summary=_regime_account_summary("500", cash=next_cash),
-        portfolio_positions={"BBB": [next_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"} if still_hard else set(),
         cohorts=cohorts,
     )
 
-    assert next_orders == expected_orders
+    assert orders == [("BBB", "NYSE", 3)]
     assert [
         contract.conId
         for contract, _order, _intent_id in portfolio_manager.orders.records()
@@ -4142,13 +4389,13 @@ async def test_harvest_next_run_uses_cash_then_rechecks_remaining_shortfall(
         "put_sales",
     ),
     [
-        (250.0, 100.0, True, 2, 0),
-        (50.0, 100.0, True, 1, 1),
-        (50.0, 200.0, True, 2, 0),
-        (250.0, 100.0, False, 0, 2),
+        (250.0, 100.0, True, 2, 2),
+        (50.0, 100.0, True, 2, 2),
+        (50.0, 200.0, True, 2, 2),
+        (250.0, 100.0, False, 2, 2),
     ],
 )
-async def test_cash_fund_and_tolerance_bound_harvest_shortfall(
+async def test_cash_fund_and_tolerance_do_not_affect_tail_harvest(
     portfolio_manager_with_db,
     mocker,
     cash_fund_value,
@@ -4192,8 +4439,7 @@ async def test_cash_fund_and_tolerance_bound_harvest_shortfall(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 2)],
-        account_summary=_regime_account_summary("500", cash="0"),
-        portfolio_positions=positions,
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -4213,7 +4459,7 @@ async def test_cash_fund_and_tolerance_bound_harvest_shortfall(
 
 
 @pytest.mark.asyncio
-async def test_cash_fund_capacity_excludes_fractional_unsellable_share(
+async def test_fractional_cash_fund_value_does_not_affect_tail_harvest(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -4237,21 +4483,19 @@ async def test_cash_fund_capacity_excludes_fractional_unsellable_share(
     )
     tail_put.contract.multiplier = "100"
     cash_fund = _stock_position("SHV", 1.5, market_value=150.0)
-    positions = {"BBB": [tail_put], "SHV": [cash_fund]}
     _set_live_tail_positions(portfolio_manager, [tail_put, cash_fund], cash=50.0)
     _set_tail_quotes(portfolio_manager, mocker, {801: 1.2})
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 2)],
-        account_summary=_regime_account_summary("500", cash="50"),
-        portfolio_positions=positions,
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=_tail_state(symbol="BBB", puts=[tail_put]).open_cohorts,
     )
 
-    assert orders == [("BBB", "NYSE", 1)]
+    assert orders == [("BBB", "NYSE", 2)]
     assert len(portfolio_manager.orders.records()) == 1
 
 
@@ -4264,7 +4508,7 @@ async def test_cash_fund_capacity_excludes_fractional_unsellable_share(
         ("local", TAIL_HEDGE_CLOSE_ORDER_REF),
     ],
 )
-async def test_working_tail_sale_keeps_unfunded_shares_deferred(
+async def test_working_tail_sale_blocks_duplicate_without_changing_rebalance(
     portfolio_manager_with_db,
     mocker,
     source,
@@ -4304,15 +4548,14 @@ async def test_working_tail_sale_keeps_unfunded_shares_deferred(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 2)],
-        account_summary=_regime_account_summary("500", cash="100"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=_tail_state(symbol="BBB", puts=[tail_put]).open_cohorts,
     )
 
-    assert orders == [("BBB", "NYSE", 1)]
+    assert orders == [("BBB", "NYSE", 2)]
     assert len(portfolio_manager.orders.records()) == (1 if source == "local" else 0)
     portfolio_manager.ibkr.get_ticker_for_contract.assert_not_awaited()
 
@@ -4321,7 +4564,7 @@ async def test_working_tail_sale_keeps_unfunded_shares_deferred(
 @pytest.mark.parametrize(
     ("entry_limit_price", "expected_orders", "put_sales"),
     [
-        (0.5, [], 1),
+        (0.5, [("BBB", "NYSE", 1)], 1),
         (float("nan"), [("BBB", "NYSE", 1)], 0),
     ],
 )
@@ -4351,8 +4594,7 @@ async def test_nan_live_cost_uses_only_a_finite_entry_limit_basis(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -4364,7 +4606,7 @@ async def test_nan_live_cost_uses_only_a_finite_entry_limit_basis(
 
 
 @pytest.mark.asyncio
-async def test_harvest_keeps_buy_when_puts_cannot_fund_one_whole_share(
+async def test_harvest_is_not_gated_by_one_share_of_rebalance_value(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -4385,8 +4627,7 @@ async def test_harvest_keeps_buy_when_puts_cannot_fund_one_whole_share(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=1_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
@@ -4394,11 +4635,11 @@ async def test_harvest_keeps_buy_when_puts_cannot_fund_one_whole_share(
     )
 
     assert orders == [("BBB", "NYSE", 1)]
-    assert portfolio_manager.orders.records() == []
+    assert len(portfolio_manager.orders.records()) == 1
 
 
 @pytest.mark.asyncio
-async def test_harvest_skips_too_small_shortest_tranche_for_later_useful_one(
+async def test_harvest_combines_earliest_profitable_cohorts_toward_target(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -4429,23 +4670,22 @@ async def test_harvest_skips_too_small_shortest_tranche_for_later_useful_one(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions=positions,
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"BBB"},
         cohorts=_tail_state(symbol="BBB", puts=[shortest_put, later_put]).open_cohorts,
     )
 
-    assert orders == []
+    assert orders == [("BBB", "NYSE", 1)]
     assert [
         contract.conId
         for contract, _order, _intent_id in portfolio_manager.orders.records()
-    ] == [802]
+    ] == [801, 802]
 
 
 @pytest.mark.asyncio
-async def test_harvest_rounding_cannot_over_defer_across_symbols(
+async def test_harvest_combines_eligible_symbols_for_portfolio_band(
     portfolio_manager_with_db,
     mocker,
 ):
@@ -4479,20 +4719,19 @@ async def test_harvest_rounding_cannot_over_defer_across_symbols(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("AAA", "NYSE", 1), ("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("500", cash="150"),
-        portfolio_positions={"AAA": [aaa_put], "BBB": [bbb_put]},
+        net_liquidation=2_000.0,
         market_prices={"AAA": 100.0, "BBB": 100.0},
         regime_summary=[{"symbol": "AAA"}, {"symbol": "BBB"}],
         hard_underweight_symbols={"AAA", "BBB"},
         cohorts=cohorts,
     )
 
-    assert orders == [("BBB", "NYSE", 1)]
+    assert orders == [("AAA", "NYSE", 1), ("BBB", "NYSE", 1)]
     assert [
         contract.symbol
         for contract, _order, _intent_id in portfolio_manager.orders.records()
-    ] == ["AAA"]
-    portfolio_manager.ibkr.get_ticker_for_contract.assert_awaited_once()
+    ] == ["AAA", "BBB"]
+    assert portfolio_manager.ibkr.get_ticker_for_contract.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -4517,8 +4756,7 @@ async def test_harvest_requires_same_symbol_hard_underweight(
 
     orders = await portfolio_manager.regime_engine._apply_tail_harvest(
         orders=[("BBB", "NYSE", 1)],
-        account_summary=_regime_account_summary("200", cash="0"),
-        portfolio_positions={"BBB": [tail_put]},
+        net_liquidation=2_000.0,
         market_prices={"BBB": 100.0},
         regime_summary=[{"symbol": "BBB"}],
         hard_underweight_symbols={"AAA"},

--- a/tests/test_tail_harvest_policy.py
+++ b/tests/test_tail_harvest_policy.py
@@ -1,0 +1,88 @@
+import math
+
+import pytest
+
+from thetagang.strategies.tail_harvest_policy import (
+    evaluate_harvest_band,
+    minimum_harvest_limit_price,
+)
+
+
+def test_band_breach_sizes_sale_toward_target() -> None:
+    decision = evaluate_harvest_band(
+        net_liquidation=100_000.0,
+        sleeve_value=7_000.0,
+        trigger_weight=0.05,
+        target_weight=0.03,
+    )
+
+    assert decision is not None
+    assert decision.sleeve_weight == pytest.approx(0.07)
+    assert decision.trigger_value == 5_000.0
+    assert decision.target_value == 3_000.0
+    assert decision.sale_budget == 4_000.0
+
+
+def test_band_sale_is_independent_of_broker_cash_or_rebalance_size() -> None:
+    decision = evaluate_harvest_band(
+        net_liquidation=100_000.0,
+        sleeve_value=7_000.0,
+        trigger_weight=0.05,
+        target_weight=0.03,
+    )
+
+    assert decision is not None
+    assert decision.sale_budget == 4_000.0
+
+
+def test_reprice_floor_preserves_a_barely_crossed_band() -> None:
+    assert minimum_harvest_limit_price(
+        quoted_limit_price=1.20,
+        sleeve_value=120.0,
+        trigger_value=100.0,
+        profitable_limit_price=0.51,
+    ) == pytest.approx(1.01)
+
+
+def test_reprice_floor_is_strictly_above_an_exact_cent_trigger() -> None:
+    assert minimum_harvest_limit_price(
+        quoted_limit_price=2.02,
+        sleeve_value=202.0,
+        trigger_value=101.0,
+        profitable_limit_price=0.51,
+    ) == pytest.approx(1.02)
+
+
+def test_reprice_floor_never_crosses_profitability() -> None:
+    assert minimum_harvest_limit_price(
+        quoted_limit_price=1.20,
+        sleeve_value=400.0,
+        trigger_value=100.0,
+        profitable_limit_price=0.51,
+    ) == pytest.approx(0.51)
+
+
+@pytest.mark.parametrize("sleeve_value", [0.0, 5_000.0, 4_999.99])
+def test_band_does_not_trigger_at_or_below_upper_bound(sleeve_value: float) -> None:
+    assert (
+        evaluate_harvest_band(
+            net_liquidation=100_000.0,
+            sleeve_value=sleeve_value,
+            trigger_weight=0.05,
+            target_weight=0.03,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("bad_value", [math.nan, math.inf, -1.0, 0.0])
+def test_band_rejects_invalid_net_liquidation(bad_value: float) -> None:
+    assert (
+        evaluate_harvest_band(
+            net_liquidation=bad_value,
+            sleeve_value=7_000.0,
+            trigger_weight=0.05,
+            target_weight=0.03,
+        )
+        is None
+    )

--- a/tests/test_tail_harvest_policy.py
+++ b/tests/test_tail_harvest_policy.py
@@ -10,7 +10,7 @@ from thetagang.strategies.tail_harvest_policy import (
 
 def test_band_breach_sizes_sale_toward_target() -> None:
     decision = evaluate_harvest_band(
-        net_liquidation=100_000.0,
+        portfolio_base_value=100_000.0,
         sleeve_value=7_000.0,
         trigger_weight=0.05,
         target_weight=0.03,
@@ -20,18 +20,6 @@ def test_band_breach_sizes_sale_toward_target() -> None:
     assert decision.sleeve_weight == pytest.approx(0.07)
     assert decision.trigger_value == 5_000.0
     assert decision.target_value == 3_000.0
-    assert decision.sale_budget == 4_000.0
-
-
-def test_band_sale_is_independent_of_broker_cash_or_rebalance_size() -> None:
-    decision = evaluate_harvest_band(
-        net_liquidation=100_000.0,
-        sleeve_value=7_000.0,
-        trigger_weight=0.05,
-        target_weight=0.03,
-    )
-
-    assert decision is not None
     assert decision.sale_budget == 4_000.0
 
 
@@ -66,7 +54,7 @@ def test_reprice_floor_never_crosses_profitability() -> None:
 def test_band_does_not_trigger_at_or_below_upper_bound(sleeve_value: float) -> None:
     assert (
         evaluate_harvest_band(
-            net_liquidation=100_000.0,
+            portfolio_base_value=100_000.0,
             sleeve_value=sleeve_value,
             trigger_weight=0.05,
             target_weight=0.03,
@@ -76,10 +64,10 @@ def test_band_does_not_trigger_at_or_below_upper_bound(sleeve_value: float) -> N
 
 
 @pytest.mark.parametrize("bad_value", [math.nan, math.inf, -1.0, 0.0])
-def test_band_rejects_invalid_net_liquidation(bad_value: float) -> None:
+def test_band_rejects_invalid_portfolio_base(bad_value: float) -> None:
     assert (
         evaluate_harvest_band(
-            net_liquidation=bad_value,
+            portfolio_base_value=bad_value,
             sleeve_value=7_000.0,
             trigger_weight=0.05,
             target_weight=0.03,

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -779,8 +779,8 @@ ignore_dte = 0
 # [strategies.tail_hedge]
 # enabled = true
 # annual_budget = 0.005  # estimated all-in cost over 365 days / net liquidation
-# harvest_trigger_weight = 0.05  # trim only above 5% of net liquidation
-# harvest_target_weight = 0.03  # size sales toward 3% of net liquidation
+# harvest_trigger_weight = 0.05  # trim only above 5% of the regime base
+# harvest_target_weight = 0.03  # size sales toward 3% of the regime base
 #
 # [[strategies.tail_hedge.targets]]
 # symbol = "QQQ"

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -779,6 +779,8 @@ ignore_dte = 0
 # [strategies.tail_hedge]
 # enabled = true
 # annual_budget = 0.005  # estimated all-in cost over 365 days / net liquidation
+# harvest_trigger_weight = 0.05  # trim only above 5% of net liquidation
+# harvest_target_weight = 0.03  # size sales toward 3% of net liquidation
 #
 # [[strategies.tail_hedge.targets]]
 # symbol = "QQQ"

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -422,13 +422,13 @@ class TailHedgeConfig(BaseModel, DisplayMixin):
         )
         table.add_row(
             "",
-            "Harvest trigger (% NLV)",
+            "Harvest trigger (% regime base)",
             "=",
             pfmt(self.harvest_trigger_weight),
         )
         table.add_row(
             "",
-            "Harvest target (% NLV)",
+            "Harvest target (% regime base)",
             "=",
             pfmt(self.harvest_target_weight),
         )

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -388,10 +388,17 @@ class TailHedgeConfig(BaseModel, DisplayMixin):
 
     enabled: bool = Field(default=False)
     annual_budget: float = Field(default=0.005, gt=0.0, le=1.0)
+    harvest_trigger_weight: float = Field(default=0.05, gt=0.0, le=1.0)
+    harvest_target_weight: float = Field(default=0.03, ge=0.0, le=1.0)
     targets: List[TailHedgeTargetConfig] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def validate_targets(self) -> Self:
+        if self.harvest_target_weight >= self.harvest_trigger_weight:
+            raise ValueError(
+                "tail_hedge.harvest_target_weight must be less than "
+                "harvest_trigger_weight"
+            )
         symbols = [target.symbol for target in self.targets]
         if len(set(symbols)) != len(symbols):
             raise ValueError("tail_hedge.targets symbols must be unique")
@@ -412,6 +419,18 @@ class TailHedgeConfig(BaseModel, DisplayMixin):
             "Annual estimated-cost budget (% NLV)",
             "=",
             pfmt(self.annual_budget),
+        )
+        table.add_row(
+            "",
+            "Harvest trigger (% NLV)",
+            "=",
+            pfmt(self.harvest_trigger_weight),
+        )
+        table.add_row(
+            "",
+            "Harvest target (% NLV)",
+            "=",
+            pfmt(self.harvest_target_weight),
         )
         if not self.targets:
             table.add_row("", "Targets", "=", "-")

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -180,9 +180,6 @@ class PortfolioManager:
             get_primary_exchange=self.get_primary_exchange,
             now_provider=lambda: datetime.now(),
             tail_hedge_stage_enabled=lambda: self.stage_enabled("post_tail_hedge"),
-            cash_management_stage_enabled=lambda: self.stage_enabled(
-                "post_cash_management"
-            ),
             set_reserved_cash_for_post_management=(
                 self.set_reserved_cash_for_post_management
             ),
@@ -676,6 +673,7 @@ class PortfolioManager:
         portfolio_positions: Dict[str, List[PortfolioItem]],
         *,
         exclude_current_run_state: bool = False,
+        allow_tail_harvest: bool = True,
     ) -> List[Tuple[str, str, int]]:
         table, orders = await self.equity_engine.check_regime_rebalance_positions(
             account_summary,
@@ -684,6 +682,7 @@ class PortfolioManager:
                 self.last_untracked_positions,
             ),
             exclude_current_run_state=exclude_current_run_state,
+            allow_tail_harvest=allow_tail_harvest,
         )
         if self.config.strategies.regime_rebalance.enabled:
             log.print(table)
@@ -725,6 +724,7 @@ class PortfolioManager:
             account_summary,
             portfolio_positions,
             exclude_current_run_state=True,
+            allow_tail_harvest=False,
         )
         extra_harvests = [
             record
@@ -737,14 +737,79 @@ class PortfolioManager:
                 con_id = getattr(contract, "conId", 0)
                 if type(con_id) is int and con_id > 0:
                     self._update_tail_recovery_submission(con_id, None)
+            if self.data_store:
+                self.data_store.discard_current_run_events(
+                    {
+                        "regime_rebalance_state",
+                        "volatility_weight_state",
+                    }
+                )
             log.error(
-                "Tail harvest proceeds were insufficient after execution; "
+                "A second tail harvest was queued during post-fill replanning; "
                 "aborting remaining stages safely."
             )
-            raise RuntimeError("Tail-harvest proceeds were insufficient")
+            raise RuntimeError("Tail-harvest replanning did not serialize")
 
         if regime_orders:
+            records_before = len(self.orders.records())
             await self.equity_engine.execute_regime_rebalance_orders(regime_orders)
+            added_records = self.orders.records()[records_before:]
+            expected_orders = Counter(
+                (
+                    symbol,
+                    "BUY" if quantity > 0 else "SELL",
+                    abs(quantity),
+                )
+                for symbol, _primary_exchange, quantity in regime_orders
+            )
+            prepared_orders: Counter[tuple[str, str, int]] = Counter()
+            for contract, order, _intent_id in added_records:
+                raw_limit_price = order.lmtPrice
+                if raw_limit_price is None:
+                    continue
+                try:
+                    raw_quantity = float(order.totalQuantity)
+                    limit_price = float(raw_limit_price)
+                except (TypeError, ValueError):
+                    continue
+                if (
+                    not math.isfinite(raw_quantity)
+                    or raw_quantity <= 0
+                    or not raw_quantity.is_integer()
+                    or not math.isfinite(limit_price)
+                    or limit_price <= 0
+                ):
+                    continue
+                quantity = int(raw_quantity)
+                if (
+                    isinstance(contract, Stock)
+                    and getattr(order, "account", None) == self.account_number
+                    and getattr(order, "orderRef", None)
+                    == f"tg:regime-rebalance:{contract.symbol}"
+                ):
+                    prepared_orders[
+                        (
+                            contract.symbol,
+                            str(getattr(order, "action", "")).upper(),
+                            quantity,
+                        )
+                    ] += 1
+            if prepared_orders != expected_orders or len(added_records) != sum(
+                prepared_orders.values()
+            ):
+                self.orders.remove_records(added_records)
+                if self.data_store:
+                    self.data_store.discard_current_run_events(
+                        {
+                            "regime_rebalance_state",
+                            "volatility_weight_state",
+                        }
+                    )
+                log.error(
+                    "Post-harvest regime orders were not prepared completely; "
+                    "aborting before final submission."
+                )
+                raise RuntimeError("Post-harvest rebalance preparation was incomplete")
         return account_summary, portfolio_positions
 
     async def manage(self) -> None:

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -83,6 +83,10 @@ logging.getLogger("ib_async.ib").setLevel(logging.ERROR)
 logging.getLogger("ib_async.wrapper").setLevel(logging.CRITICAL)
 
 TAIL_HARVEST_FILL_TIMEOUT_SECONDS = 5 * 60
+REGIME_PLANNING_STATE_EVENTS = {
+    "regime_rebalance_state",
+    "volatility_weight_state",
+}
 
 
 class PortfolioManager:
@@ -667,13 +671,16 @@ class PortfolioManager:
             )
         return account_summary, self.get_portfolio_positions()
 
+    def _discard_current_regime_planning_state(self) -> None:
+        if self.data_store:
+            self.data_store.discard_current_run_events(REGIME_PLANNING_STATE_EVENTS)
+
     async def _plan_regime_rebalance(
         self,
         account_summary: Dict[str, AccountValue],
         portfolio_positions: Dict[str, List[PortfolioItem]],
         *,
         exclude_current_run_state: bool = False,
-        allow_tail_harvest: bool = True,
     ) -> List[Tuple[str, str, int]]:
         table, orders = await self.equity_engine.check_regime_rebalance_positions(
             account_summary,
@@ -682,7 +689,6 @@ class PortfolioManager:
                 self.last_untracked_positions,
             ),
             exclude_current_run_state=exclude_current_run_state,
-            allow_tail_harvest=allow_tail_harvest,
         )
         if self.config.strategies.regime_rebalance.enabled:
             log.print(table)
@@ -707,13 +713,7 @@ class PortfolioManager:
                 await self.equity_engine.execute_regime_rebalance_orders(regime_orders)
             return account_summary, portfolio_positions
 
-        if self.data_store:
-            self.data_store.discard_current_run_events(
-                {
-                    "regime_rebalance_state",
-                    "volatility_weight_state",
-                }
-            )
+        self._discard_current_regime_planning_state()
         self.orders.remove_records(harvest_records)
         if not await self._execute_tail_harvest_phase(harvest_records):
             raise RuntimeError("Tail-harvest execution did not fully fill")
@@ -724,7 +724,6 @@ class PortfolioManager:
             account_summary,
             portfolio_positions,
             exclude_current_run_state=True,
-            allow_tail_harvest=False,
         )
         extra_harvests = [
             record
@@ -737,13 +736,7 @@ class PortfolioManager:
                 con_id = getattr(contract, "conId", 0)
                 if type(con_id) is int and con_id > 0:
                     self._update_tail_recovery_submission(con_id, None)
-            if self.data_store:
-                self.data_store.discard_current_run_events(
-                    {
-                        "regime_rebalance_state",
-                        "volatility_weight_state",
-                    }
-                )
+            self._discard_current_regime_planning_state()
             log.error(
                 "A second tail harvest was queued during post-fill replanning; "
                 "aborting remaining stages safely."
@@ -752,59 +745,13 @@ class PortfolioManager:
 
         if regime_orders:
             records_before = len(self.orders.records())
-            await self.equity_engine.execute_regime_rebalance_orders(regime_orders)
-            added_records = self.orders.records()[records_before:]
-            expected_orders = Counter(
-                (
-                    symbol,
-                    "BUY" if quantity > 0 else "SELL",
-                    abs(quantity),
-                )
-                for symbol, _primary_exchange, quantity in regime_orders
+            prepared = await self.equity_engine.execute_regime_rebalance_orders(
+                regime_orders
             )
-            prepared_orders: Counter[tuple[str, str, int]] = Counter()
-            for contract, order, _intent_id in added_records:
-                raw_limit_price = order.lmtPrice
-                if raw_limit_price is None:
-                    continue
-                try:
-                    raw_quantity = float(order.totalQuantity)
-                    limit_price = float(raw_limit_price)
-                except (TypeError, ValueError):
-                    continue
-                if (
-                    not math.isfinite(raw_quantity)
-                    or raw_quantity <= 0
-                    or not raw_quantity.is_integer()
-                    or not math.isfinite(limit_price)
-                    or limit_price <= 0
-                ):
-                    continue
-                quantity = int(raw_quantity)
-                if (
-                    isinstance(contract, Stock)
-                    and getattr(order, "account", None) == self.account_number
-                    and getattr(order, "orderRef", None)
-                    == f"tg:regime-rebalance:{contract.symbol}"
-                ):
-                    prepared_orders[
-                        (
-                            contract.symbol,
-                            str(getattr(order, "action", "")).upper(),
-                            quantity,
-                        )
-                    ] += 1
-            if prepared_orders != expected_orders or len(added_records) != sum(
-                prepared_orders.values()
-            ):
+            if prepared != len(regime_orders):
+                added_records = self.orders.records()[records_before:]
                 self.orders.remove_records(added_records)
-                if self.data_store:
-                    self.data_store.discard_current_run_events(
-                        {
-                            "regime_rebalance_state",
-                            "volatility_weight_state",
-                        }
-                    )
+                self._discard_current_regime_planning_state()
                 log.error(
                     "Post-harvest regime orders were not prepared completely; "
                     "aborting before final submission."

--- a/thetagang/strategies/equity.py
+++ b/thetagang/strategies/equity.py
@@ -26,6 +26,7 @@ class RegimeRebalanceService(Protocol):
         portfolio_positions: PortfolioBySymbol,
         *,
         exclude_current_run_state: bool = False,
+        allow_tail_harvest: bool = True,
     ) -> Any: ...
 
     async def execute_regime_rebalance_orders(self, orders: List[Any]) -> None: ...

--- a/thetagang/strategies/equity.py
+++ b/thetagang/strategies/equity.py
@@ -26,10 +26,9 @@ class RegimeRebalanceService(Protocol):
         portfolio_positions: PortfolioBySymbol,
         *,
         exclude_current_run_state: bool = False,
-        allow_tail_harvest: bool = True,
     ) -> Any: ...
 
-    async def execute_regime_rebalance_orders(self, orders: List[Any]) -> None: ...
+    async def execute_regime_rebalance_orders(self, orders: List[Any]) -> int: ...
 
 
 class EquityRebalanceService(Protocol):

--- a/thetagang/strategies/equity_engine.py
+++ b/thetagang/strategies/equity_engine.py
@@ -111,11 +111,13 @@ class EquityRebalanceEngine:
         portfolio_positions: Dict[str, List[PortfolioItem]],
         *,
         exclude_current_run_state: bool = False,
+        allow_tail_harvest: bool = True,
     ) -> Tuple[Table, List[Tuple[str, str, int]]]:
         return await self.regime_engine.check_regime_rebalance_positions(
             account_summary,
             portfolio_positions,
             exclude_current_run_state=exclude_current_run_state,
+            allow_tail_harvest=allow_tail_harvest,
         )
 
     async def check_buy_only_positions(

--- a/thetagang/strategies/equity_engine.py
+++ b/thetagang/strategies/equity_engine.py
@@ -72,9 +72,12 @@ class EquityRebalanceEngine:
 
     async def execute_regime_rebalance_orders(
         self, orders: List[Tuple[str, str, int]]
-    ) -> None:
+    ) -> int:
+        prepared = 0
         for symbol, primary_exchange, quantity in orders:
             try:
+                if quantity == 0:
+                    raise ValueError("regime rebalance quantity must be non-zero")
                 stock_contract = Stock(
                     symbol,
                     self.order_ops.get_order_exchange(),
@@ -87,6 +90,8 @@ class EquityRebalanceEngine:
                     optional_fields=[TickerField.MIDPOINT, TickerField.MARKET_PRICE],
                 )
                 limit_price = round(self._midpoint_or_market_price(ticker), 2)
+                if not math.isfinite(limit_price) or limit_price <= 0:
+                    raise ValueError("regime rebalance limit price must be positive")
                 action = "BUY" if quantity > 0 else "SELL"
                 order = self.order_ops.create_limit_order(
                     action=action,
@@ -99,11 +104,13 @@ class EquityRebalanceEngine:
                     f"Regime rebalancing: {action.lower()} {abs(quantity)} shares of {symbol} @ ${limit_price}"
                 )
                 self.order_ops.enqueue_order(stock_contract, order)
+                prepared += 1
             except Exception as e:
                 log.error(
                     f"{symbol}: Failed to execute regime rebalance order. Error: {e}"
                 )
                 continue
+        return prepared
 
     async def check_regime_rebalance_positions(
         self,
@@ -111,13 +118,11 @@ class EquityRebalanceEngine:
         portfolio_positions: Dict[str, List[PortfolioItem]],
         *,
         exclude_current_run_state: bool = False,
-        allow_tail_harvest: bool = True,
     ) -> Tuple[Table, List[Tuple[str, str, int]]]:
         return await self.regime_engine.check_regime_rebalance_positions(
             account_summary,
             portfolio_positions,
             exclude_current_run_state=exclude_current_run_state,
-            allow_tail_harvest=allow_tail_harvest,
         )
 
     async def check_buy_only_positions(

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -308,18 +308,48 @@ class RegimeRebalanceEngine:
         return self._tail_state_store.load().open_cohorts
 
     @staticmethod
+    def _owned_tail_position_value(
+        position: PortfolioItem,
+        cohort: TailHedgeCohort,
+    ) -> tuple[int, float] | None:
+        if (
+            not isinstance(position.contract, Option)
+            or position.contract.conId != cohort.con_id
+        ):
+            return None
+        try:
+            live_quantity = float(position.position)
+            reported_value = float(position.marketValue or 0.0)
+        except (TypeError, ValueError):
+            return None
+        if (
+            not math.isfinite(live_quantity)
+            or live_quantity <= 0
+            or not math.isfinite(reported_value)
+        ):
+            return None
+        owned_quantity = min(cohort.quantity, math.floor(live_quantity))
+        if owned_quantity <= 0:
+            return None
+        return owned_quantity, reported_value * owned_quantity / live_quantity
+
+    @classmethod
     def _tail_hedge_market_value(
+        cls,
         portfolio_positions: Dict[str, List[PortfolioItem]],
         cohorts: list[TailHedgeCohort],
     ) -> float:
-        owned_con_ids = {cohort.con_id for cohort in cohorts}
-        return sum(
-            float(position.marketValue or 0.0)
-            for positions in portfolio_positions.values()
-            for position in positions
-            if isinstance(position.contract, Option)
-            and position.contract.conId in owned_con_ids
-        )
+        cohorts_by_con_id = {cohort.con_id: cohort for cohort in cohorts}
+        sleeve_value = 0.0
+        for positions in portfolio_positions.values():
+            for position in positions:
+                cohort = cohorts_by_con_id.get(position.contract.conId)
+                if cohort is None:
+                    continue
+                owned_position = cls._owned_tail_position_value(position, cohort)
+                if owned_position is not None:
+                    sleeve_value += owned_position[1]
+        return sleeve_value
 
     @staticmethod
     def _long_puts_by_con_id(
@@ -353,24 +383,16 @@ class RegimeRebalanceEngine:
             position = positions_by_con_id.get(key[1])
             if cohort is None or position is None:
                 continue
+            owned_position = cls._owned_tail_position_value(position, cohort)
+            if owned_position is None:
+                continue
+            owned_quantity, reported_owned_value = owned_position
             try:
-                live_quantity = float(position.position)
                 multiplier = float(position.contract.multiplier)
-                reported_value = float(position.marketValue or 0.0)
             except (TypeError, ValueError):
                 continue
-            if (
-                not math.isfinite(live_quantity)
-                or live_quantity <= 0
-                or not math.isfinite(multiplier)
-                or multiplier <= 0
-                or not math.isfinite(reported_value)
-            ):
+            if not math.isfinite(multiplier) or multiplier <= 0:
                 continue
-            owned_quantity = min(cohort.quantity, math.floor(live_quantity))
-            if owned_quantity <= 0:
-                continue
-            reported_owned_value = reported_value * owned_quantity / live_quantity
             quoted_owned_value = limit_price * multiplier * owned_quantity
             sleeve_value -= max(0.0, reported_owned_value - quoted_owned_value)
         return sleeve_value

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -30,7 +30,6 @@ from thetagang.strategies.tail_hedge_state import (
     TailHedgeCohort,
     TailHedgeStateStore,
     build_tail_reduction_order_ref,
-    is_tail_reduction_ref,
     parse_state_datetime,
 )
 from thetagang.trading_operations import OrderOperations
@@ -117,6 +116,15 @@ class HarvestPut:
         return self.net_proceeds_per_contract / self.cost_basis_per_contract
 
 
+@dataclass(frozen=True)
+class PlannedHarvest:
+    candidate: HarvestPut
+    quantity: int
+    order: Any
+    minimum_limit_price: float
+    minimum_net_proceeds: float
+
+
 def _ffmt_or_dash(value: Optional[float], precision: int = 2) -> str:
     return ffmt(value, precision) if value is not None else "-"
 
@@ -200,6 +208,66 @@ class RegimeRebalanceEngine:
             # Never substitute a cash-derived proxy for an unavailable NLV.
             return fallback
 
+    def _regime_rebalance_base_value(
+        self,
+        *,
+        net_liquidation: float,
+        portfolio_positions: Dict[str, List[PortfolioItem]],
+        market_prices: Dict[str, float],
+        cohorts: list[TailHedgeCohort],
+        tail_hedge_value_override: float | None = None,
+    ) -> tuple[float, float]:
+        """Return the configured regime base and its signed option exclusion."""
+        weight_base = self.config.strategies.regime_rebalance.weight_base
+        if weight_base == RegimeRebalanceBaseEnum.managed_stocks:
+            stock_positions = {
+                position.contract.symbol: position
+                for positions in portfolio_positions.values()
+                for position in positions
+                if isinstance(position.contract, Stock)
+            }
+            managed_stock_value = sum(
+                math.floor(
+                    float(stock_positions[symbol].position)
+                    if symbol in stock_positions
+                    else 0.0
+                )
+                * market_price
+                for symbol, market_price in market_prices.items()
+            )
+            return managed_stock_value, 0.0
+
+        owned_tail_hedge_con_ids = {cohort.con_id for cohort in cohorts}
+        reported_tail_hedge_value = self._tail_hedge_market_value(
+            portfolio_positions,
+            cohorts,
+        )
+        tail_hedge_value = (
+            reported_tail_hedge_value
+            if tail_hedge_value_override is None
+            else tail_hedge_value_override
+        )
+        if weight_base == RegimeRebalanceBaseEnum.net_liq_ex_options:
+            excluded_option_value = sum(
+                float(position.marketValue or 0.0)
+                for positions in portfolio_positions.values()
+                for position in positions
+                if isinstance(position.contract, Option)
+                and (
+                    position.contract.symbol in market_prices
+                    or position.contract.conId in owned_tail_hedge_con_ids
+                )
+            )
+            excluded_option_value += tail_hedge_value - reported_tail_hedge_value
+        else:
+            excluded_option_value = tail_hedge_value
+        adjusted_net_liquidation = net_liquidation - excluded_option_value
+        regime_margin_usage = self._resolve_regime_margin_usage()
+        return (
+            math.floor(adjusted_net_liquidation * regime_margin_usage),
+            excluded_option_value,
+        )
+
     def _record_tail_harvest(
         self,
         outcome: str,
@@ -253,17 +321,68 @@ class RegimeRebalanceEngine:
             and position.contract.conId in owned_con_ids
         )
 
-    def _working_option_orders(
+    @staticmethod
+    def _long_puts_by_con_id(
+        portfolio_positions: Dict[str, List[PortfolioItem]],
+    ) -> dict[int, PortfolioItem]:
+        return {
+            int(position.contract.conId): position
+            for positions in portfolio_positions.values()
+            for position in positions
+            if isinstance(position.contract, Option)
+            and position.contract.right.upper().startswith("P")
+            and type(position.contract.conId) is int
+            and position.contract.conId > 0
+            and float(position.position) > 0
+        }
+
+    @classmethod
+    def _tail_hedge_market_value_at_quotes(
+        cls,
+        portfolio_positions: Dict[str, List[PortfolioItem]],
+        cohorts: list[TailHedgeCohort],
+        quoted_limit_prices: dict[tuple[str, int], float],
+    ) -> float:
+        sleeve_value = cls._tail_hedge_market_value(portfolio_positions, cohorts)
+        cohorts_by_key = {
+            (cohort.entry_id, cohort.con_id): cohort for cohort in cohorts
+        }
+        positions_by_con_id = cls._long_puts_by_con_id(portfolio_positions)
+        for key, limit_price in quoted_limit_prices.items():
+            cohort = cohorts_by_key.get(key)
+            position = positions_by_con_id.get(key[1])
+            if cohort is None or position is None:
+                continue
+            try:
+                live_quantity = float(position.position)
+                multiplier = float(position.contract.multiplier)
+                reported_value = float(position.marketValue or 0.0)
+            except (TypeError, ValueError):
+                continue
+            if (
+                not math.isfinite(live_quantity)
+                or live_quantity <= 0
+                or not math.isfinite(multiplier)
+                or multiplier <= 0
+                or not math.isfinite(reported_value)
+            ):
+                continue
+            owned_quantity = min(cohort.quantity, math.floor(live_quantity))
+            if owned_quantity <= 0:
+                continue
+            reported_owned_value = reported_value * owned_quantity / live_quantity
+            quoted_owned_value = limit_price * multiplier * owned_quantity
+            sleeve_value -= max(0.0, reported_owned_value - quoted_owned_value)
+        return sleeve_value
+
+    def _option_order_state(
         self,
         owned_con_ids: set[int] | None = None,
     ) -> tuple[set[int], set[str]]:
         account_number = self.config.runtime.account.number
-        open_trades = self.ibkr.open_trades()
-        if not isinstance(open_trades, list):
-            return set(), set()
-        con_ids: set[int] = set()
+        unavailable_con_ids: set[int] = set()
         tail_sell_symbols: set[str] = set()
-        for trade in open_trades:
+        for trade in self.ibkr.open_trades():
             order = getattr(trade, "order", None)
             contract = getattr(trade, "contract", None)
             is_done = getattr(trade, "isDone", None)
@@ -276,80 +395,161 @@ class RegimeRebalanceEngine:
                 or contract.conId <= 0
             ):
                 continue
-            con_ids.add(contract.conId)
+            unavailable_con_ids.add(contract.conId)
             if (
                 owned_con_ids is not None
                 and contract.conId in owned_con_ids
                 and str(getattr(order, "action", "")).upper() == "SELL"
-                and is_tail_reduction_ref(getattr(order, "orderRef", None))
             ):
                 tail_sell_symbols.add(str(contract.symbol))
-        return con_ids, tail_sell_symbols
+        for contract, order, _intent_id in self.order_ops.orders.records():
+            if (
+                not isinstance(contract, Option)
+                or type(contract.conId) is not int
+                or contract.conId <= 0
+            ):
+                continue
+            unavailable_con_ids.add(contract.conId)
+            if (
+                owned_con_ids is not None
+                and contract.conId in owned_con_ids
+                and getattr(order, "account", None) == account_number
+                and str(getattr(order, "action", "")).upper() == "SELL"
+            ):
+                tail_sell_symbols.add(str(contract.symbol))
+        return unavailable_con_ids, tail_sell_symbols
 
-    def _tail_sale_in_progress_symbols(self, owned_con_ids: set[int]) -> set[str]:
-        _working_con_ids, symbols = self._working_option_orders(owned_con_ids)
-        account_number = self.config.runtime.account.number
-        symbols.update(
-            str(contract.symbol)
-            for contract, order, _intent_id in self.order_ops.orders.records()
-            if isinstance(contract, Option)
-            and contract.conId in owned_con_ids
-            and getattr(order, "account", None) == account_number
-            and str(getattr(order, "action", "")).upper() == "SELL"
-            and is_tail_reduction_ref(getattr(order, "orderRef", None))
+    def _tail_harvest_conflicts(
+        self,
+        cohorts: list[TailHedgeCohort],
+    ) -> tuple[set[int], set[str], str | None]:
+        owned_con_ids = {cohort.con_id for cohort in cohorts}
+        unavailable_con_ids, working_sale_symbols = self._option_order_state(
+            owned_con_ids
         )
-        return symbols
-
-    def _live_account_puts(self) -> dict[int, PortfolioItem]:
-        account_number = self.config.runtime.account.number
-        positions = self.ibkr.portfolio(account=account_number)
-        if not isinstance(positions, list):
-            return {}
-        return {
-            int(position.contract.conId): position
-            for position in positions
-            if getattr(position, "account", None) == account_number
-            and isinstance(position.contract, Option)
-            and position.contract.right.upper().startswith("P")
-            and type(position.contract.conId) is int
-            and position.contract.conId > 0
-            and float(position.position) > 0
+        pending_recovery_symbols = {
+            cohort.symbol for cohort in cohorts if cohort.has_pending_recovery
         }
+        blocked_symbols = working_sale_symbols | pending_recovery_symbols
+        if pending_recovery_symbols and working_sale_symbols:
+            reason = "unresolved_tail_reduction"
+        elif pending_recovery_symbols:
+            reason = "pending_recovery"
+        elif working_sale_symbols:
+            reason = "working_tail_sale"
+        else:
+            reason = None
+        return unavailable_con_ids, blocked_symbols, reason
 
-    async def _profitable_tail_puts(
+    def _record_tail_harvest_blocked(
         self,
         *,
-        symbol: str,
-        cohorts: list[TailHedgeCohort],
-        portfolio_positions: Dict[str, List[PortfolioItem]],
-    ) -> list[HarvestPut]:
-        snapshot_positions = {
-            int(position.contract.conId): position
-            for position in portfolio_positions.get(symbol, [])
-            if isinstance(position.contract, Option)
-            and position.contract.right.upper().startswith("P")
-            and type(position.contract.conId) is int
-            and position.contract.conId > 0
-            and float(position.position) > 0
-        }
-        unavailable_con_ids, _harvest_symbols = self._working_option_orders()
-        unavailable_con_ids.update(
-            int(contract.conId)
-            for contract, _order, _intent_id in self.order_ops.orders.records()
-            if isinstance(contract, Option)
-            and type(contract.conId) is int
-            and contract.conId > 0
+        rebalance_shares: dict[str, int],
+        blocked_symbols: set[str],
+        reason: str,
+    ) -> None:
+        for symbol, quantity in rebalance_shares.items():
+            self._record_tail_harvest(
+                "harvest_blocked",
+                symbol=symbol,
+                reason=reason,
+                rebalance_shares=quantity,
+                blocking_symbols=sorted(blocked_symbols),
+            )
+        log.info(
+            "Skipping a new portfolio tail harvest while prior reductions "
+            f"are unresolved for {', '.join(sorted(blocked_symbols))}."
         )
 
-        quoted: list[tuple[TailHedgeCohort, float]] = []
+    def _build_profitable_tail_put(
+        self,
+        *,
+        cohort: TailHedgeCohort,
+        position: PortfolioItem,
+        limit_price: float,
+    ) -> HarvestPut | None:
+        symbol = cohort.symbol
+        contract = position.contract
+        if not isinstance(contract, Option) or contract.symbol != symbol:
+            return None
+        try:
+            multiplier = float(contract.multiplier)
+            live_quantity = float(position.position)
+        except (TypeError, ValueError):
+            return None
+        if (
+            not math.isfinite(multiplier)
+            or multiplier <= 0
+            or not math.isfinite(live_quantity)
+        ):
+            return None
+        quantity = min(cohort.quantity, math.floor(live_quantity))
+        if quantity <= 0:
+            return None
+
+        try:
+            average_cost = float(getattr(position, "averageCost", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            average_cost = 0.0
+        estimated_fee = self._estimated_tail_fee_per_contract()
+        configured_entry_basis = cohort.entry_limit_price * multiplier + estimated_fee
+        if not math.isfinite(average_cost) or average_cost <= 0:
+            average_cost = configured_entry_basis
+        else:
+            average_cost = max(average_cost, configured_entry_basis)
+        gross_proceeds = limit_price * multiplier
+        net_proceeds = max(0.0, gross_proceeds - estimated_fee)
+        if (
+            not math.isfinite(average_cost)
+            or average_cost <= 0
+            or net_proceeds <= average_cost
+        ):
+            self._record_tail_harvest(
+                "candidate_not_net_profitable",
+                symbol=symbol,
+                entry_id=cohort.entry_id,
+                con_id=cohort.con_id,
+                gross_proceeds_per_contract=gross_proceeds,
+                estimated_fee_per_contract=estimated_fee,
+                net_proceeds_per_contract=net_proceeds,
+                cost_basis_per_contract=average_cost,
+            )
+            log.info(
+                f"{symbol}: Tail put conId={cohort.con_id} is not profitable "
+                "after its estimated sell fee."
+            )
+            return None
+
+        contract.exchange = self.order_ops.get_order_exchange()
+        return HarvestPut(
+            entry_id=cohort.entry_id,
+            contract=contract,
+            expiration=cohort.expiration,
+            quantity=quantity,
+            limit_price=limit_price,
+            gross_proceeds_per_contract=gross_proceeds,
+            estimated_fee_per_contract=estimated_fee,
+            net_proceeds_per_contract=net_proceeds,
+            cost_basis_per_contract=average_cost,
+        )
+
+    async def _quote_tail_puts(
+        self,
+        *,
+        symbols: set[str],
+        cohorts: list[TailHedgeCohort],
+        portfolio_positions: Dict[str, List[PortfolioItem]],
+    ) -> dict[tuple[str, int], float]:
+        snapshot_positions = self._long_puts_by_con_id(portfolio_positions)
+
+        quoted: dict[tuple[str, int], float] = {}
         for cohort in cohorts:
             con_id = cohort.con_id
             position = snapshot_positions.get(con_id)
             if (
-                cohort.symbol != symbol
+                cohort.symbol not in symbols
                 or cohort.status != "active"
                 or cohort.has_pending_recovery
-                or con_id in unavailable_con_ids
                 or position is None
             ):
                 continue
@@ -364,111 +564,19 @@ class RegimeRebalanceEngine:
                 )
             except Exception as exc:
                 log.warning(
-                    f"{symbol}: Unable to quote tail put {con_id} for harvesting "
+                    f"{cohort.symbol}: Unable to quote tail put {con_id} for harvesting "
                     f"({type(exc).__name__})."
                 )
                 continue
             limit_price = round(float(midpoint_or_market_price(ticker)), 2)
             if math.isfinite(limit_price) and limit_price > 0:
-                quoted.append((cohort, limit_price))
-
-        # Quote requests yield to ib_async. Re-read its cache once after all
-        # requests and before committing any close.
-        live_positions = self._live_account_puts()
-        unavailable_con_ids, _harvest_symbols = self._working_option_orders()
-        candidates: list[HarvestPut] = []
-        for cohort, limit_price in quoted:
-            con_id = cohort.con_id
-            position = live_positions.get(con_id)
-            if (
-                position is None
-                or position.contract.symbol != symbol
-                or con_id in unavailable_con_ids
-            ):
-                continue
-            contract = position.contract
-            if not isinstance(contract, Option):
-                continue
-            try:
-                multiplier = float(contract.multiplier)
-            except (TypeError, ValueError):
-                continue
-            if not math.isfinite(multiplier) or multiplier <= 0:
-                continue
-            quantity = min(
-                cohort.quantity,
-                math.floor(float(position.position)),
-            )
-            if quantity <= 0:
-                continue
-
-            try:
-                average_cost = float(getattr(position, "averageCost", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                average_cost = 0.0
-            configured_entry_basis = (
-                cohort.entry_limit_price * multiplier
-                + self._estimated_tail_fee_per_contract()
-            )
-            if not math.isfinite(average_cost) or average_cost <= 0:
-                average_cost = configured_entry_basis
-            else:
-                average_cost = max(average_cost, configured_entry_basis)
-            gross_proceeds = limit_price * multiplier
-            estimated_fee = self._estimated_tail_fee_per_contract()
-            net_proceeds = max(0.0, gross_proceeds - estimated_fee)
-            if (
-                not math.isfinite(average_cost)
-                or average_cost <= 0
-                or net_proceeds <= average_cost
-            ):
-                self._record_tail_harvest(
-                    "candidate_not_net_profitable",
-                    symbol=symbol,
-                    entry_id=cohort.entry_id,
-                    con_id=con_id,
-                    gross_proceeds_per_contract=gross_proceeds,
-                    estimated_fee_per_contract=estimated_fee,
-                    net_proceeds_per_contract=net_proceeds,
-                    cost_basis_per_contract=average_cost,
-                )
-                log.info(
-                    f"{symbol}: Tail put conId={con_id} is not profitable after "
-                    "its estimated sell fee."
-                )
-                continue
-
-            contract.exchange = self.order_ops.get_order_exchange()
-            candidates.append(
-                HarvestPut(
-                    entry_id=cohort.entry_id,
-                    contract=contract,
-                    expiration=cohort.expiration,
-                    quantity=quantity,
-                    limit_price=limit_price,
-                    gross_proceeds_per_contract=gross_proceeds,
-                    estimated_fee_per_contract=estimated_fee,
-                    net_proceeds_per_contract=net_proceeds,
-                    cost_basis_per_contract=average_cost,
-                )
-            )
-
-        return sorted(
-            candidates,
-            key=lambda candidate: (
-                candidate.expiration,
-                -candidate.net_proceeds_per_contract,
-                candidate.contract.conId,
-            ),
-        )
+                quoted[(cohort.entry_id, con_id)] = limit_price
+        return quoted
 
     async def _enqueue_tail_harvest(
         self,
         *,
         net_liquidation: float,
-        trigger_weight: float,
-        target_weight: float,
-        approved_rebalance_value: float,
         rebalance_shares: Dict[str, int],
         market_prices: Dict[str, float],
         cohorts: list[TailHedgeCohort],
@@ -477,21 +585,10 @@ class RegimeRebalanceEngine:
         if self._tail_state_store is None:
             return set()
 
-        candidates: list[HarvestPut] = []
-        for symbol in rebalance_shares:
-            candidates.extend(
-                await self._profitable_tail_puts(
-                    symbol=symbol,
-                    cohorts=cohorts,
-                    portfolio_positions=portfolio_positions,
-                )
-            )
-        candidates.sort(
-            key=lambda candidate: (
-                candidate.expiration,
-                -candidate.net_proceeds_per_contract,
-                candidate.contract.conId,
-            )
+        quoted_limit_prices = await self._quote_tail_puts(
+            symbols=set(rebalance_shares),
+            cohorts=cohorts,
+            portfolio_positions=portfolio_positions,
         )
 
         # Quote requests yield to ib_async. Re-evaluate the portfolio-level
@@ -500,25 +597,98 @@ class RegimeRebalanceEngine:
         refreshed_positions = portfolio_positions_to_dict(
             self.ibkr.portfolio(account=account_number)
         )
-        sleeve_value = self._tail_hedge_market_value(refreshed_positions, cohorts)
+        state = self._tail_state_store.load()
+        live_cohorts = state.open_cohorts
+        unavailable_con_ids, blocked_symbols, blocked_reason = (
+            self._tail_harvest_conflicts(live_cohorts)
+        )
+        if blocked_reason is not None:
+            self._record_tail_harvest_blocked(
+                rebalance_shares=rebalance_shares,
+                blocked_symbols=blocked_symbols,
+                reason=blocked_reason,
+            )
+            return set()
+        refreshed_puts = self._long_puts_by_con_id(refreshed_positions)
+        cohorts_by_key = {
+            (cohort.entry_id, cohort.con_id): cohort for cohort in live_cohorts
+        }
+        candidates: list[HarvestPut] = []
+        live_quotes: dict[tuple[str, int], float] = {}
+        for key, limit_price in quoted_limit_prices.items():
+            cohort = cohorts_by_key.get(key)
+            con_id = key[1]
+            position = refreshed_puts.get(con_id)
+            if (
+                cohort is None
+                or cohort.status != "active"
+                or cohort.has_pending_recovery
+                or position is None
+                or position.contract.symbol != cohort.symbol
+            ):
+                continue
+            live_quotes[key] = limit_price
+            if con_id in unavailable_con_ids:
+                continue
+            candidate = self._build_profitable_tail_put(
+                cohort=cohort,
+                position=position,
+                limit_price=limit_price,
+            )
+            if candidate is not None:
+                candidates.append(candidate)
+        candidates = sorted(
+            candidates,
+            key=lambda candidate: (
+                candidate.expiration,
+                -candidate.net_proceeds_per_contract,
+                candidate.contract.conId,
+            ),
+        )
+        sleeve_value = self._tail_hedge_market_value_at_quotes(
+            refreshed_positions,
+            live_cohorts,
+            live_quotes,
+        )
         refreshed_net_liquidation = self._latest_net_liquidation(net_liquidation)
+        refreshed_regime_base, excluded_option_value = (
+            self._regime_rebalance_base_value(
+                net_liquidation=refreshed_net_liquidation,
+                portfolio_positions=refreshed_positions,
+                market_prices=market_prices,
+                cohorts=live_cohorts,
+                # Use the conservative quote-aware tail mark on both sides of
+                # the ratio. This keeps the shared option-exclusion formula
+                # coherent even when IBKR's portfolio mark lags the quote.
+                tail_hedge_value_override=sleeve_value,
+            )
+        )
+        tail_hedge = self.config.strategies.tail_hedge
         decision = evaluate_harvest_band(
-            net_liquidation=refreshed_net_liquidation,
+            portfolio_base_value=refreshed_regime_base,
             sleeve_value=sleeve_value,
-            trigger_weight=trigger_weight,
-            target_weight=target_weight,
+            trigger_weight=tail_hedge.harvest_trigger_weight,
+            target_weight=tail_hedge.harvest_target_weight,
         )
         if decision is None:
             return set()
         sale_budget = decision.sale_budget
         band_payload = {
             "net_liquidation": refreshed_net_liquidation,
+            "regime_rebalance_base": refreshed_regime_base,
+            "regime_weight_base": (
+                self.config.strategies.regime_rebalance.weight_base.value
+            ),
+            "excluded_option_value": excluded_option_value,
             "sleeve_value": decision.sleeve_value,
             "sleeve_weight": decision.sleeve_weight,
-            "harvest_trigger_weight": trigger_weight,
-            "harvest_target_weight": target_weight,
+            "harvest_trigger_weight": tail_hedge.harvest_trigger_weight,
+            "harvest_target_weight": tail_hedge.harvest_target_weight,
             "target_sleeve_value": decision.target_value,
-            "approved_rebalance_value": approved_rebalance_value,
+            "approved_rebalance_value": sum(
+                shares * market_prices[symbol]
+                for symbol, shares in rebalance_shares.items()
+            ),
         }
 
         selected: list[tuple[HarvestPut, int]] = []
@@ -551,9 +721,8 @@ class RegimeRebalanceEngine:
                 )
             return set()
 
-        state = self._tail_state_store.load()
         enqueued_at = self._now()
-        planned: list[tuple[HarvestPut, int, Any, float, float]] = []
+        planned: list[PlannedHarvest] = []
         for candidate, quantity in selected:
             symbol = candidate.contract.symbol
             con_id = candidate.contract.conId
@@ -608,12 +777,12 @@ class RegimeRebalanceEngine:
             )
             setattr(order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR, minimum_limit_price)
             planned.append(
-                (
-                    candidate,
-                    quantity,
-                    order,
-                    minimum_limit_price,
-                    minimum_net_proceeds,
+                PlannedHarvest(
+                    candidate=candidate,
+                    quantity=quantity,
+                    order=order,
+                    minimum_limit_price=minimum_limit_price,
+                    minimum_net_proceeds=minimum_net_proceeds,
                 )
             )
 
@@ -627,19 +796,15 @@ class RegimeRebalanceEngine:
             return set()
 
         enqueued_symbols: set[str] = set()
-        for (
-            candidate,
-            quantity,
-            order,
-            minimum_limit_price,
-            minimum_net_proceeds,
-        ) in planned:
+        for plan in planned:
+            candidate = plan.candidate
+            quantity = plan.quantity
             symbol = candidate.contract.symbol
             estimated_net_proceeds = quantity * candidate.net_proceeds_per_contract
             estimated_gross_proceeds = quantity * candidate.gross_proceeds_per_contract
             estimated_fees = quantity * candidate.estimated_fee_per_contract
             stock_price = market_prices[symbol]
-            self.order_ops.enqueue_order(candidate.contract, order)
+            self.order_ops.enqueue_order(candidate.contract, plan.order)
             enqueued_symbols.add(symbol)
             self._record_tail_harvest(
                 "harvest_enqueued",
@@ -649,8 +814,8 @@ class RegimeRebalanceEngine:
                 expiration=candidate.expiration,
                 quantity=quantity,
                 limit_price=candidate.limit_price,
-                minimum_limit_price=minimum_limit_price,
-                minimum_net_proceeds_per_contract=minimum_net_proceeds,
+                minimum_limit_price=plan.minimum_limit_price,
+                minimum_net_proceeds_per_contract=plan.minimum_net_proceeds,
                 cost_basis_per_contract=candidate.cost_basis_per_contract,
                 gross_proceeds=estimated_gross_proceeds,
                 estimated_fees=estimated_fees,
@@ -692,12 +857,6 @@ class RegimeRebalanceEngine:
             self.ibkr.portfolio(account=account_number)
         )
 
-        owned_con_ids = {cohort.con_id for cohort in cohorts}
-        working_sale_symbols = self._tail_sale_in_progress_symbols(owned_con_ids)
-        pending_recovery_symbols = {
-            cohort.symbol for cohort in cohorts if cohort.has_pending_recovery
-        }
-        blocked_symbols = working_sale_symbols | pending_recovery_symbols
         rebalance_shares: Dict[str, int] = {}
         for symbol, _primary_exchange, quantity in orders:
             if (
@@ -711,39 +870,32 @@ class RegimeRebalanceEngine:
         if not rebalance_shares:
             return orders
 
+        _unavailable_con_ids, blocked_symbols, blocked_reason = (
+            self._tail_harvest_conflicts(cohorts)
+        )
+
         # The band is portfolio-wide. Until every prior reduction is resolved,
         # its eventual sleeve impact is unknown and no new excess can be sized
         # safely—even for a different target symbol.
-        if blocked_symbols:
-            if pending_recovery_symbols and working_sale_symbols:
-                reason = "unresolved_tail_reduction"
-            elif pending_recovery_symbols:
-                reason = "pending_recovery"
-            else:
-                reason = "working_tail_sale"
-            for symbol, quantity in rebalance_shares.items():
-                self._record_tail_harvest(
-                    "harvest_blocked",
-                    symbol=symbol,
-                    reason=reason,
-                    rebalance_shares=quantity,
-                    blocking_symbols=sorted(blocked_symbols),
-                )
-            log.info(
-                "Skipping a new portfolio tail harvest while prior reductions "
-                f"are unresolved for {', '.join(sorted(blocked_symbols))}."
+        if blocked_reason is not None:
+            self._record_tail_harvest_blocked(
+                rebalance_shares=rebalance_shares,
+                blocked_symbols=blocked_symbols,
+                reason=blocked_reason,
             )
             return orders
 
         current_net_liquidation = self._latest_net_liquidation(net_liquidation)
-        sleeve_value = self._tail_hedge_market_value(portfolio_positions, cohorts)
-        approved_rebalance_value = sum(
-            shares * market_prices[symbol]
-            for symbol, shares in rebalance_shares.items()
+        current_regime_base, _ = self._regime_rebalance_base_value(
+            net_liquidation=current_net_liquidation,
+            portfolio_positions=portfolio_positions,
+            market_prices=market_prices,
+            cohorts=cohorts,
         )
+        sleeve_value = self._tail_hedge_market_value(portfolio_positions, cohorts)
         tail_hedge = self.config.strategies.tail_hedge
         decision = evaluate_harvest_band(
-            net_liquidation=current_net_liquidation,
+            portfolio_base_value=current_regime_base,
             sleeve_value=sleeve_value,
             trigger_weight=tail_hedge.harvest_trigger_weight,
             target_weight=tail_hedge.harvest_target_weight,
@@ -753,9 +905,6 @@ class RegimeRebalanceEngine:
 
         enqueued_symbols = await self._enqueue_tail_harvest(
             net_liquidation=current_net_liquidation,
-            trigger_weight=tail_hedge.harvest_trigger_weight,
-            target_weight=tail_hedge.harvest_target_weight,
-            approved_rebalance_value=approved_rebalance_value,
             rebalance_shares=rebalance_shares,
             market_prices=market_prices,
             cohorts=cohorts,
@@ -1532,7 +1681,6 @@ class RegimeRebalanceEngine:
         portfolio_positions: Dict[str, List[PortfolioItem]],
         *,
         exclude_current_run_state: bool = False,
-        allow_tail_harvest: bool = True,
     ) -> Tuple[Table, List[Tuple[str, str, int]]]:
         symbol_configs = resolve_symbol_configs(
             self.config, context="regime rebalance check"
@@ -1579,8 +1727,6 @@ class RegimeRebalanceEngine:
             raise ValueError(
                 "Regime-aware rebalancing requires positive target weights."
             )
-        managed_regime_symbols = set(symbols)
-
         stock_positions = [
             position
             for symbol in portfolio_positions
@@ -1638,45 +1784,28 @@ class RegimeRebalanceEngine:
 
         last_rebalance = await self._get_last_regime_rebalance_time(symbols)
         tail_cohorts = self._load_tail_cohorts()
-        owned_tail_hedge_con_ids = {cohort.con_id for cohort in tail_cohorts}
 
         weight_base = regime_rebalance.weight_base
         regime_margin_usage = self._resolve_regime_margin_usage()
-        if weight_base == RegimeRebalanceBaseEnum.managed_stocks:
-            total_value = sum(current_values.values())
-        elif weight_base == RegimeRebalanceBaseEnum.net_liq_ex_options:
-            excluded_value = 0.0
-            # Regime checks receive the combined account map for tail ownership.
-            # Ignore unrelated financing options, but retain state-owned tail puts.
-            for positions in portfolio_positions.values():
-                for position in positions:
-                    if isinstance(position.contract, Option) and (
-                        position.contract.symbol in managed_regime_symbols
-                        or position.contract.conId in owned_tail_hedge_con_ids
-                    ):
-                        market_value = float(position.marketValue or 0.0)
-                        excluded_value += market_value
-            net_liq = float(account_summary["NetLiquidation"].value)
-            adjusted_net_liq = net_liq - excluded_value
-            total_value = math.floor(adjusted_net_liq * regime_margin_usage)
+        net_liq = float(account_summary["NetLiquidation"].value)
+        total_value, excluded_value = self._regime_rebalance_base_value(
+            net_liquidation=net_liq,
+            portfolio_positions=portfolio_positions,
+            market_prices=market_prices,
+            cohorts=tail_cohorts,
+        )
+        if weight_base == RegimeRebalanceBaseEnum.net_liq_ex_options:
             log.notice(
                 "Regime rebalancing base: mode=net_liq_ex_options "
                 f"net_liq={dfmt(net_liq)} excluded_options={dfmt(excluded_value)} "
                 f"margin_usage={ffmt(regime_margin_usage)} "
                 f"base={dfmt(total_value)}"
             )
-        else:
-            net_liq = float(account_summary["NetLiquidation"].value)
-            excluded_tail_hedge_value = self._tail_hedge_market_value(
-                portfolio_positions,
-                tail_cohorts,
-            )
-            adjusted_net_liq = net_liq - excluded_tail_hedge_value
-            total_value = math.floor(adjusted_net_liq * regime_margin_usage)
+        elif weight_base == RegimeRebalanceBaseEnum.net_liq:
             log.notice(
                 "Regime rebalancing base: mode=net_liq "
                 f"net_liq={dfmt(net_liq)} "
-                f"excluded_tail_hedges={dfmt(excluded_tail_hedge_value)} "
+                f"excluded_tail_hedges={dfmt(excluded_value)} "
                 f"margin_usage={ffmt(regime_margin_usage)} "
                 f"base={dfmt(total_value)}"
             )
@@ -2395,17 +2524,16 @@ class RegimeRebalanceEngine:
                 }
             )
 
-        if allow_tail_harvest:
-            to_trade = await self._apply_tail_harvest(
-                orders=to_trade,
-                net_liquidation=net_liquidation_value,
-                market_prices=market_prices,
-                regime_summary=regime_summary,
-                hard_underweight_symbols=(
-                    hard_underweight_symbols & harvest_risk_ready_symbols
-                ),
-                cohorts=tail_cohorts,
-            )
+        to_trade = await self._apply_tail_harvest(
+            orders=to_trade,
+            net_liquidation=net_liquidation_value,
+            market_prices=market_prices,
+            regime_summary=regime_summary,
+            hard_underweight_symbols=(
+                hard_underweight_symbols & harvest_risk_ready_symbols
+            ),
+            cohorts=tail_cohorts,
+        )
         for details in regime_summary:
             symbol = str(details["symbol"])
             table.add_row(

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -19,8 +19,11 @@ from thetagang.config_models import RegimeRebalanceBaseEnum
 from thetagang.db import DataStore
 from thetagang.fmt import dfmt, ffmt, ifmt, pfmt
 from thetagang.ibkr import IBKR, TickerField
-from thetagang.orders import PendingBuyCash, pending_buy_cash
 from thetagang.strategies.runtime_services import resolve_symbol_configs
+from thetagang.strategies.tail_harvest_policy import (
+    evaluate_harvest_band,
+    minimum_harvest_limit_price,
+)
 from thetagang.strategies.tail_hedge_state import (
     TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX,
     TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
@@ -43,7 +46,7 @@ REGIME_HISTORY_TIMEFRAME = "1 day"
 REGIME_HISTORY_MAX_ATTEMPTS = 3
 REGIME_HISTORY_RETRY_DELAY_SECONDS = 0.25
 TAIL_HEDGE_HARVEST_EVENT = "tail_hedge_harvest"
-TAIL_HEDGE_HARVEST_SCHEMA_VERSION = 1
+TAIL_HEDGE_HARVEST_SCHEMA_VERSION = 2
 
 
 class RegimeHistoryValidationError(ValueError):
@@ -109,6 +112,10 @@ class HarvestPut:
     net_proceeds_per_contract: float
     cost_basis_per_contract: float
 
+    @property
+    def profit_multiple(self) -> float:
+        return self.net_proceeds_per_contract / self.cost_basis_per_contract
+
 
 def _ffmt_or_dash(value: Optional[float], precision: int = 2) -> str:
     return ffmt(value, precision) if value is not None else "-"
@@ -149,7 +156,6 @@ class RegimeRebalanceEngine:
         get_primary_exchange: Callable[[str], str],
         now_provider: Callable[[], datetime],
         tail_hedge_stage_enabled: Callable[[], bool] | None = None,
-        cash_management_stage_enabled: Callable[[], bool] | None = None,
         set_reserved_cash_for_post_management: Callable[[float], None] | None = None,
     ) -> None:
         self.config = config
@@ -159,9 +165,6 @@ class RegimeRebalanceEngine:
         self._get_primary_exchange = get_primary_exchange
         self._now = now_provider
         self._tail_hedge_stage_enabled = tail_hedge_stage_enabled or (lambda: False)
-        self._cash_management_stage_enabled = cash_management_stage_enabled or (
-            lambda: False
-        )
         self._set_reserved_cash_for_post_management = (
             set_reserved_cash_for_post_management
         )
@@ -189,6 +192,13 @@ class RegimeRebalanceEngine:
                 0.0,
             )
         )
+
+    def _latest_net_liquidation(self, fallback: float) -> float:
+        try:
+            return self.ibkr.cached_net_liquidation(self.config.runtime.account.number)
+        except RuntimeError:
+            # Never substitute a cash-derived proxy for an unavailable NLV.
+            return fallback
 
     def _record_tail_harvest(
         self,
@@ -228,126 +238,6 @@ class RegimeRebalanceEngine:
         if self._tail_state_store is None:
             return []
         return self._tail_state_store.load().open_cohorts
-
-    def _cash_fund_value(
-        self,
-        portfolio_positions: Dict[str, List[PortfolioItem]],
-    ) -> float:
-        cash_management = getattr(self.config.strategies, "cash_management", None)
-        if (
-            not bool(getattr(cash_management, "enabled", False))
-            or not self._cash_management_stage_enabled()
-        ):
-            return 0.0
-        cash_fund = getattr(cash_management, "cash_fund", None)
-        if not isinstance(cash_fund, str) or not cash_fund:
-            return 0.0
-
-        value = 0.0
-        for position in portfolio_positions.get(cash_fund, []):
-            if not isinstance(position.contract, Stock) or (
-                position.contract.symbol != cash_fund
-            ):
-                continue
-            try:
-                quantity = float(position.position)
-                market_price = float(getattr(position, "marketPrice", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                continue
-            if not math.isfinite(quantity) or quantity <= 0:
-                continue
-            if not math.isfinite(market_price) or market_price <= 0:
-                try:
-                    market_value = float(getattr(position, "marketValue", 0.0) or 0.0)
-                except (TypeError, ValueError):
-                    continue
-                if not math.isfinite(market_value) or market_value <= 0:
-                    continue
-                market_price = market_value / quantity
-            if not math.isfinite(market_price) or market_price <= 0:
-                continue
-            value += math.floor(quantity) * market_price
-        return value
-
-    def _queued_cash_debits(self) -> PendingBuyCash:
-        return pending_buy_cash(
-            self.ibkr.open_trades(),
-            self.order_ops.orders.records(),
-            account=self.config.runtime.account.number,
-            estimated_fee_per_contract=float(
-                getattr(
-                    self.config.runtime.orders,
-                    "estimated_fee_per_contract",
-                    0.0,
-                )
-            ),
-        )
-
-    def _ordinary_rebalance_shortfall(
-        self,
-        *,
-        orders: List[Tuple[str, str, int]],
-        account_summary: Dict[str, AccountValue],
-        portfolio_positions: Dict[str, List[PortfolioItem]],
-        market_prices: Dict[str, float],
-    ) -> float:
-        approved_buys = sum(
-            quantity * market_prices[symbol]
-            for symbol, _primary_exchange, quantity in orders
-            if quantity > 0
-        )
-        approved_sells = sum(
-            abs(quantity) * market_prices[symbol]
-            for symbol, _primary_exchange, quantity in orders
-            if quantity < 0
-        )
-
-        cash_value = account_summary.get("TotalCashValue")
-        available_cash = float(getattr(cash_value, "value", 0.0) or 0.0)
-        cash_management = getattr(self.config.strategies, "cash_management", None)
-        cash_target = (
-            float(getattr(cash_management, "target_cash_balance", 0.0) or 0.0)
-            if bool(getattr(cash_management, "enabled", False))
-            else 0.0
-        )
-        queued_cash = self._queued_cash_debits()
-        if queued_cash.ambiguous:
-            return 0.0
-        cash_management_runs = (
-            bool(getattr(cash_management, "enabled", False))
-            and self._cash_management_stage_enabled()
-        )
-        sell_threshold = (
-            float(getattr(cash_management, "sell_threshold", 0.0) or 0.0)
-            if cash_management_runs
-            else 0.0
-        )
-        cash_fund_value = self._cash_fund_value(portfolio_positions)
-        cash_fund_symbol = getattr(cash_management, "cash_fund", None)
-        cash_fund_sales = sum(
-            abs(quantity) * market_prices[symbol]
-            for symbol, _primary_exchange, quantity in orders
-            if quantity < 0 and symbol == cash_fund_symbol
-        )
-        remaining_cash_fund_value = max(0.0, cash_fund_value - cash_fund_sales)
-
-        # This is cash management's fixed point: after the retained buys, it
-        # can liquidate the remaining fund and may leave at most its configured
-        # deficit tolerance. Subtracting an approved fund sale above prevents
-        # counting the same holding twice.
-        ordinary_capacity = max(
-            0.0,
-            available_cash
-            - cash_target
-            - queued_cash.debit
-            + approved_sells
-            + remaining_cash_fund_value
-            + sell_threshold,
-        )
-        return max(
-            0.0,
-            approved_buys - ordinary_capacity,
-        )
 
     @staticmethod
     def _tail_hedge_market_value(
@@ -575,150 +465,214 @@ class RegimeRebalanceEngine:
     async def _enqueue_tail_harvest(
         self,
         *,
-        symbol: str,
-        stock_price: float,
-        deferred_shares: int,
+        net_liquidation: float,
+        trigger_weight: float,
+        target_weight: float,
+        approved_rebalance_value: float,
+        rebalance_shares: Dict[str, int],
+        market_prices: Dict[str, float],
         cohorts: list[TailHedgeCohort],
         portfolio_positions: Dict[str, List[PortfolioItem]],
-    ) -> bool:
-        candidates = await self._profitable_tail_puts(
-            symbol=symbol,
-            cohorts=cohorts,
-            portfolio_positions=portfolio_positions,
-        )
-        candidate = next(
-            (
-                item
-                for item in candidates
-                if math.floor(
-                    item.quantity * item.net_proceeds_per_contract / stock_price
-                )
-                > 0
-            ),
-            None,
-        )
-        if candidate is None or deferred_shares <= 0:
-            self._record_tail_harvest(
-                "no_eligible_cohort",
-                symbol=symbol,
-                deferred_shares=deferred_shares,
-                stock_price=stock_price,
-            )
-            return False
-
-        # Monetize one useful tranche, shortest expiration first. A smaller
-        # earlier tranche remains invested rather than blocking the ladder.
-        total_proceeds = candidate.quantity * candidate.net_proceeds_per_contract
-        fundable_shares = min(
-            deferred_shares,
-            math.floor(total_proceeds / stock_price),
-        )
-        required_proceeds = fundable_shares * stock_price
-        quantity = min(
-            candidate.quantity,
-            math.ceil(required_proceeds / candidate.net_proceeds_per_contract),
-        )
-        estimated_net_proceeds = quantity * candidate.net_proceeds_per_contract
-        if estimated_net_proceeds < required_proceeds:
-            return False
-        estimated_gross_proceeds = quantity * candidate.gross_proceeds_per_contract
-        estimated_fees = quantity * candidate.estimated_fee_per_contract
-        excess_proceeds = estimated_net_proceeds - required_proceeds
-
-        con_id = candidate.contract.conId
+    ) -> set[str]:
         if self._tail_state_store is None:
-            return False
-        state = self._tail_state_store.load()
-        state_cohort = state.find_open(candidate.entry_id, con_id)
-        if (
-            state_cohort is None
-            or state_cohort.symbol != symbol
-            or state_cohort.status != "active"
-            or state_cohort.quantity < quantity
-            or state_cohort.has_pending_recovery
-        ):
-            return False
-        multiplier = float(candidate.contract.multiplier)
-        minimum_profitable_price = (
-            math.floor(
-                (
-                    candidate.cost_basis_per_contract
-                    + candidate.estimated_fee_per_contract
+            return set()
+
+        candidates: list[HarvestPut] = []
+        for symbol in rebalance_shares:
+            candidates.extend(
+                await self._profitable_tail_puts(
+                    symbol=symbol,
+                    cohorts=cohorts,
+                    portfolio_positions=portfolio_positions,
                 )
-                / multiplier
-                * 100
             )
-            + 1
-        ) / 100
-        minimum_net_proceeds = round(
-            minimum_profitable_price * multiplier
-            - candidate.estimated_fee_per_contract,
-            2,
+        candidates.sort(
+            key=lambda candidate: (
+                candidate.expiration,
+                -candidate.net_proceeds_per_contract,
+                candidate.contract.conId,
+            )
         )
-        # Candidate sizing was refreshed from the live portfolio after quotes.
-        # A prior external reduction is not proceeds from this unsubmitted sale.
-        state_cohort.quantity = min(state_cohort.quantity, candidate.quantity)
-        state_cohort.begin_recovery(
-            quantity=quantity,
-            # Actual fill proceeds replace this conservative floor during
-            # tail-state reconciliation.
-            proceeds_per_contract=minimum_net_proceeds,
-            enqueued_at=self._now(),
+
+        # Quote requests yield to ib_async. Re-evaluate the portfolio-level
+        # band from its current cache before persisting or queuing a sale.
+        account_number = self.config.runtime.account.number
+        refreshed_positions = portfolio_positions_to_dict(
+            self.ibkr.portfolio(account=account_number)
         )
+        sleeve_value = self._tail_hedge_market_value(refreshed_positions, cohorts)
+        refreshed_net_liquidation = self._latest_net_liquidation(net_liquidation)
+        decision = evaluate_harvest_band(
+            net_liquidation=refreshed_net_liquidation,
+            sleeve_value=sleeve_value,
+            trigger_weight=trigger_weight,
+            target_weight=target_weight,
+        )
+        if decision is None:
+            return set()
+        sale_budget = decision.sale_budget
+        band_payload = {
+            "net_liquidation": refreshed_net_liquidation,
+            "sleeve_value": decision.sleeve_value,
+            "sleeve_weight": decision.sleeve_weight,
+            "harvest_trigger_weight": trigger_weight,
+            "harvest_target_weight": target_weight,
+            "target_sleeve_value": decision.target_value,
+            "approved_rebalance_value": approved_rebalance_value,
+        }
+
+        selected: list[tuple[HarvestPut, int]] = []
+        selected_con_ids: set[int] = set()
+        remaining = sale_budget
+        for candidate in candidates:
+            con_id = candidate.contract.conId
+            if remaining <= 0.0 or con_id in selected_con_ids:
+                continue
+            # The band measures option market value, so fees must not change
+            # how many contracts are removed from the sleeve.
+            quantity = min(
+                candidate.quantity,
+                math.ceil(remaining / candidate.gross_proceeds_per_contract),
+            )
+            if quantity <= 0:
+                continue
+            selected.append((candidate, quantity))
+            selected_con_ids.add(con_id)
+            remaining -= quantity * candidate.gross_proceeds_per_contract
+
+        if not selected:
+            for symbol, shares in rebalance_shares.items():
+                self._record_tail_harvest(
+                    "no_eligible_cohort",
+                    symbol=symbol,
+                    rebalance_shares=shares,
+                    sale_budget=sale_budget,
+                    **band_payload,
+                )
+            return set()
+
+        state = self._tail_state_store.load()
+        enqueued_at = self._now()
+        planned: list[tuple[HarvestPut, int, Any, float, float]] = []
+        for candidate, quantity in selected:
+            symbol = candidate.contract.symbol
+            con_id = candidate.contract.conId
+            state_cohort = state.find_open(candidate.entry_id, con_id)
+            if (
+                state_cohort is None
+                or state_cohort.symbol != symbol
+                or state_cohort.status != "active"
+                or state_cohort.quantity < quantity
+                or state_cohort.has_pending_recovery
+            ):
+                return set()
+            multiplier = float(candidate.contract.multiplier)
+            minimum_profitable_price = (
+                math.floor(
+                    (
+                        candidate.cost_basis_per_contract
+                        + candidate.estimated_fee_per_contract
+                    )
+                    / multiplier
+                    * 100
+                )
+                + 1
+            ) / 100
+            minimum_limit_price = minimum_harvest_limit_price(
+                quoted_limit_price=candidate.limit_price,
+                sleeve_value=decision.sleeve_value,
+                trigger_value=decision.trigger_value,
+                profitable_limit_price=minimum_profitable_price,
+            )
+            minimum_net_proceeds = round(
+                minimum_limit_price * multiplier - candidate.estimated_fee_per_contract,
+                2,
+            )
+            state_cohort.quantity = min(state_cohort.quantity, candidate.quantity)
+            state_cohort.begin_recovery(
+                quantity=quantity,
+                proceeds_per_contract=minimum_net_proceeds,
+                enqueued_at=enqueued_at,
+            )
+            order = self.order_ops.create_limit_order(
+                action="SELL",
+                quantity=quantity,
+                limit_price=candidate.limit_price,
+                use_default_algo=False,
+                order_ref=build_tail_reduction_order_ref(
+                    f"{TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX}:{symbol}",
+                    con_id,
+                    state_cohort.pending_recovery_enqueued_at,
+                ),
+                transmit=True,
+            )
+            setattr(order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR, minimum_limit_price)
+            planned.append(
+                (
+                    candidate,
+                    quantity,
+                    order,
+                    minimum_limit_price,
+                    minimum_net_proceeds,
+                )
+            )
+
         try:
             self._tail_state_store.save(state)
         except RuntimeError:
             log.error(
-                f"{symbol}: Unable to persist tail-harvest recovery intent; "
-                "keeping the ordinary rebalance order unchanged."
+                "Unable to persist tail-harvest recovery intents; keeping the "
+                "approved rebalance unchanged."
             )
-            return False
-        order = self.order_ops.create_limit_order(
-            action="SELL",
-            quantity=quantity,
-            limit_price=candidate.limit_price,
-            use_default_algo=False,
-            order_ref=build_tail_reduction_order_ref(
-                f"{TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX}:{symbol}",
-                con_id,
-                state_cohort.pending_recovery_enqueued_at,
-            ),
-            transmit=True,
-        )
-        setattr(order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR, minimum_profitable_price)
-        self.order_ops.enqueue_order(candidate.contract, order)
-        self._record_tail_harvest(
-            "harvest_enqueued",
-            symbol=symbol,
-            entry_id=candidate.entry_id,
-            con_id=con_id,
-            expiration=candidate.expiration,
-            quantity=quantity,
-            limit_price=candidate.limit_price,
-            cost_basis_per_contract=candidate.cost_basis_per_contract,
-            gross_proceeds=estimated_gross_proceeds,
-            estimated_fees=estimated_fees,
-            net_proceeds=estimated_net_proceeds,
-            required_proceeds=required_proceeds,
-            excess_proceeds=excess_proceeds,
-            stock_price=stock_price,
-            deferred_shares=deferred_shares,
-            fundable_shares=fundable_shares,
-        )
-        log.notice(
-            f"{symbol}: Harvesting {quantity} profitable tail put(s) from one "
-            f"tranche for about {dfmt(estimated_net_proceeds)} net of estimated "
-            f"fees; excess over this rebalance slice={dfmt(excess_proceeds)}, "
-            f"fundable deferred shares={fundable_shares}."
-        )
-        return True
+            return set()
+
+        enqueued_symbols: set[str] = set()
+        for (
+            candidate,
+            quantity,
+            order,
+            minimum_limit_price,
+            minimum_net_proceeds,
+        ) in planned:
+            symbol = candidate.contract.symbol
+            estimated_net_proceeds = quantity * candidate.net_proceeds_per_contract
+            estimated_gross_proceeds = quantity * candidate.gross_proceeds_per_contract
+            estimated_fees = quantity * candidate.estimated_fee_per_contract
+            stock_price = market_prices[symbol]
+            self.order_ops.enqueue_order(candidate.contract, order)
+            enqueued_symbols.add(symbol)
+            self._record_tail_harvest(
+                "harvest_enqueued",
+                symbol=symbol,
+                entry_id=candidate.entry_id,
+                con_id=candidate.contract.conId,
+                expiration=candidate.expiration,
+                quantity=quantity,
+                limit_price=candidate.limit_price,
+                minimum_limit_price=minimum_limit_price,
+                minimum_net_proceeds_per_contract=minimum_net_proceeds,
+                cost_basis_per_contract=candidate.cost_basis_per_contract,
+                gross_proceeds=estimated_gross_proceeds,
+                estimated_fees=estimated_fees,
+                net_proceeds=estimated_net_proceeds,
+                stock_price=stock_price,
+                rebalance_shares=rebalance_shares[symbol],
+                profit_multiple=candidate.profit_multiple,
+                sale_budget=sale_budget,
+                **band_payload,
+            )
+            log.notice(
+                f"{symbol}: Harvesting {quantity} earliest-expiring profitable "
+                f"tail put(s) for about {dfmt(estimated_net_proceeds)} net of "
+                "estimated fees before the approved hard rebalance."
+            )
+        return enqueued_symbols
 
     async def _apply_tail_harvest(
         self,
         *,
         orders: List[Tuple[str, str, int]],
-        account_summary: Dict[str, AccountValue],
-        portfolio_positions: Dict[str, List[PortfolioItem]],
+        net_liquidation: float,
         market_prices: Dict[str, float],
         regime_summary: List[Dict[str, Any]],
         hard_underweight_symbols: set[str],
@@ -728,29 +682,15 @@ class RegimeRebalanceEngine:
         if not targets or not cohorts or not hard_underweight_symbols:
             return orders
 
-        # Re-materialize ib_async's fill-current caches after preceding awaits;
-        # no broker refresh request is needed.
+        # Cash is intentionally absent from this decision. A harvest is an
+        # allocation response to a same-symbol hard-underweight buy, not an
+        # attempt to infer deployable capital from IBKR cash accounting.
+        # Re-materialize ib_async's fill-current portfolio cache after
+        # preceding awaits; no broker refresh request is needed.
         account_number = self.config.runtime.account.number
-        try:
-            live_cash = self.ibkr.cached_account_value(account_number, "TotalCashValue")
-        except RuntimeError:
-            return orders
-        account_summary = dict(account_summary)
-        account_summary["TotalCashValue"] = AccountValue(
-            account_number, "TotalCashValue", str(live_cash), "BASE", ""
-        )
         portfolio_positions = portfolio_positions_to_dict(
             self.ibkr.portfolio(account=account_number)
         )
-
-        funding_shortfall = self._ordinary_rebalance_shortfall(
-            orders=orders,
-            account_summary=account_summary,
-            portfolio_positions=portfolio_positions,
-            market_prices=market_prices,
-        )
-        if funding_shortfall <= 0:
-            return orders
 
         owned_con_ids = {cohort.con_id for cohort in cohorts}
         working_sale_symbols = self._tail_sale_in_progress_symbols(owned_con_ids)
@@ -758,117 +698,83 @@ class RegimeRebalanceEngine:
             cohort.symbol for cohort in cohorts if cohort.has_pending_recovery
         }
         blocked_symbols = working_sale_symbols | pending_recovery_symbols
-        summaries = {str(item["symbol"]): item for item in regime_summary}
-        eligible_buys = {
-            symbol: (quantity, quantity * market_prices[symbol])
-            for symbol, _primary_exchange, quantity in orders
-            if quantity > 0 and symbol in targets and symbol in hard_underweight_symbols
-        }
-        eligible_buy_value = sum(value for _quantity, value in eligible_buys.values())
-        if eligible_buy_value <= 0:
-            return orders
-        allocatable_shortfall = min(funding_shortfall, eligible_buy_value)
-        dollar_allocations = {
-            symbol: allocatable_shortfall * buy_value / eligible_buy_value
-            for symbol, (_quantity, buy_value) in eligible_buys.items()
-        }
-        deferred_by_symbol = {
-            symbol: min(
-                quantity,
-                math.floor(dollar_allocations[symbol] / market_prices[symbol]),
-            )
-            for symbol, (quantity, _buy_value) in eligible_buys.items()
-        }
-        deferred_value = sum(
-            quantity * market_prices[symbol]
-            for symbol, quantity in deferred_by_symbol.items()
-        )
-        # Largest-remainder apportionment keeps scarce cash proportional in
-        # dollars; symbol is only the deterministic tie-break for whole shares.
-        remainder_order = sorted(
-            eligible_buys,
-            key=lambda symbol: (
-                -(
-                    dollar_allocations[symbol] / market_prices[symbol]
-                    - deferred_by_symbol[symbol]
-                ),
-                symbol,
-            ),
-        )
-        for symbol in remainder_order:
-            if deferred_value >= allocatable_shortfall or math.isclose(
-                deferred_value,
-                allocatable_shortfall,
-                abs_tol=1e-6,
-            ):
-                break
-            quantity = eligible_buys[symbol][0]
-            if deferred_by_symbol[symbol] >= quantity:
-                continue
-            deferred_by_symbol[symbol] += 1
-            deferred_value += market_prices[symbol]
-
-        retained_orders: list[tuple[str, str, int]] = []
-        for symbol, primary_exchange, quantity in orders:
+        rebalance_shares: Dict[str, int] = {}
+        for symbol, _primary_exchange, quantity in orders:
             if (
                 quantity <= 0
                 or symbol not in targets
                 or symbol not in hard_underweight_symbols
             ):
-                retained_orders.append((symbol, primary_exchange, quantity))
                 continue
+            rebalance_shares[symbol] = quantity
 
-            stock_price = market_prices[symbol]
-            allocated_deferred_shares = deferred_by_symbol.get(symbol, 0)
-            if allocated_deferred_shares <= 0:
-                retained_orders.append((symbol, primary_exchange, quantity))
-                continue
-            if symbol in blocked_symbols:
-                # Do not spend estimated proceeds from a harvest that is still
-                # working or awaiting reconciliation. Keep only the
-                # ordinary-funded stock slice; a later invocation starts from a
-                # newly synchronized broker snapshot.
-                harvest_pending = True
-                reason = (
-                    "pending_recovery"
-                    if symbol in pending_recovery_symbols
-                    else "working_tail_sale"
-                )
+        if not rebalance_shares:
+            return orders
+
+        # The band is portfolio-wide. Until every prior reduction is resolved,
+        # its eventual sleeve impact is unknown and no new excess can be sized
+        # safely—even for a different target symbol.
+        if blocked_symbols:
+            if pending_recovery_symbols and working_sale_symbols:
+                reason = "unresolved_tail_reduction"
+            elif pending_recovery_symbols:
+                reason = "pending_recovery"
+            else:
+                reason = "working_tail_sale"
+            for symbol, quantity in rebalance_shares.items():
                 self._record_tail_harvest(
-                    "harvest_deferred",
+                    "harvest_blocked",
                     symbol=symbol,
                     reason=reason,
-                    deferred_shares=allocated_deferred_shares,
-                    funding_shortfall=funding_shortfall,
-                    live_cash=live_cash,
+                    rebalance_shares=quantity,
+                    blocking_symbols=sorted(blocked_symbols),
                 )
-                log.info(
-                    f"{symbol}: Deferring {allocated_deferred_shares} stock "
-                    f"share(s); tail harvest blocked by {reason}."
-                )
-            else:
-                harvest_pending = await self._enqueue_tail_harvest(
-                    symbol=symbol,
-                    stock_price=stock_price,
-                    deferred_shares=allocated_deferred_shares,
-                    cohorts=cohorts,
-                    portfolio_positions=portfolio_positions,
-                )
-            deferred_shares = allocated_deferred_shares if harvest_pending else 0
-            retained_quantity = quantity - deferred_shares
-            if retained_quantity > 0:
-                retained_orders.append((symbol, primary_exchange, retained_quantity))
+            log.info(
+                "Skipping a new portfolio tail harvest while prior reductions "
+                f"are unresolved for {', '.join(sorted(blocked_symbols))}."
+            )
+            return orders
+
+        current_net_liquidation = self._latest_net_liquidation(net_liquidation)
+        sleeve_value = self._tail_hedge_market_value(portfolio_positions, cohorts)
+        approved_rebalance_value = sum(
+            shares * market_prices[symbol]
+            for symbol, shares in rebalance_shares.items()
+        )
+        tail_hedge = self.config.strategies.tail_hedge
+        decision = evaluate_harvest_band(
+            net_liquidation=current_net_liquidation,
+            sleeve_value=sleeve_value,
+            trigger_weight=tail_hedge.harvest_trigger_weight,
+            target_weight=tail_hedge.harvest_target_weight,
+        )
+        if decision is None:
+            return orders
+
+        enqueued_symbols = await self._enqueue_tail_harvest(
+            net_liquidation=current_net_liquidation,
+            trigger_weight=tail_hedge.harvest_trigger_weight,
+            target_weight=tail_hedge.harvest_target_weight,
+            approved_rebalance_value=approved_rebalance_value,
+            rebalance_shares=rebalance_shares,
+            market_prices=market_prices,
+            cohorts=cohorts,
+            portfolio_positions=portfolio_positions,
+        )
+        summaries = {str(item["symbol"]): item for item in regime_summary}
+        for symbol in enqueued_symbols:
             summary = summaries.get(symbol)
-            if summary is not None and deferred_shares > 0:
-                summary["shares_to_trade"] = retained_quantity
+            if summary is not None:
                 summary["action"] = (
-                    f"[green]Buy {retained_quantity}; "
-                    f"[magenta]defer {deferred_shares} to tail proceeds"
-                    if retained_quantity > 0
-                    else f"[magenta]Harvest puts; defer {deferred_shares}"
+                    f"[magenta]Harvest puts first; "
+                    f"[green]buy {rebalance_shares[symbol]}"
                 )
 
-        return retained_orders
+        # The stock orders are preliminary planning output. In live mode a
+        # newly queued harvest executes first, then the full regime plan is
+        # recalculated from refreshed broker state. Existing or unavailable
+        # harvests never mutate an otherwise approved rebalance.
+        return orders
 
     @staticmethod
     def _as_int_or_none(value: Any) -> int | None:
@@ -1626,6 +1532,7 @@ class RegimeRebalanceEngine:
         portfolio_positions: Dict[str, List[PortfolioItem]],
         *,
         exclude_current_run_state: bool = False,
+        allow_tail_harvest: bool = True,
     ) -> Tuple[Table, List[Tuple[str, str, int]]]:
         symbol_configs = resolve_symbol_configs(
             self.config, context="regime rebalance check"
@@ -2488,17 +2395,17 @@ class RegimeRebalanceEngine:
                 }
             )
 
-        to_trade = await self._apply_tail_harvest(
-            orders=to_trade,
-            account_summary=account_summary,
-            portfolio_positions=portfolio_positions,
-            market_prices=market_prices,
-            regime_summary=regime_summary,
-            hard_underweight_symbols=(
-                hard_underweight_symbols & harvest_risk_ready_symbols
-            ),
-            cohorts=tail_cohorts,
-        )
+        if allow_tail_harvest:
+            to_trade = await self._apply_tail_harvest(
+                orders=to_trade,
+                net_liquidation=net_liquidation_value,
+                market_prices=market_prices,
+                regime_summary=regime_summary,
+                hard_underweight_symbols=(
+                    hard_underweight_symbols & harvest_risk_ready_symbols
+                ),
+                cohorts=tail_cohorts,
+            )
         for details in regime_summary:
             symbol = str(details["symbol"])
             table.add_row(

--- a/thetagang/strategies/tail_harvest_policy.py
+++ b/thetagang/strategies/tail_harvest_policy.py
@@ -15,14 +15,14 @@ class HarvestBandDecision:
 
 def evaluate_harvest_band(
     *,
-    net_liquidation: float,
+    portfolio_base_value: float,
     sleeve_value: float,
     trigger_weight: float,
     target_weight: float,
 ) -> HarvestBandDecision | None:
     """Return the value to harvest after a tail sleeve breaches its band."""
     values = (
-        net_liquidation,
+        portfolio_base_value,
         sleeve_value,
         trigger_weight,
         target_weight,
@@ -30,7 +30,7 @@ def evaluate_harvest_band(
     if any(not math.isfinite(value) for value in values):
         return None
     if (
-        net_liquidation <= 0.0
+        portfolio_base_value <= 0.0
         or sleeve_value <= 0.0
         or trigger_weight <= 0.0
         or target_weight < 0.0
@@ -38,18 +38,18 @@ def evaluate_harvest_band(
     ):
         return None
 
-    trigger_value = net_liquidation * trigger_weight
+    trigger_value = portfolio_base_value * trigger_weight
     if sleeve_value <= trigger_value:
         return None
 
-    target_value = net_liquidation * target_weight
+    target_value = portfolio_base_value * target_weight
     sale_budget = sleeve_value - target_value
     if sale_budget <= 0.0:
         return None
 
     return HarvestBandDecision(
         sleeve_value=sleeve_value,
-        sleeve_weight=sleeve_value / net_liquidation,
+        sleeve_weight=sleeve_value / portfolio_base_value,
         trigger_value=trigger_value,
         target_value=target_value,
         sale_budget=sale_budget,

--- a/thetagang/strategies/tail_harvest_policy.py
+++ b/thetagang/strategies/tail_harvest_policy.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HarvestBandDecision:
+    sleeve_value: float
+    sleeve_weight: float
+    trigger_value: float
+    target_value: float
+    sale_budget: float
+
+
+def evaluate_harvest_band(
+    *,
+    net_liquidation: float,
+    sleeve_value: float,
+    trigger_weight: float,
+    target_weight: float,
+) -> HarvestBandDecision | None:
+    """Return the value to harvest after a tail sleeve breaches its band."""
+    values = (
+        net_liquidation,
+        sleeve_value,
+        trigger_weight,
+        target_weight,
+    )
+    if any(not math.isfinite(value) for value in values):
+        return None
+    if (
+        net_liquidation <= 0.0
+        or sleeve_value <= 0.0
+        or trigger_weight <= 0.0
+        or target_weight < 0.0
+        or target_weight >= trigger_weight
+    ):
+        return None
+
+    trigger_value = net_liquidation * trigger_weight
+    if sleeve_value <= trigger_value:
+        return None
+
+    target_value = net_liquidation * target_weight
+    sale_budget = sleeve_value - target_value
+    if sale_budget <= 0.0:
+        return None
+
+    return HarvestBandDecision(
+        sleeve_value=sleeve_value,
+        sleeve_weight=sleeve_value / net_liquidation,
+        trigger_value=trigger_value,
+        target_value=target_value,
+        sale_budget=sale_budget,
+    )
+
+
+def minimum_harvest_limit_price(
+    *,
+    quoted_limit_price: float,
+    sleeve_value: float,
+    trigger_value: float,
+    profitable_limit_price: float,
+) -> float:
+    """Protect both profitability and the band condition during repricing."""
+    values = (
+        quoted_limit_price,
+        sleeve_value,
+        trigger_value,
+        profitable_limit_price,
+    )
+    if any(not math.isfinite(value) or value <= 0.0 for value in values):
+        raise ValueError("harvest limit inputs must be finite and positive")
+    if trigger_value >= sleeve_value:
+        raise ValueError("harvest sleeve must be above its trigger")
+
+    trigger_ratio = trigger_value / sleeve_value
+    band_threshold_cents = quoted_limit_price * trigger_ratio * 100.0
+    band_limit_price = (math.floor(band_threshold_cents + 1e-9) + 1) / 100.0
+    return max(profitable_limit_price, band_limit_price)


### PR DESCRIPTION
## Summary

Replace cash-shortfall-driven tail-hedge harvesting with a simple portfolio allocation band. When a configured tail sleeve rises above 5% of net liquidation value and the same symbol has an approved hard-underweight stock buy, ThetaGang sells profitable, state-owned puts toward a 3% target before replanning the rebalance from refreshed broker state.

## User Impact

A crash can now monetize oversized tail protection during the normal once-daily run without guessing at a trough or waiting until 30 DTE. Box-spread proceeds, reported cash balances, cash-fund holdings, and unrelated orders do not affect the harvest decision or sale budget. Existing overlay options remain neutral in allocation accounting rather than being subtracted from broker NLV a second time.

## Root Cause

The prior harvest path treated put sales as a way to fill an estimated cash shortfall. That coupled the decision to IBKR cash presentation and cash-management state, even though financing overlays can make those balances misleading, and sized harvesting around the preliminary stock order rather than the economic size of the tail sleeve.

## Fix

- Add configurable `harvest_trigger_weight` and `harvest_target_weight` settings with validated 5% and 3% defaults.
- Measure only live, state-owned tail puts against current broker `NetLiquidation` and size sales from the portfolio-wide excess above the target band.
- Select profitable cohorts by earliest expiration, using whole-contract rounding and fee-aware profitability checks.
- Protect repricing with both a profitable limit floor and a floor that keeps the sleeve above its trigger at the executable quote.
- Persist recovery intent before submitting orders, serialize unresolved reductions portfolio-wide, and allow only one bounded harvest phase per invocation.
- Refresh broker state and rebuild the full regime plan after fills; abort before final submission if every expected stock order is not prepared safely.
- Document the allocation semantics, including the treatment of unrelated financing and overlay options.

## Validation

- `uv run pytest` — 502 passed.
- `uv run pre-commit run --all-files` — YAML, whitespace, Ruff lint/format, lockfile, and type checks passed.
- Commit-time hooks passed.
