### PR TITLE
refactor: make run stages authoritative

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,10 @@ recent executions tagged with `tg:regime-rebalance`. When using this feature,
 run the script once per day.
 
 ```toml
-[regime_rebalance]
+[run]
+strategies = ["regime_rebalance"]
+
+[strategies.regime_rebalance]
 enabled = true
 symbols = ["QQQ", "BTAL"]
 lookback_days = 40
@@ -228,8 +231,14 @@ cooldown_days = 5
 choppiness_min = 3.0
 efficiency_max = 0.30
 order_history_lookback_days = 30
-shares_only = true  # disable option writes/rolls while rebalancing
 ```
+
+The resolved `run.strategies` or `run.stages` plan controls which trading
+capabilities execute. `regime_rebalance` enables only its equity-rebalance
+stage; it does not enable wheel option writing or management. The historical
+`strategies.regime_rebalance.shares_only` setting is deprecated and ignored.
+Existing schema-v2 configurations that still include it load with a warning and
+should remove it.
 
 ### Exchange Hours Management
 

--- a/docs/tail-hedging.md
+++ b/docs/tail-hedging.md
@@ -292,10 +292,11 @@ catastrophe_drawdowns = [0.40, 0.50, 0.60]
 ```
 
 When tail hedging is enabled, each target symbol must also appear in
-`portfolio.symbols`. If regime rebalancing is enabled,
-`regime_rebalance.shares_only` must be `false`. Enable
-`regime_rebalance` and add it to `run.strategies` if you want profitable puts to
-be monetized during hard-underweight buys.
+`portfolio.symbols`. Enable `regime_rebalance` and add it alongside `tail_hedge`
+in `run.strategies` if you want profitable puts to be monetized during
+hard-underweight buys. Tail-hedge option trading and regime share rebalancing
+are independent stages; the deprecated `regime_rebalance.shares_only` setting
+has no effect.
 
 The values above show the configuration shape. They are not trading advice or
 calibrated defaults for every account.

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -661,6 +661,8 @@ weight = 1.0
     assert "strategies" in run
     assert "stages" not in run
     assert run["strategies"] == ["regime_rebalance"]
+    assert "shares_only" not in parsed["strategies"]["regime_rebalance"]
+    assert any("shares_only" in warning for warning in migrated.warnings)
     assert not any("explicit run.stages" in warning for warning in migrated.warnings)
 
 
@@ -697,6 +699,8 @@ weight = 1.0
     assert "strategies" in run
     assert "stages" not in run
     assert run["strategies"] == ["regime_rebalance"]
+    assert "shares_only" not in parsed["strategies"]["regime_rebalance"]
+    assert any("shares_only" in warning for warning in migrated.warnings)
 
 
 def test_migration_cash_management_enabled_does_not_force_wheel_strategy() -> None:

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -1,8 +1,13 @@
+from io import StringIO
+
 import pytest
+from rich.console import Console
 
 from thetagang.config import (
+    SHARES_ONLY_DEPRECATION_MESSAGE,
     Config,
     RebalanceMode,
+    config_deprecation_warnings,
     stage_enabled_map,
     stage_enabled_map_from_run,
 )
@@ -223,7 +228,7 @@ def test_enabled_tail_hedge_requires_a_managed_symbol() -> None:
         Config(**data)
 
 
-def test_tail_hedge_rejects_shares_only_regime_mode() -> None:
+def test_tail_hedge_accepts_deprecated_shares_only_regime_setting() -> None:
     data = _base_config({"strategies": ["regime_rebalance", "tail_hedge"]})
     data["strategies"]["regime_rebalance"] = {
         "enabled": True,
@@ -234,8 +239,41 @@ def test_tail_hedge_rejects_shares_only_regime_mode() -> None:
         "targets": [_tail_target()],
     }
 
-    with pytest.raises(ValueError, match="cannot be enabled when shares_only is true"):
-        Config(**data)
+    config = Config(**data)
+
+    flags = stage_enabled_map(config)
+    assert flags["equity_regime_rebalance"] is True
+    assert flags["post_tail_hedge"] is True
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_explicit_shares_only_setting_emits_deprecation_message(value: bool) -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    data["strategies"]["regime_rebalance"] = {"shares_only": value}
+
+    warnings = config_deprecation_warnings(data)
+
+    assert warnings == [SHARES_ONLY_DEPRECATION_MESSAGE]
+
+
+def test_trading_capabilities_are_derived_from_resolved_stages() -> None:
+    data = _base_config(
+        {"strategies": ["regime_rebalance", "tail_hedge", "cash_management"]}
+    )
+    config = Config(**data)
+    output = StringIO()
+    console = Console(file=output, width=140, color_system=None)
+
+    console.print(config.create_trading_capabilities_table())
+
+    rendered = output.getvalue()
+    assert "Regime share rebalancing" in rendered
+    assert "Tail-hedge option trading" in rendered
+    assert "Cash management" in rendered
+    assert "Wheel put writing" in rendered
+    assert "equity_regime_rebalance" in rendered
+    assert "post_tail_hedge" in rendered
+    assert rendered.count("Enabled") == 3
 
 
 def test_tail_hedge_accepts_an_empty_desired_target_set_for_cleanup() -> None:

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -736,7 +736,6 @@ class TestPortfolioManager:
             },
         )
 
-        pm.options_trading_enabled = mocker.Mock(return_value=False)
         pm.initialize_account = mocker.Mock()
         pm.summarize_account = mocker.AsyncMock(return_value=({}, {}))
         pm.get_portfolio_positions = mocker.Mock(return_value={})
@@ -778,7 +777,8 @@ class TestPortfolioManager:
             ],
         )
 
-        pm.options_trading_enabled = mocker.Mock(return_value=True)
+        mock_config.strategies.regime_rebalance.enabled = True
+        mock_config.strategies.regime_rebalance.shares_only = True
         pm.initialize_account = mocker.Mock()
         pm.summarize_account = mocker.AsyncMock(return_value=({}, {}))
         pm.get_portfolio_positions = mocker.Mock(return_value={})
@@ -787,7 +787,7 @@ class TestPortfolioManager:
         calls: list[tuple[str, set[str]]] = []
 
         async def fake_run_option_write_stages(
-            deps, _account_summary, _portfolio_positions, _options_enabled
+            deps, _account_summary, _portfolio_positions
         ):
             calls.append(("write", set(deps.enabled_stages)))
 
@@ -1255,7 +1255,6 @@ class TestPortfolioManager:
         portfolio_manager.run_stage_order = ["equity_regime_rebalance"]
         portfolio_manager.initialize_account = mocker.Mock()
         portfolio_manager.summarize_account = mocker.AsyncMock(return_value=({}, {}))
-        portfolio_manager.options_trading_enabled = mocker.Mock(return_value=False)
         portfolio_manager._run_regime_rebalance_stage = mocker.AsyncMock(
             side_effect=RuntimeError("Tail-harvest execution did not fully fill")
         )

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -97,7 +97,6 @@ def portfolio_manager(mock_ib, mocker):
                 deficit_rail_stop=0.03,
                 eps=1e-8,
                 order_history_lookback_days=30,
-                shares_only=False,
                 weight_base=RegimeRebalanceBaseEnum.net_liq_ex_options,
             ),
         ),
@@ -148,7 +147,6 @@ def portfolio_manager_with_db(mock_ib, mocker, tmp_path):
                 deficit_rail_stop=0.03,
                 eps=1e-8,
                 order_history_lookback_days=30,
-                shares_only=False,
                 weight_base=RegimeRebalanceBaseEnum.net_liq_ex_options,
             ),
         ),
@@ -2841,11 +2839,6 @@ def test_normalize_config_converts_parts_to_weights():
     assert normalized["symbols"]["AAA"]["weight"] == pytest.approx(0.3)
     assert normalized["symbols"]["BBB"]["weight"] == pytest.approx(0.3)
     assert normalized["symbols"]["CCC"]["weight"] == pytest.approx(0.4)
-
-
-def test_regime_rebalance_shares_only_disables_options(portfolio_manager):
-    portfolio_manager.config.strategies.regime_rebalance.shares_only = True
-    assert portfolio_manager.options_trading_enabled() is False
 
 
 def test_regime_rebalance_config_rejects_inverted_bands():

--- a/tests/test_strategy_stage_runners.py
+++ b/tests/test_strategy_stage_runners.py
@@ -25,7 +25,7 @@ from thetagang.strategies.post import (
 
 
 @pytest.mark.asyncio
-async def test_run_option_write_stages_skips_when_options_disabled(mocker):
+async def test_run_option_write_stages_skips_stages_not_enabled():
     write_service = SimpleNamespace(
         check_if_can_write_puts=AsyncMock(),
         write_puts=AsyncMock(),
@@ -33,12 +33,12 @@ async def test_run_option_write_stages_skips_when_options_disabled(mocker):
         write_calls=AsyncMock(),
     )
     deps = OptionsStrategyDeps(
-        enabled_stages={"options_write_puts", "options_write_calls"},
+        enabled_stages=set(),
         write_service=cast(OptionsWriteService, write_service),
         manage_service=cast(OptionsManageService, SimpleNamespace()),
     )
 
-    await run_option_write_stages(deps, {}, {}, options_enabled=False)
+    await run_option_write_stages(deps, {}, {})
 
     write_service.check_if_can_write_puts.assert_not_called()
     write_service.check_for_uncovered_positions.assert_not_called()
@@ -68,7 +68,7 @@ async def test_run_option_write_stages_puts_and_calls_paths(mocker):
     )
     print_mock = mocker.patch("thetagang.strategies.options.log.print")
 
-    await run_option_write_stages(deps, {}, {}, options_enabled=True)
+    await run_option_write_stages(deps, {}, {})
 
     write_service.check_if_can_write_puts.assert_awaited_once()
     write_service.write_puts.assert_awaited_once_with(["PUT_ORDER"])
@@ -93,7 +93,7 @@ async def test_run_option_management_stages_roll_only(mocker):
         manage_service=cast(OptionsManageService, manage_service),
     )
 
-    await run_option_management_stages(deps, {}, {}, options_enabled=True)
+    await run_option_management_stages(deps, {}, {})
 
     manage_service.roll_puts.assert_awaited_once_with(["RP"], {})
     manage_service.roll_calls.assert_awaited_once_with(["RC"], {}, {})
@@ -117,7 +117,7 @@ async def test_run_option_management_stages_close_only(mocker):
         manage_service=cast(OptionsManageService, manage_service),
     )
 
-    await run_option_management_stages(deps, {}, {}, options_enabled=True)
+    await run_option_management_stages(deps, {}, {})
 
     manage_service.roll_puts.assert_not_called()
     manage_service.roll_calls.assert_not_called()
@@ -141,7 +141,7 @@ async def test_run_option_management_stages_roll_and_close_combines_results(mock
         manage_service=cast(OptionsManageService, manage_service),
     )
 
-    await run_option_management_stages(deps, {}, {}, options_enabled=True)
+    await run_option_management_stages(deps, {}, {})
 
     manage_service.roll_puts.assert_awaited_once_with(["RP"], {})
     manage_service.roll_calls.assert_awaited_once_with(["RC"], {}, {})

--- a/tests/test_thetagang_startup.py
+++ b/tests/test_thetagang_startup.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
+import tomlkit
+
 import thetagang.thetagang as tg
+from thetagang.config import SHARES_ONLY_DEPRECATION_MESSAGE
 
 
 def test_configure_ib_async_logging_noop_when_empty(monkeypatch):
@@ -50,3 +53,26 @@ def test_configure_ib_async_logging_warns_and_continues_on_oserror(
     assert len(warnings) == 1
     assert "Unable to initialize ib_async logfile" in warnings[0]
     assert str(Path(target)) in warnings[0]
+
+
+def test_start_warns_when_deprecated_shares_only_is_configured(monkeypatch, tmp_path):
+    config_doc = tomlkit.parse(
+        Path("thetagang.toml").read_text(encoding="utf8")
+    ).unwrap()
+    config_doc["runtime"]["database"]["enabled"] = False
+    config_doc["runtime"]["ib_async"]["logfile"] = ""
+    config_doc["strategies"]["regime_rebalance"] = {"shares_only": False}
+    config_path = tmp_path / "thetagang.toml"
+    config_path.write_text(
+        tomlkit.dumps(tomlkit.item(config_doc)),
+        encoding="utf8",
+    )
+    warnings: list[str] = []
+
+    monkeypatch.setattr(tg.Config, "display", lambda *_args: None)
+    monkeypatch.setattr(tg, "need_to_exit", lambda *_args: True)
+    monkeypatch.setattr(tg.log, "warning", lambda message: warnings.append(message))
+
+    tg.start(str(config_path), dry_run=True)
+
+    assert warnings == [SHARES_ONLY_DEPRECATION_MESSAGE]

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -2,7 +2,10 @@
 schema_version = 2
 
 [run]
+# This strategy plan is authoritative: only its resolved trading stages run.
+# Strategy-specific sections below configure how those stages behave.
 strategies = ["wheel", "vix_call_hedge", "cash_management"]
+
 [runtime.account]
 # The account number to operate on
 number = "DU1234567"
@@ -642,7 +645,6 @@ daily_stddev_window = "30 D"
 # deficit_rail_start = 0.06  # deficit that triggers safety rail (fraction of base)
 # deficit_rail_stop = 0.03  # hysteresis stop once within this band (fraction of base)
 # order_history_lookback_days = 30  # look back this many calendar days for fills
-# shares_only = false  # when true, disables all option writes/rolls
 # Effective symbol weights are absolute targets and are not renormalized. A total
 # below 100% remains outside the managed targets as cash (or the configured cash
 # fund); a total above 100% aborts. The managed_stocks base requires exactly 100%.

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from collections.abc import Mapping
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from rich import box
@@ -59,6 +61,25 @@ CANONICAL_STAGE_ORDER: list[str] = [
     "post_tail_hedge",
     "post_cash_management",
 ]
+
+STAGE_CAPABILITY_LABELS: dict[str, str] = {
+    "options_write_puts": "Wheel put writing",
+    "options_write_calls": "Wheel call writing",
+    "equity_regime_rebalance": "Regime share rebalancing",
+    "equity_buy_rebalance": "Wheel share buying",
+    "equity_sell_rebalance": "Wheel share selling",
+    "options_roll_positions": "Wheel option rolling",
+    "options_close_positions": "Wheel option closing",
+    "post_vix_call_hedge": "VIX call hedging",
+    "post_tail_hedge": "Tail-hedge option trading",
+    "post_cash_management": "Cash management",
+}
+
+SHARES_ONLY_DEPRECATION_MESSAGE = (
+    "Deprecated config: strategies.regime_rebalance.shares_only has no effect. "
+    "Option trading is controlled by run.strategies/run.stages. Remove this "
+    "setting from your configuration."
+)
 
 WHEEL_OPTION_STAGE_IDS = {
     "options_write_puts",
@@ -500,9 +521,6 @@ class Config(BaseModel, DisplayMixin):
                 "tail_hedge target symbols must be in portfolio.symbols: "
                 + ", ".join(missing_symbols)
             )
-        regime_rebalance = self.strategies.regime_rebalance
-        if regime_rebalance.enabled and regime_rebalance.shares_only:
-            raise ValueError("tail_hedge cannot be enabled when shares_only is true")
         return self
 
     @property
@@ -779,6 +797,26 @@ class Config(BaseModel, DisplayMixin):
             )
         return table
 
+    def create_trading_capabilities_table(self) -> Table:
+        table = Table(
+            title="Trading capabilities (resolved from run)",
+            box=box.SIMPLE_HEAVY,
+        )
+        table.add_column("Capability")
+        table.add_column("Status", justify="center")
+        table.add_column("Stage")
+
+        enabled_stage_ids = {
+            stage.id for stage in self.run.resolved_stages() if stage.enabled
+        }
+        for stage_id in CANONICAL_STAGE_ORDER:
+            table.add_row(
+                STAGE_CAPABILITY_LABELS[stage_id],
+                "Enabled" if stage_id in enabled_stage_ids else "Disabled",
+                stage_id,
+            )
+        return table
+
     def display(self, config_path: str) -> None:
         console = Console()
         config_table = Table(box=box.SIMPLE_HEAVY)
@@ -803,6 +841,12 @@ class Config(BaseModel, DisplayMixin):
 
         tree = Tree(":control_knobs:")
         tree.add(Group(f":file_cabinet: Loaded from {config_path}", config_table))
+        tree.add(
+            Group(
+                ":vertical_traffic_light: Trading capabilities",
+                self.create_trading_capabilities_table(),
+            )
+        )
         tree.add(Group(":yin_yang: Symbology", self.create_symbols_table()))
         volatility_weight_table = self.create_volatility_weight_table()
         if volatility_weight_table is not None:
@@ -914,3 +958,15 @@ def stage_enabled_map(config: Config) -> dict[str, bool]:
 def stage_enabled_map_from_run(run: RunConfig) -> dict[str, bool]:
     resolved_ids = set(enabled_stage_ids_from_run(run))
     return {stage_id: (stage_id in resolved_ids) for stage_id in STAGE_KIND_BY_ID}
+
+
+def config_deprecation_warnings(config_doc: Mapping[str, Any]) -> list[str]:
+    strategies = config_doc.get("strategies")
+    if not isinstance(strategies, Mapping):
+        return []
+    regime_rebalance = strategies.get("regime_rebalance")
+    if not isinstance(regime_rebalance, Mapping):
+        return []
+    if "shares_only" not in regime_rebalance:
+        return []
+    return [SHARES_ONLY_DEPRECATION_MESSAGE]

--- a/thetagang/config_migration/migrate_v1_to_v2.py
+++ b/thetagang/config_migration/migrate_v1_to_v2.py
@@ -240,6 +240,13 @@ def migrate_v1_to_v2(raw_text: str) -> MigrationResult:
         if new_key in strategies:
             source_item = _source_section(source_doc, old_key)
             if source_item is not None:
+                if old_key == "regime_rebalance" and "shares_only" in source_item:
+                    del source_item["shares_only"]
+                    warnings.append(
+                        "`regime_rebalance.shares_only` is deprecated and was not "
+                        "migrated; option execution is controlled by "
+                        "`run.strategies`/`run.stages`."
+                    )
                 strategies_doc.add(new_key, source_item)
             else:
                 strategies_doc.add(new_key, tomlkit.item(strategies[new_key]))

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -755,6 +755,7 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
     deficit_rail_stop: float = Field(default=0.03, ge=0.0, le=1.0)
     eps: float = Field(default=1e-8, gt=0.0)
     order_history_lookback_days: int = Field(default=30, ge=1)
+    # Schema-v2 compatibility only. Runtime behavior is selected by run stages.
     shares_only: bool = Field(default=False)
     weight_base: RegimeRebalanceBaseEnum = Field(
         default=RegimeRebalanceBaseEnum.net_liq_ex_options
@@ -824,7 +825,6 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
         )
         table.add_row("", "Deficit rail start", "=", f"{pfmt(self.deficit_rail_start)}")
         table.add_row("", "Deficit rail stop", "=", f"{pfmt(self.deficit_rail_stop)}")
-        table.add_row("", "Shares only", "=", f"{self.shares_only}")
         table.add_row("", "Weight base", "=", f"{self.weight_base.value}")
         if self.ratio_gate is not None:
             self.ratio_gate.add_to_table(table, section)

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -266,10 +266,6 @@ class PortfolioManager:
     def get_reserved_cash_for_post_management(self) -> float:
         return self._reserved_cash_for_post_management
 
-    def options_trading_enabled(self) -> bool:
-        regime_rebalance = self.config.strategies.regime_rebalance
-        return not (regime_rebalance.enabled and regime_rebalance.shares_only)
-
     async def put_is_itm(self, contract: Contract) -> bool:
         return await self.options_engine.put_is_itm(contract)
 
@@ -782,13 +778,11 @@ class PortfolioManager:
             self.initialize_account()
             (account_summary, portfolio_positions) = await self.summarize_account()
 
-            options_enabled = self.options_trading_enabled()
             enabled_stages = set(self.run_stage_order)
             stage_index = {
                 stage_id: idx for idx, stage_id in enumerate(self.run_stage_order)
             }
             close_stage_handled = False
-            options_disabled_notice_logged = False
             positions_might_be_stale = False
 
             write_stage_ids = {"options_write_puts", "options_write_calls"}
@@ -798,7 +792,6 @@ class PortfolioManager:
                 "post_tail_hedge",
                 "post_cash_management",
             }
-            option_stage_ids = write_stage_ids | management_stage_ids
             rematerialize_before_stage_ids = management_stage_ids | post_stage_ids
             pre_management_trade_stage_ids = {
                 "options_write_puts",
@@ -809,14 +802,6 @@ class PortfolioManager:
             }
 
             for stage_id in self.run_stage_order:
-                if stage_id in option_stage_ids and not options_enabled:
-                    if not options_disabled_notice_logged:
-                        log.notice(
-                            "Regime rebalancing shares-only enabled; skipping option writes and rolls."
-                        )
-                        options_disabled_notice_logged = True
-                    continue
-
                 if (
                     stage_id in rematerialize_before_stage_ids
                     and positions_might_be_stale
@@ -829,7 +814,6 @@ class PortfolioManager:
                         self._options_strategy_deps({stage_id}),
                         account_summary,
                         portfolio_positions,
-                        options_enabled,
                     )
                 elif stage_id == "options_roll_positions":
                     if (
@@ -843,7 +827,6 @@ class PortfolioManager:
                             ),
                             account_summary,
                             portfolio_positions,
-                            options_enabled,
                         )
                         close_stage_handled = True
                     else:
@@ -851,7 +834,6 @@ class PortfolioManager:
                             self._options_strategy_deps({"options_roll_positions"}),
                             account_summary,
                             portfolio_positions,
-                            options_enabled,
                         )
                 elif stage_id == "options_close_positions":
                     if close_stage_handled:
@@ -860,7 +842,6 @@ class PortfolioManager:
                         self._options_strategy_deps({"options_close_positions"}),
                         account_summary,
                         portfolio_positions,
-                        options_enabled,
                     )
                 elif stage_id == "equity_regime_rebalance":
                     (

--- a/thetagang/strategies/options.py
+++ b/thetagang/strategies/options.py
@@ -56,14 +56,7 @@ async def run_option_write_stages(
     deps: OptionsStrategyDeps,
     account_summary: AccountSummary,
     portfolio_positions: PortfolioBySymbol,
-    options_enabled: bool,
 ) -> None:
-    if not options_enabled:
-        log.notice(
-            "Regime rebalancing shares-only enabled; skipping option writes and rolls."
-        )
-        return
-
     if "options_write_puts" in deps.enabled_stages:
         (
             positions_table,
@@ -91,11 +84,7 @@ async def run_option_management_stages(
     deps: OptionsStrategyDeps,
     account_summary: AccountSummary,
     portfolio_positions: PortfolioBySymbol,
-    options_enabled: bool,
 ) -> None:
-    if not options_enabled:
-        return
-
     should_roll = "options_roll_positions" in deps.enabled_stages
     should_close = "options_close_positions" in deps.enabled_stages
     if not (should_roll or should_close):

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -9,7 +9,12 @@ from ib_async import IB, IBC, Contract, Watchdog, util
 from rich.console import Console
 
 from thetagang import log
-from thetagang.config import Config, enabled_stage_ids_from_run, stage_enabled_map
+from thetagang.config import (
+    Config,
+    config_deprecation_warnings,
+    enabled_stage_ids_from_run,
+    stage_enabled_map,
+)
 from thetagang.config_migration.startup_migration import (
     run_startup_migration,
 )
@@ -74,6 +79,8 @@ def start(
         return
 
     config_doc = tomlkit.parse(raw_config).unwrap()
+    for warning in config_deprecation_warnings(config_doc):
+        log.warning(warning)
     config = Config(**config_doc)
     run_stage_flags = stage_enabled_map(config)
     run_stage_order = enabled_stage_ids_from_run(config.run)


### PR DESCRIPTION
## Summary

Make the resolved `run.strategies` or `run.stages` plan authoritative for trading execution and deprecate the historical `strategies.regime_rebalance.shares_only` switch.

## User Impact

Regime share rebalancing and tail-hedge option trading can now run together without a misleading global option prohibition. Existing schema-v2 configurations that include `shares_only` continue to load, emit a removal warning, and otherwise behave according to their resolved run stages. Startup output now lists each resolved trading capability explicitly.

## Root Cause

The legacy `shares_only` flag survived the introduction of strategy-to-stage resolution and continued to gate wheel option execution globally. It also created an unnecessary validation dependency between the independent regime-rebalance and tail-hedge strategies.

## Fix

- Remove the global option-execution gate and redundant `options_enabled` plumbing.
- Remove the tail-hedge and `shares_only` incompatibility.
- Retain the field for schema-v2 compatibility while warning that it has no effect.
- Drop the deprecated key during v1-to-v2 migration with a migration warning.
- Replace the misleading `Shares only` display with a resolved trading-capabilities table.
- Update the sample configuration, README, tail-hedging documentation, and targeted tests.

## Validation

- `uv run pytest --cov=thetagang --disable-warnings` — 517 passed, 81% total coverage.
- Focused configuration, migration, startup-warning, and stage-execution matrix — 8 passed.
- `uv run ruff check .`
- `uv run ty check`
- `uv run pre-commit run --all-files`
