### PR TITLE
feat(regime): add absolute trend target modifier

### DIFF
--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -536,6 +536,36 @@ def test_symbol_accepts_volatility_weight_above_base_weight() -> None:
     assert volatility_weight.max_weight == 0.5
 
 
+def test_symbol_accepts_absolute_trend_config() -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {
+        "enabled": True,
+        "lookback_days": 168,
+        "risk_off_multiplier": 0.15,
+    }
+
+    config = Config(**data)
+
+    absolute_trend = config.portfolio.symbols["AAA"].absolute_trend
+    assert absolute_trend is not None
+    assert absolute_trend.enabled is True
+    assert absolute_trend.lookback_days == 168
+    assert absolute_trend.risk_off_multiplier == pytest.approx(0.15)
+
+
+def test_symbol_absolute_trend_defaults_disabled() -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {}
+
+    config = Config(**data)
+
+    absolute_trend = config.portfolio.symbols["AAA"].absolute_trend
+    assert absolute_trend is not None
+    assert absolute_trend.enabled is False
+    assert absolute_trend.lookback_days == 168
+    assert absolute_trend.risk_off_multiplier == pytest.approx(0.15)
+
+
 def test_portfolio_configured_weights_must_sum_to_100() -> None:
     data = _base_config({"strategies": ["wheel"]})
     data["portfolio"]["symbols"] = {

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -566,6 +566,19 @@ def test_symbol_absolute_trend_defaults_disabled() -> None:
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.15)
 
 
+def test_symbol_absolute_trend_allows_zero_risk_off_multiplier() -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {
+        "risk_off_multiplier": 0.0,
+    }
+
+    config = Config(**data)
+
+    absolute_trend = config.portfolio.symbols["AAA"].absolute_trend
+    assert absolute_trend is not None
+    assert absolute_trend.risk_off_multiplier == pytest.approx(0.0)
+
+
 def test_portfolio_configured_weights_must_sum_to_100() -> None:
     data = _base_config({"strategies": ["wheel"]})
     data["portfolio"]["symbols"] = {

--- a/tests/test_legacy_config.py
+++ b/tests/test_legacy_config.py
@@ -31,6 +31,7 @@ class AccountConfigFactory(ModelFactory[AccountConfig]): ...
 
 
 class SymbolConfigFactory(ModelFactory[SymbolConfig]):
+    absolute_trend = None
     volatility_weight = None
 
 

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1141,7 +1141,11 @@ class TestPortfolioManager:
         assert result == (refreshed_summary, refreshed_positions)
         execute_harvest.assert_awaited_once_with([(contract, harvest_order, None)])
         portfolio_manager.data_store.discard_current_run_events.assert_called_once_with(
-            {"regime_rebalance_state", "volatility_weight_state"}
+            {
+                "absolute_trend_state",
+                "regime_rebalance_state",
+                "volatility_weight_state",
+            }
         )
         portfolio_manager.ibkr.refresh_account.assert_awaited_once_with("TEST123")
         assert (

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1605,6 +1605,37 @@ async def test_absolute_trend_reuses_persisted_state_when_history_fails(
     assert details["AAA"]["history_source"] == "persisted"
 
 
+@pytest.mark.asyncio
+async def test_absolute_trend_excludes_current_run_state_when_requested(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager_with_db.config.portfolio.symbols[
+        "AAA"
+    ].absolute_trend = _absolute_trend(lookback_days=3)
+    history_cache = _absolute_trend_history_cache(
+        mocker,
+        [100.0, 100.0, 100.0, 90.0],
+        lookback_days=3,
+    )
+    get_last_event_payload = mocker.spy(
+        portfolio_manager_with_db.data_store,
+        "get_last_event_payload",
+    )
+
+    await portfolio_manager_with_db.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        portfolio_manager_with_db.config.portfolio.symbols,
+        history_cache,
+        exclude_current_run_state=True,
+    )
+
+    get_last_event_payload.assert_called_once_with(
+        "absolute_trend_state",
+        exclude_current_run=True,
+        raise_on_error=True,
+    )
+
+
 @pytest.mark.parametrize(
     "persisted_signal",
     [
@@ -1627,6 +1658,29 @@ async def test_absolute_trend_history_failure_without_valid_state_aborts(
             "absolute_trend_state",
             {"symbols": {"AAA": persisted_signal}},
         )
+    history_cache = SimpleNamespace(
+        get=mocker.AsyncMock(side_effect=TimeoutError("history unavailable"))
+    )
+
+    with pytest.raises(RuntimeError, match="current history or a valid persisted"):
+        await portfolio_manager_with_db.regime_engine._apply_absolute_trend(
+            {"AAA": 0.4},
+            portfolio_manager_with_db.config.portfolio.symbols,
+            history_cache,
+        )
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_invalid_persisted_symbol_map_aborts_cleanly(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager_with_db.config.portfolio.symbols[
+        "AAA"
+    ].absolute_trend = _absolute_trend()
+    portfolio_manager_with_db.data_store.record_event(
+        "absolute_trend_state",
+        {"symbols": []},
+    )
     history_cache = SimpleNamespace(
         get=mocker.AsyncMock(side_effect=TimeoutError("history unavailable"))
     )
@@ -1701,6 +1755,42 @@ async def test_absolute_trend_preserves_volatility_state_and_forces_hard_band_se
     assert trend["pre_trend_target"] == pytest.approx(0.4)
     assert trend["final_target"] == pytest.approx(0.06)
     assert trend["applied_multiplier"] == pytest.approx(0.15)
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_zero_multiplier_can_exit_all_symbols(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager = portfolio_manager_with_db
+    for symbol in ("AAA", "BBB"):
+        symbol_config = portfolio_manager.config.portfolio.symbols[symbol]
+        symbol_config.absolute_trend = _absolute_trend(
+            lookback_days=3,
+            risk_off_multiplier=0.0,
+        )
+        symbol_config.sell_only_min_threshold_percent_relative = 0.5
+    portfolio_manager.config.strategies.regime_rebalance.ratio_gate = (
+        _ratio_gate_config()
+    )
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_histories(
+        portfolio_manager,
+        mocker,
+        {
+            "AAA": [100.0, 100.0, 100.0, 90.0],
+            "BBB": [100.0, 100.0, 100.0, 90.0],
+        },
+    )
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+        _regime_account_summary(),
+        _regime_stock_positions(aaa=2, bbb=2),
+    )
+
+    assert orders == [("AAA", "NYSE", -2), ("BBB", "NYSE", -2)]
+    gate = portfolio_manager.data_store.get_last_event_payload("regime_rebalance_gate")
+    assert gate["max_relative_drift"] == pytest.approx(1.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -22,6 +22,7 @@ from thetagang.strategies.regime_engine import (
     REGIME_HISTORY_MAX_ATTEMPTS,
     REGIME_HISTORY_TIMEFRAME,
     TAIL_HEDGE_HARVEST_EVENT,
+    RegimeHistoryCache,
 )
 from thetagang.strategies.tail_hedge_state import (
     TAIL_HEDGE_CLOSE_ORDER_REF,
@@ -439,6 +440,47 @@ def _volatility_weight(
         increase_smoothing_factor=increase_smoothing_factor,
         decrease_smoothing_factor=decrease_smoothing_factor,
     )
+
+
+def _absolute_trend(
+    *,
+    lookback_days: int = 168,
+    risk_off_multiplier: float = 0.15,
+    enabled: bool = True,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        enabled=enabled,
+        lookback_days=lookback_days,
+        risk_off_multiplier=risk_off_multiplier,
+    )
+
+
+def _absolute_trend_history_cache(
+    mocker,
+    closes: list[float],
+    *,
+    lookback_days: int,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        get=mocker.AsyncMock(
+            return_value=(
+                _required_regime_history_dates(lookback_days + 1),
+                {"AAA": closes},
+            )
+        )
+    )
+
+
+def _absolute_trend_signal_payload(*, risk_off: bool = True) -> dict[str, object]:
+    return {
+        "lookback_days": 168,
+        "latest_session": "2026-08-21",
+        "latest_close": 90.0,
+        "moving_average": 100.0,
+        "momentum_reference_close": 105.0,
+        "lookback_return": 90.0 / 105.0 - 1.0,
+        "risk_off": risk_off,
+    }
 
 
 def _ratio_gate_result(
@@ -1374,6 +1416,267 @@ async def test_regime_rebalance_volatility_weight_state_payload_fields(
         "realized_vol",
         "smoothing_factor",
     }
+
+
+@pytest.mark.parametrize(
+    ("closes", "expected_risk_off"),
+    [
+        pytest.param(
+            [100.0, 100.0, 100.0, 99.0],
+            True,
+            id="below-average-and-reference",
+        ),
+        pytest.param(
+            [110.0, 95.0, 95.0, 100.0],
+            False,
+            id="equal-average-boundary",
+        ),
+        pytest.param(
+            [100.0, 110.0, 110.0, 100.0],
+            False,
+            id="equal-reference-boundary",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_absolute_trend_risk_boundaries(
+    portfolio_manager, mocker, closes, expected_risk_off
+):
+    portfolio_manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        lookback_days=3
+    )
+    history_cache = _absolute_trend_history_cache(
+        mocker,
+        closes,
+        lookback_days=3,
+    )
+
+    weights, details = await portfolio_manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        portfolio_manager.config.portfolio.symbols,
+        history_cache,
+    )
+
+    expected_multiplier = 0.15 if expected_risk_off else 1.0
+    assert details["AAA"]["risk_off"] is expected_risk_off
+    assert details["AAA"]["applied_multiplier"] == pytest.approx(expected_multiplier)
+    assert weights["AAA"] == pytest.approx(0.4 * expected_multiplier)
+
+
+@pytest.mark.parametrize(
+    ("pre_trend_target", "expected_final_target"),
+    [(0.30, 0.045), (0.40, 0.06), (0.45, 0.0675)],
+)
+@pytest.mark.asyncio
+async def test_absolute_trend_scales_volatility_targets(
+    portfolio_manager, mocker, pre_trend_target, expected_final_target
+):
+    portfolio_manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend()
+    completed_closes = [100.0] * 168 + [90.0]
+    history_cache = _absolute_trend_history_cache(
+        mocker,
+        completed_closes,
+        lookback_days=168,
+    )
+
+    weights, details = await portfolio_manager.regime_engine._apply_absolute_trend(
+        {"AAA": pre_trend_target},
+        portfolio_manager.config.portfolio.symbols,
+        history_cache,
+    )
+
+    history_cache.get.assert_awaited_once_with(["AAA"], 168, 0)
+    assert details["AAA"]["pre_trend_target"] == pytest.approx(pre_trend_target)
+    assert details["AAA"]["final_target"] == pytest.approx(expected_final_target)
+    assert weights["AAA"] == pytest.approx(expected_final_target)
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_excludes_incomplete_bar(
+    portfolio_manager, mocker, monkeypatch
+):
+    portfolio_manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend()
+    required_dates = _set_required_regime_history_dates(
+        portfolio_manager, monkeypatch, 169
+    )
+    completed_closes = [100.0] * 168 + [90.0]
+    bars = [
+        SimpleNamespace(
+            date=datetime.combine(bar_date, datetime.min.time()),
+            close=close,
+        )
+        for bar_date, close in zip(required_dates, completed_closes, strict=True)
+    ]
+    bars.append(
+        SimpleNamespace(
+            date=datetime.combine(
+                required_dates[-1] + timedelta(days=1), datetime.min.time()
+            ),
+            close=200.0,
+        )
+    )
+    portfolio_manager.ibkr.request_historical_data = mocker.AsyncMock(return_value=bars)
+    aligned_spy = mocker.spy(
+        portfolio_manager.regime_engine,
+        "_get_regime_aligned_closes",
+    )
+
+    _, details = await portfolio_manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        portfolio_manager.config.portfolio.symbols,
+        RegimeHistoryCache(portfolio_manager.regime_engine._get_regime_aligned_closes),
+    )
+
+    aligned_spy.assert_awaited_once_with(["AAA"], 168, 0)
+    assert details["AAA"]["latest_session"] == str(required_dates[-1])
+    assert details["AAA"]["latest_close"] == pytest.approx(90.0)
+    assert details["AAA"]["risk_off"] is True
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_reuses_persisted_state_when_history_fails(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager_with_db.config.portfolio.symbols[
+        "AAA"
+    ].absolute_trend = _absolute_trend()
+    portfolio_manager_with_db.data_store.record_event(
+        "absolute_trend_state",
+        {"symbols": {"AAA": _absolute_trend_signal_payload()}},
+    )
+    history_cache = SimpleNamespace(
+        get=mocker.AsyncMock(side_effect=TimeoutError("history unavailable"))
+    )
+
+    (
+        weights,
+        details,
+    ) = await portfolio_manager_with_db.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        portfolio_manager_with_db.config.portfolio.symbols,
+        history_cache,
+    )
+
+    assert weights["AAA"] == pytest.approx(0.06)
+    assert details["AAA"]["risk_off"] is True
+    assert details["AAA"]["history_source"] == "persisted"
+
+
+@pytest.mark.parametrize(
+    "persisted_signal",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param(
+            _absolute_trend_signal_payload(risk_off=False),
+            id="inconsistent-risk-state",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_absolute_trend_history_failure_without_valid_state_aborts(
+    portfolio_manager_with_db, mocker, persisted_signal
+):
+    portfolio_manager_with_db.config.portfolio.symbols[
+        "AAA"
+    ].absolute_trend = _absolute_trend()
+    if persisted_signal is not None:
+        portfolio_manager_with_db.data_store.record_event(
+            "absolute_trend_state",
+            {"symbols": {"AAA": persisted_signal}},
+        )
+    history_cache = SimpleNamespace(
+        get=mocker.AsyncMock(side_effect=TimeoutError("history unavailable"))
+    )
+
+    with pytest.raises(RuntimeError, match="current history or a valid persisted"):
+        await portfolio_manager_with_db.regime_engine._apply_absolute_trend(
+            {"AAA": 0.4},
+            portfolio_manager_with_db.config.portfolio.symbols,
+            history_cache,
+        )
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_preserves_volatility_state_and_forces_hard_band_sell(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager_with_db.config.portfolio.symbols[
+        "AAA"
+    ].absolute_trend = _absolute_trend(lookback_days=3)
+    volatility_details = {
+        "AAA": {
+            "base_weight": 0.5,
+            "effective_weight": 0.4,
+            "target_weight": 0.4,
+            "realized_vol": 0.5,
+            "smoothing_factor": 0.3,
+        }
+    }
+    mocker.patch.object(
+        portfolio_manager_with_db.regime_engine,
+        "_resolve_effective_weights",
+        new=mocker.AsyncMock(
+            return_value=({"AAA": 0.4, "BBB": 0.5}, volatility_details)
+        ),
+    )
+    _mock_regime_tickers(portfolio_manager_with_db, mocker)
+    _mock_regime_histories(
+        portfolio_manager_with_db,
+        mocker,
+        {
+            "AAA": [100.0, 100.0, 100.0, 90.0],
+            "BBB": [100.0, 100.0, 100.0, 100.0],
+        },
+    )
+    portfolio_manager_with_db.ibkr.request_executions = mocker.AsyncMock(
+        return_value=[]
+    )
+
+    (
+        _,
+        orders,
+    ) = await portfolio_manager_with_db.regime_engine.check_regime_rebalance_positions(
+        _regime_account_summary(),
+        _regime_stock_positions(aaa=2, bbb=2),
+    )
+
+    assert orders == [("AAA", "NYSE", -2)]
+    volatility_state = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "volatility_weight_state"
+    )
+    assert volatility_state["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.4)
+    assert volatility_state["total_effective_weight"] == pytest.approx(0.9)
+
+    trend_state = portfolio_manager_with_db.data_store.get_last_event_payload(
+        "absolute_trend_state"
+    )
+    trend = trend_state["symbols"]["AAA"]
+    assert trend["latest_close"] == pytest.approx(90.0)
+    assert trend["moving_average"] == pytest.approx(100.0)
+    assert trend["lookback_return"] == pytest.approx(-0.1)
+    assert trend["state"] == "risk_off"
+    assert trend["pre_trend_target"] == pytest.approx(0.4)
+    assert trend["final_target"] == pytest.approx(0.06)
+    assert trend["applied_multiplier"] == pytest.approx(0.15)
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_disabled_is_noop(portfolio_manager, mocker):
+    portfolio_manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        enabled=False
+    )
+    history_cache = SimpleNamespace(get=mocker.AsyncMock())
+    original = {"AAA": 0.4, "BBB": 0.6}
+
+    weights, details = await portfolio_manager.regime_engine._apply_absolute_trend(
+        original,
+        portfolio_manager.config.portfolio.symbols,
+        history_cache,
+    )
+
+    assert weights == original
+    assert details == {}
+    history_cache.get.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -680,6 +680,49 @@ async def test_regime_rebalance_ignores_history_after_required_sessions(
 
 
 @pytest.mark.asyncio
+async def test_regime_history_request_covers_200_completed_sessions(
+    portfolio_manager, mocker
+):
+    fixed_now = _naive_utc(2026, 8, 24, 10)
+    calendar = regime_engine_module.xcals.get_calendar("XNYS")
+    completed_sessions = calendar.sessions[
+        calendar.sessions <= regime_engine_module.pd.Timestamp("2026-08-21")
+    ][-201:]
+    required_dates = [session.date() for session in completed_sessions]
+    assert required_dates[0] == date(2025, 11, 3)
+
+    engine = portfolio_manager.regime_engine
+    required_dates_mock = mocker.patch.object(
+        engine,
+        "_get_required_history_dates",
+        return_value=required_dates,
+    )
+    mocker.patch.object(engine, "_now", return_value=fixed_now)
+    bars = [
+        SimpleNamespace(
+            date=datetime.combine(session, datetime.min.time()),
+            close=100.0,
+        )
+        for session in required_dates
+    ]
+    portfolio_manager.ibkr.request_historical_data = mocker.AsyncMock(return_value=bars)
+
+    dates, aligned_closes = await engine._get_regime_aligned_closes(
+        list(REGIME_SYMBOLS),
+        lookback_days=200,
+        cooldown_days=0,
+    )
+
+    required_dates_mock.assert_called_once_with(201)
+    assert dates == required_dates
+    assert all(len(closes) == 201 for closes in aligned_closes.values())
+    assert {
+        call.args[1]
+        for call in portfolio_manager.ibkr.request_historical_data.await_args_list
+    } == {"295 D"}
+
+
+@pytest.mark.asyncio
 async def test_regime_rebalance_rejects_incomplete_cached_history(
     portfolio_manager_with_db, mocker, monkeypatch
 ):

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -519,6 +519,12 @@ daily_stddev_window = "30 D"
 
   [portfolio.symbols.QQQ]
   weight = 0.3
+  # Optional post-volatility absolute-trend target modifier. It uses only
+  # completed sessions and defaults to disabled when absent or enabled=false.
+  # [portfolio.symbols.QQQ.absolute_trend]
+  # enabled = false
+  # lookback_days = 168
+  # risk_off_multiplier = 0.15
   # The target DTE may also be specified per-symbol, and takes precedence over
   # `target.dte`
   dte = 60

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -665,6 +665,11 @@ class SymbolConfig(BaseModel):
                 raise ValueError("volatility_weight.max_weight must be >= min_weight")
             return self
 
+    class AbsoluteTrend(BaseModel):
+        enabled: bool = Field(default=False)
+        lookback_days: int = Field(default=168, ge=2)
+        risk_off_multiplier: float = Field(default=0.15, ge=0.0, le=1.0)
+
     weight: float = Field(..., ge=0, le=1)
     primary_exchange: str = Field(default="", min_length=1)
     delta: float | None = Field(default=None, ge=0, le=1)
@@ -676,6 +681,7 @@ class SymbolConfig(BaseModel):
     calls: Optional["SymbolConfig.Calls"] = None
     puts: Optional["SymbolConfig.Puts"] = None
     volatility_weight: Optional["SymbolConfig.VolatilityWeight"] = None
+    absolute_trend: Optional["SymbolConfig.AbsoluteTrend"] = None
     adjust_price_after_delay: bool = Field(default=False)
     no_trading: bool | None = None
     buy_only_rebalancing: bool | None = None

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -56,7 +56,10 @@ from thetagang.strategies.equity_engine import EquityRebalanceEngine
 from thetagang.strategies.options import OptionsManageService, OptionsWriteService
 from thetagang.strategies.options_engine import OptionsStrategyEngine
 from thetagang.strategies.post_engine import PostStrategyEngine
-from thetagang.strategies.regime_engine import RegimeRebalanceEngine
+from thetagang.strategies.regime_engine import (
+    ABSOLUTE_TREND_STATE_EVENT,
+    RegimeRebalanceEngine,
+)
 from thetagang.strategies.runtime_services import (
     EquityRuntimeServiceAdapter,
     OptionsRuntimeServiceAdapter,
@@ -92,6 +95,7 @@ logging.getLogger("ib_async.wrapper").setLevel(logging.CRITICAL)
 
 TAIL_HARVEST_FILL_TIMEOUT_SECONDS = 5 * 60
 REGIME_PLANNING_STATE_EVENTS = {
+    ABSOLUTE_TREND_STATE_EVENT,
     "regime_rebalance_state",
     "volatility_weight_state",
 }

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1478,8 +1478,12 @@ class RegimeRebalanceEngine:
                 "Regime-aware rebalancing requires completed session dates.",
                 cache_recoverable=False,
             )
-        trading_days_needed = lookback_days + 1 + max(cooldown_days, 0)
-        calendar_days = math.ceil(trading_days_needed * 7 / 5) + 5
+        calendar_days = (self._now().date() - required_dates[0]).days + 1
+        if calendar_days <= 0:
+            raise RegimeHistoryValidationError(
+                "Regime-aware rebalancing requires a valid history request window.",
+                cache_recoverable=False,
+            )
         duration = f"{calendar_days} D"
         api_closes_by_symbol = await self._fetch_regime_history_closes(
             symbols, duration

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -1670,6 +1670,8 @@ class RegimeRebalanceEngine:
         effective_weights: dict[str, float],
         symbol_configs: dict[str, Any],
         history_cache: RegimeHistoryCache,
+        *,
+        exclude_current_run_state: bool = False,
     ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
         adjusted_weights = dict(effective_weights)
         trend_details: dict[str, dict[str, Any]] = {}
@@ -1690,15 +1692,17 @@ class RegimeRebalanceEngine:
         previous_state = (
             self.data_store.get_last_event_payload(
                 ABSOLUTE_TREND_STATE_EVENT,
+                exclude_current_run=exclude_current_run_state,
                 raise_on_error=True,
             )
             if self.data_store
             else None
         )
+        previous_symbols_raw = (
+            previous_state.get("symbols") if isinstance(previous_state, dict) else None
+        )
         previous_symbols = (
-            previous_state.get("symbols", {})
-            if isinstance(previous_state, dict)
-            else {}
+            previous_symbols_raw if isinstance(previous_symbols_raw, dict) else {}
         )
 
         def apply_signal(
@@ -1986,7 +1990,6 @@ class RegimeRebalanceEngine:
         market_prices: dict[str, float] = {}
         target_shares: dict[str, int] = {}
         target_values: dict[str, float] = {}
-        relative_ratios: dict[str, float] = {}
         relative_drifts: dict[str, float] = {}
         share_gaps: dict[str, int] = {}
         for symbol in symbols:
@@ -2053,11 +2056,13 @@ class RegimeRebalanceEngine:
             history_cache,
             exclude_current_run_state=exclude_current_run_state,
         )
-        pre_trend_total_effective_weight = sum(effective_weights.values())
+        pre_trend_effective_weights = dict(effective_weights)
+        pre_trend_total_effective_weight = sum(pre_trend_effective_weights.values())
         effective_weights, trend_details = await self._apply_absolute_trend(
             effective_weights,
             symbol_configs,
             history_cache,
+            exclude_current_run_state=exclude_current_run_state,
         )
         target_modifier_details = (
             ("volatility_weight", volatility_details),
@@ -2079,10 +2084,11 @@ class RegimeRebalanceEngine:
             )
         }
         total_effective_weight = sum(effective_weights.values())
-        if total_effective_weight <= 0:
-            log.error("Regime-aware rebalancing effective weights sum to zero.")
+        if not math.isfinite(total_effective_weight) or total_effective_weight < 0:
+            log.error("Regime-aware rebalancing effective weights are invalid.")
             raise ValueError(
-                "Regime-aware rebalancing requires positive effective weights."
+                "Regime-aware rebalancing requires finite non-negative "
+                "effective weights."
             )
         if weight_base == RegimeRebalanceBaseEnum.managed_stocks and not math.isclose(
             total_effective_weight,
@@ -2128,10 +2134,14 @@ class RegimeRebalanceEngine:
                 f"{pfmt(stacked_target_weight)} above the configured 100% "
                 "allocation using the NLV-backed margin base."
             )
-        normalized_effective_weights = {
-            symbol: weight / total_effective_weight
-            for symbol, weight in effective_weights.items()
-        }
+        normalized_effective_weights = (
+            {
+                symbol: weight / total_effective_weight
+                for symbol, weight in effective_weights.items()
+            }
+            if total_effective_weight > 0
+            else {symbol: 0.0 for symbol in symbols}
+        )
         for symbol in symbols:
             market_price = market_prices[symbol]
             current_position = current_positions[symbol]
@@ -2141,9 +2151,19 @@ class RegimeRebalanceEngine:
             target_values[symbol] = target_weight * total_value
             target_shares[symbol] = math.floor(target_values[symbol] / market_price)
             share_gaps[symbol] = target_shares[symbol] - current_position
-            relative_ratio = current_weights[symbol] / target_weight
-            relative_ratios[symbol] = relative_ratio
-            relative_drifts[symbol] = abs(relative_ratio - 1.0)
+            if target_weight > 0:
+                relative_drift = abs(current_weights[symbol] / target_weight - 1.0)
+            elif math.isclose(
+                current_weights[symbol],
+                0.0,
+                rel_tol=0.0,
+                abs_tol=regime_rebalance.eps,
+            ):
+                relative_drift = 0.0
+            else:
+                # A zero target with a live position is a full hard-band drift.
+                relative_drift = 1.0
+            relative_drifts[symbol] = relative_drift
 
         invested_value = sum(current_values.values())
         proxy_symbols = [symbol for symbol in symbols if current_values[symbol] > 0]
@@ -2158,7 +2178,13 @@ class RegimeRebalanceEngine:
             log.warning(
                 "Regime proxy has no invested symbols; falling back to target weights."
             )
-            proxy_weights = {symbol: effective_weights[symbol] for symbol in symbols}
+            # A zero trend multiplier can intentionally move every final target to
+            # cash. Keep the market proxy usable with the post-volatility weights.
+            proxy_weights = (
+                effective_weights
+                if total_effective_weight > 0
+                else pre_trend_effective_weights
+            )
 
         dates, values = await self._get_regime_proxy_series(
             symbols,
@@ -2190,6 +2216,16 @@ class RegimeRebalanceEngine:
         ratio_gate = getattr(regime_rebalance, "ratio_gate", None)
         ratio_result: RatioGateResult | None = None
         if ratio_gate is not None:
+            ratio_anchor = getattr(ratio_gate, "anchor", "")
+            ratio_rest = [symbol for symbol in symbols if symbol != ratio_anchor]
+            ratio_effective_weights = effective_weights
+            if (
+                ratio_rest
+                and sum(effective_weights[symbol] for symbol in ratio_rest) <= 0
+            ):
+                # Preserve a usable relative-market signal when zero trend
+                # multipliers intentionally move the entire rest basket to cash.
+                ratio_effective_weights = pre_trend_effective_weights
             _, ratio_aligned_closes = await history_cache.get(
                 symbols,
                 regime_rebalance.lookback_days,
@@ -2200,7 +2236,7 @@ class RegimeRebalanceEngine:
                 dates=dates,
                 aligned_closes=ratio_aligned_closes,
                 ratio_gate=ratio_gate,
-                effective_weights=effective_weights,
+                effective_weights=ratio_effective_weights,
                 lookback_days=regime_rebalance.lookback_days,
                 eps=regime_rebalance.eps,
             )

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -54,6 +54,7 @@ TRADING_DAYS_PER_YEAR = 252
 REGIME_HISTORY_TIMEFRAME = "1 day"
 REGIME_HISTORY_MAX_ATTEMPTS = 3
 REGIME_HISTORY_RETRY_DELAY_SECONDS = 0.25
+ABSOLUTE_TREND_STATE_EVENT = "absolute_trend_state"
 TAIL_HEDGE_HARVEST_EVENT = "tail_hedge_harvest"
 TAIL_HEDGE_HARVEST_SCHEMA_VERSION = 2
 
@@ -107,6 +108,146 @@ class RatioGateResult:
             f"ratio_drift_max={_ffmt_or_dash(self.drift_max)} "
             f"anchor={self.anchor} rest={','.join(self.rest)}"
         )
+
+
+@dataclass(frozen=True)
+class _AbsoluteTrendSignal:
+    lookback_days: int
+    latest_session: str
+    latest_close: float
+    moving_average: float
+    momentum_reference_close: float
+    lookback_return: float
+    risk_off: bool
+
+    @classmethod
+    def from_history(
+        cls,
+        *,
+        dates: list[date],
+        closes: list[float],
+        lookback_days: int,
+    ) -> _AbsoluteTrendSignal:
+        required_points = lookback_days + 1
+        if len(dates) != len(closes):
+            raise ValueError("misaligned_history")
+        if len(dates) < required_points or len(closes) < required_points:
+            raise ValueError("insufficient_history")
+
+        window = np.asarray(closes[-required_points:], dtype=float)
+        if not np.all(np.isfinite(window)) or np.any(window <= 0):
+            raise ValueError("invalid_closes")
+
+        latest_close = float(window[-1])
+        moving_average = float(np.mean(window[:-1]))
+        momentum_reference_close = float(window[0])
+        return cls(
+            lookback_days=lookback_days,
+            latest_session=str(dates[-1]),
+            latest_close=latest_close,
+            moving_average=moving_average,
+            momentum_reference_close=momentum_reference_close,
+            lookback_return=latest_close / momentum_reference_close - 1.0,
+            risk_off=(
+                latest_close < moving_average
+                and latest_close < momentum_reference_close
+            ),
+        )
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: Any,
+        *,
+        lookback_days: int,
+    ) -> _AbsoluteTrendSignal:
+        if not isinstance(payload, dict):
+            raise TypeError("state_not_an_object")
+        if payload.get("lookback_days") != lookback_days:
+            raise ValueError("lookback_mismatch")
+
+        latest_session = payload.get("latest_session")
+        risk_off = payload.get("risk_off")
+        if not isinstance(latest_session, str):
+            raise TypeError("invalid_latest_session")
+        if not latest_session:
+            raise ValueError("invalid_latest_session")
+        try:
+            date.fromisoformat(latest_session)
+        except ValueError as exc:
+            raise ValueError("invalid_latest_session") from exc
+        if not isinstance(risk_off, bool):
+            raise TypeError("invalid_risk_state")
+
+        def finite_number(field: str, *, positive: bool = False) -> float:
+            value = payload.get(field)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"invalid_{field}")
+            normalized_value = float(value)
+            if not math.isfinite(normalized_value) or (
+                positive and normalized_value <= 0
+            ):
+                raise ValueError(f"invalid_{field}")
+            return normalized_value
+
+        latest_close = finite_number("latest_close", positive=True)
+        moving_average = finite_number("moving_average", positive=True)
+        momentum_reference_close = finite_number(
+            "momentum_reference_close", positive=True
+        )
+        lookback_return = finite_number("lookback_return")
+        if not math.isclose(
+            lookback_return,
+            latest_close / momentum_reference_close - 1.0,
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("inconsistent_lookback_return")
+        if risk_off != (
+            latest_close < moving_average and latest_close < momentum_reference_close
+        ):
+            raise ValueError("inconsistent_risk_state")
+
+        return cls(
+            lookback_days=lookback_days,
+            latest_session=latest_session,
+            latest_close=latest_close,
+            moving_average=moving_average,
+            momentum_reference_close=momentum_reference_close,
+            lookback_return=lookback_return,
+            risk_off=risk_off,
+        )
+
+    @property
+    def state(self) -> str:
+        return "risk_off" if self.risk_off else "risk_on"
+
+    def target_details(
+        self,
+        *,
+        pre_trend_target: float,
+        risk_off_multiplier: float,
+        history_source: str,
+        history_failure: str | None = None,
+    ) -> dict[str, Any]:
+        applied_multiplier = risk_off_multiplier if self.risk_off else 1.0
+        details: dict[str, Any] = {
+            "lookback_days": self.lookback_days,
+            "latest_session": self.latest_session,
+            "latest_close": self.latest_close,
+            "moving_average": self.moving_average,
+            "momentum_reference_close": self.momentum_reference_close,
+            "lookback_return": self.lookback_return,
+            "risk_off": self.risk_off,
+            "state": self.state,
+            "pre_trend_target": pre_trend_target,
+            "final_target": pre_trend_target * applied_multiplier,
+            "applied_multiplier": applied_multiplier,
+            "history_source": history_source,
+        }
+        if history_failure is not None:
+            details["history_failure"] = history_failure
+        return details
 
 
 @dataclass(frozen=True)
@@ -1520,6 +1661,134 @@ class RegimeRebalanceEngine:
 
         return effective_weights, volatility_details
 
+    async def _apply_absolute_trend(
+        self,
+        effective_weights: dict[str, float],
+        symbol_configs: dict[str, Any],
+        history_cache: RegimeHistoryCache,
+    ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
+        adjusted_weights = dict(effective_weights)
+        trend_details: dict[str, dict[str, Any]] = {}
+        trend_configs: dict[str, Any] = {}
+        trend_symbols_by_lookback: dict[int, list[str]] = {}
+
+        for symbol in effective_weights:
+            absolute_trend = getattr(symbol_configs[symbol], "absolute_trend", None)
+            if absolute_trend is None or not getattr(absolute_trend, "enabled", False):
+                continue
+            trend_configs[symbol] = absolute_trend
+            lookback_days = int(absolute_trend.lookback_days)
+            trend_symbols_by_lookback.setdefault(lookback_days, []).append(symbol)
+
+        if not trend_symbols_by_lookback:
+            return adjusted_weights, trend_details
+
+        previous_state = (
+            self.data_store.get_last_event_payload(
+                ABSOLUTE_TREND_STATE_EVENT,
+                raise_on_error=True,
+            )
+            if self.data_store
+            else None
+        )
+        previous_symbols = (
+            previous_state.get("symbols", {})
+            if isinstance(previous_state, dict)
+            else {}
+        )
+
+        def apply_signal(
+            symbol: str,
+            signal: _AbsoluteTrendSignal,
+            *,
+            history_source: str,
+            history_failure: str | None = None,
+        ) -> dict[str, Any]:
+            details = signal.target_details(
+                pre_trend_target=adjusted_weights[symbol],
+                risk_off_multiplier=float(trend_configs[symbol].risk_off_multiplier),
+                history_source=history_source,
+                history_failure=history_failure,
+            )
+            adjusted_weights[symbol] = float(details["final_target"])
+            trend_details[symbol] = details
+            return details
+
+        def apply_persisted_state(
+            symbol: str,
+            lookback_days: int,
+            failure_reason: str,
+        ) -> None:
+            try:
+                signal = _AbsoluteTrendSignal.from_payload(
+                    previous_symbols.get(symbol),
+                    lookback_days=lookback_days,
+                )
+            except (TypeError, ValueError) as exc:
+                log.error(
+                    f"{symbol}: absolute trend history is unavailable and no "
+                    "valid persisted state exists; aborting rebalancing."
+                )
+                raise RuntimeError(
+                    f"{symbol}: absolute trend requires current history or a "
+                    "valid persisted state."
+                ) from exc
+
+            details = apply_signal(
+                symbol,
+                signal,
+                history_source="persisted",
+                history_failure=failure_reason,
+            )
+            log.warning(
+                f"{symbol}: absolute trend history unavailable "
+                f"({failure_reason}); retaining persisted "
+                f"{signal.state.replace('_', '-')} state with target "
+                f"{pfmt(details['pre_trend_target'])}->"
+                f"{pfmt(details['final_target'])}."
+            )
+
+        for lookback_days, group_symbols in trend_symbols_by_lookback.items():
+            try:
+                dates, aligned_closes = await history_cache.get(
+                    group_symbols,
+                    lookback_days,
+                    0,
+                )
+            except Exception as exc:  # noqa: BLE001
+                failure_reason = type(exc).__name__
+                for symbol in group_symbols:
+                    apply_persisted_state(symbol, lookback_days, failure_reason)
+                continue
+
+            for symbol in group_symbols:
+                try:
+                    signal = _AbsoluteTrendSignal.from_history(
+                        dates=dates,
+                        closes=aligned_closes[symbol],
+                        lookback_days=lookback_days,
+                    )
+                except (KeyError, TypeError, ValueError) as exc:
+                    apply_persisted_state(
+                        symbol,
+                        lookback_days,
+                        type(exc).__name__,
+                    )
+                    continue
+
+                details = apply_signal(symbol, signal, history_source="fresh")
+                log.notice(
+                    f"{symbol}: absolute trend latest={signal.latest_close:.4f} "
+                    f"average_{lookback_days}d={signal.moving_average:.4f} "
+                    f"return_{lookback_days}d={pfmt(signal.lookback_return)} "
+                    f"state={signal.state.replace('_', '-')} "
+                    f"multiplier={ffmt(details['applied_multiplier'])} "
+                    f"target={pfmt(details['pre_trend_target'])}->"
+                    f"{pfmt(details['final_target'])}"
+                )
+
+        return adjusted_weights, trend_details
+
     async def _get_last_regime_rebalance_time(
         self, symbols: list[str]
     ) -> datetime | None:
@@ -1780,17 +2049,30 @@ class RegimeRebalanceEngine:
             history_cache,
             exclude_current_run_state=exclude_current_run_state,
         )
+        pre_trend_total_effective_weight = sum(effective_weights.values())
+        effective_weights, trend_details = await self._apply_absolute_trend(
+            effective_weights,
+            symbol_configs,
+            history_cache,
+        )
+        target_modifier_details = (
+            ("volatility_weight", volatility_details),
+            ("absolute_trend", trend_details),
+        )
         harvest_risk_ready_symbols = {
             symbol
             for symbol in symbols
-            if not bool(
-                getattr(
-                    getattr(symbol_configs[symbol], "volatility_weight", None),
-                    "enabled",
-                    False,
+            if all(
+                not bool(
+                    getattr(
+                        getattr(symbol_configs[symbol], config_name, None),
+                        "enabled",
+                        False,
+                    )
                 )
+                or symbol in modifier_details
+                for config_name, modifier_details in target_modifier_details
             )
-            or symbol in volatility_details
         }
         total_effective_weight = sum(effective_weights.values())
         if total_effective_weight <= 0:
@@ -2475,6 +2757,7 @@ class RegimeRebalanceEngine:
             )
 
             volatility_detail = volatility_details.get(symbol)
+            trend_detail = trend_details.get(symbol)
             target_weight_display = pfmt(target_weight)
             if volatility_detail is not None:
                 target_weight_display = (
@@ -2482,31 +2765,37 @@ class RegimeRebalanceEngine:
                     f"(base {pfmt(volatility_detail['base_weight'])}, "
                     f"vol {pfmt(volatility_detail['realized_vol'])})"
                 )
+            if trend_detail is not None:
+                target_weight_display += (
+                    f" (trend {trend_detail['state']} "
+                    f"x{ffmt(trend_detail['applied_multiplier'])})"
+                )
 
-            regime_summary.append(
-                {
-                    "symbol": symbol,
-                    "market_price": market_prices[symbol],
-                    "current_weight": current_weights[symbol],
-                    "target_weight": target_weight,
-                    "current_value": current_values[symbol],
-                    "target_value": target_value,
-                    "current_shares": current_positions[symbol],
-                    "target_shares": target_share,
-                    "shares_to_trade": filtered_trade_shares,
-                    "weight_delta": weight_delta,
-                    "value_delta": value_delta,
-                    "shares_delta": shares_delta,
-                    "trading_allowed": trading_allowed,
-                    "minimum_trade_shares": min_shares,
-                    "minimum_trade_amount": min_amount,
-                    "minimum_trade_relative": min_percent_relative,
-                    "action": action,
-                    "target_weight_display": target_weight_display,
-                    "gate_status": gate_status,
-                    "volatility_weight": volatility_detail,
-                }
-            )
+            summary_details = {
+                "symbol": symbol,
+                "market_price": market_prices[symbol],
+                "current_weight": current_weights[symbol],
+                "target_weight": target_weight,
+                "current_value": current_values[symbol],
+                "target_value": target_value,
+                "current_shares": current_positions[symbol],
+                "target_shares": target_share,
+                "shares_to_trade": filtered_trade_shares,
+                "weight_delta": weight_delta,
+                "value_delta": value_delta,
+                "shares_delta": shares_delta,
+                "trading_allowed": trading_allowed,
+                "minimum_trade_shares": min_shares,
+                "minimum_trade_amount": min_amount,
+                "minimum_trade_relative": min_percent_relative,
+                "action": action,
+                "target_weight_display": target_weight_display,
+                "gate_status": gate_status,
+                "volatility_weight": volatility_detail,
+            }
+            if trend_detail is not None:
+                summary_details["absolute_trend"] = trend_detail
+            regime_summary.append(summary_details)
 
         to_trade = await self._apply_tail_harvest(
             orders=to_trade,
@@ -2771,14 +3060,35 @@ class RegimeRebalanceEngine:
                     "deficit_active": deficit_active_next,
                 },
             )
+            if trend_details and not self.data_store.record_event(
+                ABSOLUTE_TREND_STATE_EVENT,
+                {
+                    "pre_trend_total_effective_weight": (
+                        pre_trend_total_effective_weight
+                    ),
+                    "final_total_effective_weight": total_effective_weight,
+                    "symbols": trend_details,
+                },
+            ):
+                raise RuntimeError("Failed to persist absolute trend state.")
             if volatility_details:
+                volatility_unallocated_target_weight = max(
+                    0.0, 1.0 - pre_trend_total_effective_weight
+                )
+                volatility_stacked_target_weight = max(
+                    0.0, pre_trend_total_effective_weight - 1.0
+                )
                 self.data_store.record_event(
                     "volatility_weight_state",
                     {
-                        "total_effective_weight": total_effective_weight,
-                        "unallocated_target_weight": unallocated_target_weight,
-                        "stacked_target_weight": stacked_target_weight,
-                        "stacked_target_value": stacked_target_value,
+                        "total_effective_weight": pre_trend_total_effective_weight,
+                        "unallocated_target_weight": (
+                            volatility_unallocated_target_weight
+                        ),
+                        "stacked_target_weight": volatility_stacked_target_weight,
+                        "stacked_target_value": (
+                            volatility_stacked_target_weight * total_value
+                        ),
                         "symbols": {
                             symbol: {
                                 "base_weight": details["base_weight"],


### PR DESCRIPTION
## Summary

Add an optional per-symbol absolute-trend target modifier to the existing regime-rebalance engine. The modifier runs after volatility weighting and before the existing band, rebalance, and order logic. It defaults to disabled, so existing configurations retain their current behavior.

## User Impact

When enabled, a symbol is risk-off only when its latest completed close is below both the average of the preceding lookback window and the close at the start of that window. In risk-off, the post-volatility target is multiplied by the configured factor; for example, a 40% volatility target becomes 6% with a 0.15 multiplier. Existing hard-band logic then sells toward that lower target.

Configurations without `absolute_trend`, or with `enabled = false`, are unchanged.

## Root Cause

Regime rebalancing could adapt per-symbol targets to realized volatility, but it had no absolute-trend modifier for reducing an already volatility-adjusted target. Trend state also needed independent persistence so a history outage could not silently restore risk-on exposure.

The historical-data request also approximated exchange sessions as weekdays. Because IBKR interprets a `D` duration as calendar days, that approximation could under-request daily bars across exchange holidays; the 201-close XNYS window ending 2026-08-21 needs a 295-day request rather than the previous 287-day estimate.

## Fix

- Add validated `absolute_trend` symbol configuration with disabled-by-default settings.
- Build the signal from `lookback_days + 1` completed closes using strict risk-off boundaries.
- Derive the IBKR request duration from the inclusive calendar span between the earliest required completed session and the request date.
- Apply the trend multiplier after volatility weighting without writing the reduced target into `volatility_weight_state`.
- Persist validated signal state and telemetry, reuse only a consistent same-lookback state when history retrieval fails, and otherwise abort rebalancing.
- Report latest close, moving average, lookback return, state, pre-trend target, final target, multiplier, and history source.
- Cover boundary behavior, 30%/40%/45% target scaling, incomplete-bar exclusion, the 200-session request span, fail-closed persistence, hard-band selling, volatility-state isolation, and disabled configurations.

The checked-in example documents the configuration but leaves it disabled pending paper-account validation.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest -q --disable-warnings --cov=thetagang --cov-report=term` — 536 passed, 81% coverage
- `uv run pytest -q tests/test_config_new.py tests/test_legacy_config.py tests/test_regime_rebalance.py -k 'absolute_trend or history_request_covers_200_completed_sessions or volatility_weight_state_payload_fields'` — 16 passed
- `git diff --check`

Not performed in this branch: paper-TWS execution and telemetry comparison against the backtester. The feature remains disabled in the sample configuration until that operational validation is available.
