### PR TITLE
feat(regime): allow volatility-weighted margin stacking

### DIFF
--- a/docs/accounting.md
+++ b/docs/accounting.md
@@ -38,6 +38,14 @@ For `net_liq`, only the state-owned tail-option value is removed. For
 `managed_stocks`, the base is the marked value of active regime stocks and no
 margin multiplier is applied.
 
+Configured portfolio weights always sum to 100%. Volatility-adjusted regime
+weights remain absolute rather than being renormalized, so an increase from a
+configured 60%/40% allocation to 65%/40% targets 105% of the NLV-backed regime
+base. That 5% excess is intentional stacked exposure; the deficit rail measures
+only exposure beyond the resulting 105% gross target. `managed_stocks` does not
+support stacking because using the changing sleeve value as the base would
+compound an above-100% target on subsequent runs.
+
 Every `CapitalBase` retains its gross value, exclusions, selected multiplier,
 and final value so logs and telemetry can show how the number was derived.
 

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -536,6 +536,17 @@ def test_symbol_accepts_volatility_weight_above_base_weight() -> None:
     assert volatility_weight.max_weight == 0.5
 
 
+def test_portfolio_configured_weights_must_sum_to_100() -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"] = {
+        "AAA": {"weight": 0.65},
+        "BBB": {"weight": 0.40},
+    }
+
+    with pytest.raises(ValueError, match="Symbol weights must sum to 1.0"):
+        Config(**data)
+
+
 def test_v2_rejects_transitional_symbols_and_overrides() -> None:
     with pytest.raises(ValueError):
         Config.model_validate(

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -814,9 +814,123 @@ async def test_regime_rebalance_volatility_weight_can_scale_above_base(
 
 
 @pytest.mark.asyncio
-async def test_regime_rebalance_rejects_effective_weights_above_100(
+async def test_regime_rebalance_volatility_weight_stacks_above_100_on_margin(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager = portfolio_manager_with_db
+    portfolio_manager.config.portfolio.symbols["AAA"].weight = 0.6
+    portfolio_manager.config.portfolio.symbols["BBB"].weight = 0.4
+    portfolio_manager.config.portfolio.symbols[
+        "AAA"
+    ].volatility_weight = _volatility_weight(
+        target_vol=0.32,
+        min_weight=0.25,
+        max_weight=0.65,
+        smoothing_factor=1.0,
+    )
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 0.0
+    regime_rebalance.choppiness_min = 0.0
+    regime_rebalance.efficiency_max = 1.0
+    regime_rebalance.deficit_rail_start = 0.01
+    regime_rebalance.deficit_rail_stop = 0.01
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="100000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 600)],
+        "BBB": [_stock_position("BBB", 400)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 101.0, 102.0, 103.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == [("AAA", "NYSE", 50)]
+    payload = portfolio_manager.data_store.get_last_event_payload(
+        "volatility_weight_state"
+    )
+    assert payload["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.65)
+    assert payload["total_effective_weight"] == pytest.approx(1.05)
+    assert payload["unallocated_target_weight"] == pytest.approx(0.0)
+    assert payload["stacked_target_weight"] == pytest.approx(0.05)
+    assert payload["stacked_target_value"] == pytest.approx(5000.0)
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_authorized_stack_is_not_a_flow_or_deficit(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager = portfolio_manager_with_db
+    portfolio_manager.config.portfolio.symbols["AAA"].weight = 0.6
+    portfolio_manager.config.portfolio.symbols["BBB"].weight = 0.4
+    portfolio_manager.config.portfolio.symbols[
+        "AAA"
+    ].volatility_weight = _volatility_weight(
+        target_vol=0.32,
+        min_weight=0.25,
+        max_weight=0.65,
+        smoothing_factor=1.0,
+    )
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.deficit_rail_start = 0.01
+    regime_rebalance.deficit_rail_stop = 0.005
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="100000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 650)],
+        "BBB": [_stock_position("BBB", 400)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 101.0, 102.0, 103.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+        account_summary, portfolio_positions
+    )
+
+    assert orders == []
+    payload = portfolio_manager.data_store.get_last_event_payload(
+        "regime_rebalance_gate"
+    )
+    assert payload["unallocated_rebalance_capacity"] == pytest.approx(-5000.0)
+    assert payload["flow"]["flow_rebalance_capacity"] == pytest.approx(0.0)
+    assert payload["flow"]["classification"] == "none"
+    assert payload["flow"]["gate"] is False
+    assert payload["deficit"]["gate"] is False
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_rejects_non_volatility_stack(portfolio_manager, mocker):
+    portfolio_manager.config.portfolio.symbols["AAA"].weight = 0.6
+    portfolio_manager.config.portfolio.symbols["BBB"].weight = 0.5
+
+    account_summary = {"NetLiquidation": SimpleNamespace(value="1000")}
+    portfolio_positions = {
+        "AAA": [_stock_position("AAA", 6)],
+        "BBB": [_stock_position("BBB", 5)],
+    }
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    with pytest.raises(ValueError, match="Only volatility-adjusted weights"):
+        await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+            account_summary, portfolio_positions
+        )
+
+
+@pytest.mark.asyncio
+async def test_regime_rebalance_managed_stocks_rejects_volatility_stack(
     portfolio_manager, mocker
 ):
+    portfolio_manager.config.strategies.regime_rebalance.weight_base = (
+        RegimeRebalanceBaseEnum.managed_stocks
+    )
     portfolio_manager.config.portfolio.symbols[
         "AAA"
     ].volatility_weight = _volatility_weight(
@@ -836,7 +950,7 @@ async def test_regime_rebalance_rejects_effective_weights_above_100(
     _mock_regime_history(portfolio_manager, mocker, [100.0, 101.0, 102.0, 103.0])
     portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
 
-    with pytest.raises(ValueError, match="must not exceed 100%"):
+    with pytest.raises(ValueError, match="weight_base is managed_stocks"):
         await portfolio_manager.regime_engine.check_regime_rebalance_positions(
             account_summary, portfolio_positions
         )
@@ -2363,6 +2477,7 @@ async def test_regime_rebalance_positive_flow_bypasses_regime_gate(
         "rebalance_base": 2000,
         "managed_sleeve_value": 1600.0,
         "unallocated_rebalance_capacity": 400.0,
+        "flow_rebalance_capacity": 400.0,
         "direction": "buy",
         "gate": True,
         "decision_status": "selected",

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -645,9 +645,14 @@ daily_stddev_window = "30 D"
 # deficit_rail_start = 0.06  # deficit that triggers safety rail (fraction of base)
 # deficit_rail_stop = 0.03  # hysteresis stop once within this band (fraction of base)
 # order_history_lookback_days = 30  # look back this many calendar days for fills
-# Effective symbol weights are absolute targets and are not renormalized. A total
-# below 100% remains outside the managed targets as cash (or the configured cash
-# fund); a total above 100% aborts. The managed_stocks base requires exactly 100%.
+# Configured portfolio symbol weights must sum to 100%. Effective volatility-
+# adjusted weights are absolute targets and are not renormalized: a total below
+# 100% remains outside the managed targets as cash (or the configured cash fund),
+# while an increase above 100% stacks exposure using the NLV-backed margin base.
+# For example, configured 60%/40% weights may become 65%/40%, targeting 105% gross.
+# The selected margin_usage still scales that base. Because managed_stocks uses the
+# current sleeve value as its base, it requires effective weights to total 100% and
+# does not support stacking.
 #
 # # Optional regime stock execution policy, same shape as wheel:
 # [strategies.regime_rebalance.equity_rebalance.defaults]

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1798,14 +1798,6 @@ class RegimeRebalanceEngine:
             raise ValueError(
                 "Regime-aware rebalancing requires positive effective weights."
             )
-        if total_effective_weight > 1.0 + regime_rebalance.eps:
-            log.error(
-                "Regime-aware rebalancing effective weights exceed 100%: "
-                f"{pfmt(total_effective_weight)}."
-            )
-            raise ValueError(
-                "Regime-aware rebalancing effective weights must not exceed 100%."
-            )
         if weight_base == RegimeRebalanceBaseEnum.managed_stocks and not math.isclose(
             total_effective_weight,
             1.0,
@@ -1820,11 +1812,35 @@ class RegimeRebalanceEngine:
                 "100% when weight_base is managed_stocks."
             )
         unallocated_target_weight = max(0.0, 1.0 - total_effective_weight)
+        stacked_target_weight = max(0.0, total_effective_weight - 1.0)
         if unallocated_target_weight > regime_rebalance.eps:
             log.notice(
                 "Regime-aware rebalancing leaving "
                 f"{pfmt(unallocated_target_weight)} outside managed targets for "
                 "cash reserves."
+            )
+        elif stacked_target_weight > regime_rebalance.eps:
+            volatility_increase_weight = sum(
+                max(
+                    0.0,
+                    details["effective_weight"] - details["base_weight"],
+                )
+                for details in volatility_details.values()
+            )
+            if stacked_target_weight > (
+                volatility_increase_weight + regime_rebalance.eps
+            ):
+                log.error(
+                    "Regime-aware rebalancing effective weights exceed 100% "
+                    "without a sufficient volatility-weight increase."
+                )
+                raise ValueError(
+                    "Only volatility-adjusted weights may stack above 100%."
+                )
+            log.notice(
+                "Regime-aware rebalancing stacking "
+                f"{pfmt(stacked_target_weight)} above the configured 100% "
+                "allocation using the NLV-backed margin base."
             )
         normalized_effective_weights = {
             symbol: weight / total_effective_weight
@@ -1961,11 +1977,22 @@ class RegimeRebalanceEngine:
                 deficit_was_active = bool(state.get("deficit_active", False))
 
         unallocated_rebalance_capacity = total_value - invested_value
+        stacked_target_value = stacked_target_weight * total_value
+        deficit_rebalance_capacity = (
+            unallocated_rebalance_capacity + stacked_target_value
+        )
+        # Preserve ordinary positive inferred capacity, but do not classify the
+        # authorized margin stack as a withdrawal or funding deficit.
+        flow_rebalance_capacity = (
+            unallocated_rebalance_capacity
+            if unallocated_rebalance_capacity >= 0
+            else min(0.0, deficit_rebalance_capacity)
+        )
         flow_classification = (
             "inferred_capacity_deployment"
-            if unallocated_rebalance_capacity > 0
+            if flow_rebalance_capacity > 0
             else "inferred_capacity_reduction"
-            if unallocated_rebalance_capacity < 0
+            if flow_rebalance_capacity < 0
             else "none"
         )
         flow_trade_min_amount = total_value * regime_rebalance.flow_trade_min
@@ -1974,19 +2001,15 @@ class RegimeRebalanceEngine:
         deficit_rail_stop_amount = total_value * regime_rebalance.deficit_rail_stop
         flow_gate = False
         deficit_gate = False
-        if unallocated_rebalance_capacity < 0:
-            deficit_amount = -unallocated_rebalance_capacity
+        if deficit_rebalance_capacity < 0:
+            deficit_amount = -deficit_rebalance_capacity
             deficit_gate = deficit_amount >= deficit_rail_start_amount or (
                 deficit_was_active and deficit_amount >= deficit_rail_stop_amount
             )
-            if not deficit_gate:
-                flow_gate = deficit_amount >= flow_trade_min_amount or (
-                    flow_was_active and deficit_amount >= flow_trade_stop_amount
-                )
-        else:
-            flow_gate = unallocated_rebalance_capacity >= flow_trade_min_amount or (
-                flow_was_active
-                and unallocated_rebalance_capacity >= flow_trade_stop_amount
+        if not deficit_gate:
+            flow_amount = abs(flow_rebalance_capacity)
+            flow_gate = flow_amount >= flow_trade_min_amount or (
+                flow_was_active and flow_amount >= flow_trade_stop_amount
             )
 
         flow_eligibility_gate_blockers = []
@@ -2043,7 +2066,7 @@ class RegimeRebalanceEngine:
             return False
 
         flow_directional_imbalance_ok = directional_flow_is_allowed(
-            unallocated_rebalance_capacity
+            flow_rebalance_capacity
         )
         if flow_gate and not flow_directional_imbalance_ok:
             flow_eligibility_gate_blockers.append("directional_imbalance")
@@ -2217,7 +2240,7 @@ class RegimeRebalanceEngine:
             invested_after = sum(
                 shares_after[symbol] * market_prices[symbol] for symbol in symbols
             )
-            excess_after = total_value - invested_after
+            excess_after = total_value + stacked_target_value - invested_after
             deficit_amount_after = max(0.0, -excess_after)
             deficit_gate_after = deficit_amount_after >= deficit_rail_stop_amount
             if deficit_gate_after:
@@ -2242,7 +2265,7 @@ class RegimeRebalanceEngine:
             rebalance_mode = "deficit"
             deficit_needed = max(
                 0.0,
-                -unallocated_rebalance_capacity - deficit_rail_stop_amount,
+                -deficit_rebalance_capacity - deficit_rail_stop_amount,
             )
             deficit_orders = build_deficit_orders(
                 current_positions,
@@ -2257,7 +2280,7 @@ class RegimeRebalanceEngine:
                     orders_by_symbol[symbol] = orders_by_symbol.get(symbol, 0) + delta
         elif flow_rebalance_eligible:
             rebalance_mode = "flow"
-            flow_orders = build_flow_orders(unallocated_rebalance_capacity)
+            flow_orders = build_flow_orders(flow_rebalance_capacity)
             for symbol, delta in flow_orders.items():
                 if delta == 0:
                     continue
@@ -2277,9 +2300,9 @@ class RegimeRebalanceEngine:
             flow_decision_status = "selected"
         flow_direction = (
             "buy"
-            if unallocated_rebalance_capacity > 0
+            if flow_rebalance_capacity > 0
             else "sell"
-            if unallocated_rebalance_capacity < 0
+            if flow_rebalance_capacity < 0
             else "flat"
         )
         deficit_active_next = (
@@ -2577,6 +2600,7 @@ class RegimeRebalanceEngine:
             "rebalance_base": total_value,
             "managed_sleeve_value": invested_value,
             "unallocated_rebalance_capacity": unallocated_rebalance_capacity,
+            "flow_rebalance_capacity": flow_rebalance_capacity,
             "direction": flow_direction,
             "gate": flow_gate,
             "decision_status": flow_decision_status,
@@ -2630,6 +2654,7 @@ class RegimeRebalanceEngine:
             f"rebalance_base={dfmt(total_value)} "
             f"managed_sleeves={dfmt(invested_value)} "
             f"unallocated_capacity={dfmt(unallocated_rebalance_capacity)} "
+            f"flow_capacity={dfmt(flow_rebalance_capacity)} "
             f"classification={flow_classification} "
             f"direction={flow_direction} gate={flow_gate} "
             f"decision={flow_decision_status} "
@@ -2677,6 +2702,8 @@ class RegimeRebalanceEngine:
                     "symbols": symbols,
                     "total_effective_weight": total_effective_weight,
                     "unallocated_target_weight": unallocated_target_weight,
+                    "stacked_target_weight": stacked_target_weight,
+                    "stacked_target_value": stacked_target_value,
                     "max_relative_drift": max_relative_drift,
                     "soft_band": regime_rebalance.soft_band,
                     "hard_band": regime_rebalance.hard_band,
@@ -2716,6 +2743,8 @@ class RegimeRebalanceEngine:
                     "total_value": total_value,
                     "total_effective_weight": total_effective_weight,
                     "unallocated_target_weight": unallocated_target_weight,
+                    "stacked_target_weight": stacked_target_weight,
+                    "stacked_target_value": stacked_target_value,
                     "hard_breach": hard_breach,
                     "soft_breach": soft_breach,
                     "regime_ok": regime_ok,
@@ -2748,6 +2777,8 @@ class RegimeRebalanceEngine:
                     {
                         "total_effective_weight": total_effective_weight,
                         "unallocated_target_weight": unallocated_target_weight,
+                        "stacked_target_weight": stacked_target_weight,
+                        "stacked_target_value": stacked_target_value,
                         "symbols": {
                             symbol: {
                                 "base_weight": details["base_weight"],


### PR DESCRIPTION
## Summary

Allow volatility-adjusted regime weights to stack above the configured 100% portfolio allocation when using an NLV-backed rebalance base.

A configured 60%/40% portfolio can now target 65%/40%, or 105% gross of the margin-scaled regime base, without renormalizing the unaffected symbol.

## User Impact

Operators can use volatility sizing to add intentional leveraged exposure while keeping configured portfolio weights constrained to 100%. The selected regime `margin_usage` continues to scale the base before effective weights are applied.

Non-volatility allocations above 100% still fail closed. `managed_stocks` continues to require exactly 100% effective weight because an above-100% target against the changing managed-sleeve value would compound exposure on subsequent runs.

## Root Cause

The regime planner rejected every effective-weight total above 100%, even when the excess came from a bounded volatility adjustment. Its flow and deficit rails also treated any managed stock value above the base as an inferred reduction or funding deficit, which would have unwound an otherwise authorized margin stack.

## Fix

- Permit effective totals above 100% only when volatility-weight increases fully explain the excess.
- Preserve the configured 100% portfolio-weight invariant and the `managed_stocks` safeguard.
- Measure deficit exposure above the volatility-authorized gross target.
- Exclude the authorized stack from inferred cash-flow reductions.
- Record stacked target weight and value in regime telemetry.
- Document the interaction between effective weights, `margin_usage`, and the selected rebalance base.
- Add regressions for 60%/40% to 65%/40% stacking, steady-state margin exposure, invalid static over-allocation, and `managed_stocks` rejection.

## Validation

- `uv run pytest --cov=thetagang` — 521 passed, 81% total coverage
- `uv run pytest tests/test_regime_rebalance.py::test_regime_rebalance_volatility_weight_stacks_above_100_on_margin tests/test_regime_rebalance.py::test_regime_rebalance_authorized_stack_is_not_a_flow_or_deficit tests/test_regime_rebalance.py::test_regime_rebalance_rejects_non_volatility_stack tests/test_regime_rebalance.py::test_regime_rebalance_managed_stocks_rejects_volatility_stack tests/test_config_new.py::test_portfolio_configured_weights_must_sum_to_100 -q` — 5 passed after commit
- `uv run ruff check .`
- `uv run ty check`
- `uv run pre-commit run --all-files`
- `uv lock --check`
