### PR TITLE
feat: add configurable order execution policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,17 +303,41 @@ close_if_unable_to_roll = true
 Automatically adjust limit orders after initial delay:
 
 ```toml
-[symbols.SPY]
+[portfolio.symbols.SPY]
 adjust_price_after_delay = true  # Adjusts to midpoint after delay
 ```
+
+#### Per-Symbol Execution Policies
+
+Per-symbol execution behavior is opt-in. Without an `execution` table, ThetaGang
+keeps its existing behavior and leaves unfinished DAY limit orders working at the
+broker when the run ends.
+
+```toml
+[portfolio.symbols.SPY.execution]
+buy_price = "ask"                # bid | ask | mid
+sell_price = "bid"               # bid | ask | mid
+fill_timeout = 300               # Supervise this order for five minutes
+on_timeout = "marketable_limit"  # leave_open | cancel | marketable_limit | market
+final_wait = 30                   # Cancel an incomplete replacement after 30 seconds
+```
+
+The configured quote is used for initial submission and subsequent repricing.
+Using the ask for buys and the bid for sells is the aggressive, marketable
+configuration. At the timeout, a `marketable_limit` replacement retains price
+protection by using the current ask or bid. A raw `market` fallback is explicitly
+opt-in and is not supported for combo orders. ThetaGang confirms cancellation of
+the original order and replaces only its unfilled quantity; if cancellation or
+fill state is ambiguous, no replacement is submitted. Tail-hedge orders retain
+their separate execution safeguards.
 
 #### Algorithm Configuration
 Customize order execution algorithms:
 
 ```toml
-[orders.algo]
+[runtime.orders.algo]
 strategy = "Adaptive"
-params.priority = "Patient"  # Options: "Urgent", "Normal", "Patient"
+params = [["adaptivePriority", "Patient"]]
 ```
 
 ### Position Management

--- a/README.md
+++ b/README.md
@@ -322,14 +322,17 @@ on_timeout = "marketable_limit"  # leave_open | cancel | marketable_limit | mark
 final_wait = 30                   # Cancel an incomplete replacement after 30 seconds
 ```
 
-The configured quote is used for initial submission and subsequent repricing.
-Using the ask for buys and the bid for sells is the aggressive, marketable
-configuration. At the timeout, a `marketable_limit` replacement retains price
-protection by using the current ask or bid. A raw `market` fallback is explicitly
-opt-in and is not supported for combo orders. ThetaGang confirms cancellation of
-the original order and replaces only its unfilled quantity; if cancellation or
-fill state is ambiguous, no replacement is submitted. Tail-hedge orders retain
-their separate execution safeguards.
+The configured quote is used for initial submission and, when `fill_timeout`
+enables supervision, subsequent repricing. Using the ask for buys and the bid for
+sells is the aggressive, marketable configuration. At the timeout, a
+`marketable_limit` replacement retains price protection by using the current ask
+or bid. A raw `market` fallback is explicitly opt-in and is not supported for
+combo orders. ThetaGang confirms cancellation of the original order and replaces
+only its unfilled quantity; if cancellation or fill state is ambiguous, no
+replacement is submitted. Tail-hedge orders retain their separate execution
+safeguards. Configured limit prices also preserve the sign of combo orders and the
+`minimum_credit` floor, so a credit order cannot be silently converted into a
+debit.
 
 #### Algorithm Configuration
 Customize order execution algorithms:

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -86,6 +86,41 @@ def test_orders_reject_invalid_price_update_delay_ranges(
         Config(**data)
 
 
+def test_symbol_execution_is_opt_in() -> None:
+    config = Config(**_base_config({"strategies": ["wheel"]}))
+
+    assert config.portfolio.symbols["AAA"].execution is None
+
+
+def test_symbol_execution_accepts_per_side_pricing_and_timeout_policy() -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["execution"] = {
+        "buy_price": "ask",
+        "sell_price": "bid",
+        "fill_timeout": 300,
+        "on_timeout": "marketable_limit",
+        "final_wait": 20,
+    }
+
+    config = Config(**data)
+    execution = config.portfolio.symbols["AAA"].execution
+
+    assert execution is not None
+    assert execution.buy_price == "ask"
+    assert execution.sell_price == "bid"
+    assert execution.fill_timeout == 300
+    assert execution.on_timeout == "marketable_limit"
+    assert execution.final_wait == 20
+
+
+def test_symbol_execution_timeout_action_requires_timeout() -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["execution"] = {"on_timeout": "market"}
+
+    with pytest.raises(ValueError, match="execution.fill_timeout"):
+        Config(**data)
+
+
 def test_tail_hedge_rejects_removed_strike_ratio() -> None:
     data = _base_config({"strategies": ["tail_hedge"]})
     data["strategies"]["tail_hedge"] = {

--- a/tests/test_legacy_config.py
+++ b/tests/test_legacy_config.py
@@ -32,6 +32,7 @@ class AccountConfigFactory(ModelFactory[AccountConfig]): ...
 
 class SymbolConfigFactory(ModelFactory[SymbolConfig]):
     absolute_trend = None
+    execution = None
     volatility_weight = None
 
 

--- a/tests/test_order_execution.py
+++ b/tests/test_order_execution.py
@@ -1,0 +1,365 @@
+from types import SimpleNamespace
+
+import pytest
+from ib_async import Contract, LimitOrder, Option
+
+from thetagang.config import Config
+from thetagang.order_execution import OrderExecutionManager
+from thetagang.strategies.tail_hedge_state import TAIL_HEDGE_ENTRY_ORDER_REF
+from thetagang.trades import Trades
+
+
+def _config(*, execution=None, minimum_credit=0.05) -> Config:
+    symbol = {"weight": 1.0}
+    if execution is not None:
+        symbol["execution"] = execution
+    return Config(
+        meta={"schema_version": 2},
+        run={"strategies": ["wheel"]},
+        runtime={
+            "account": {"number": "DUX", "margin_usage": 0.5},
+            "option_chains": {"expirations": 4, "strikes": 10},
+            "orders": {
+                "minimum_credit": minimum_credit,
+                "price_update_delay": [1, 2],
+            },
+            "ib_async": {"api_response_wait_time": 1},
+        },
+        portfolio={"symbols": {"AAA": symbol}},
+        strategies={
+            "wheel": {
+                "defaults": {
+                    "target": {"dte": 30, "minimum_open_interest": 5},
+                    "roll_when": {"dte": 7},
+                }
+            }
+        },
+    )
+
+
+def _option() -> Option:
+    return Option(
+        "AAA",
+        "20270115",
+        100,
+        "C",
+        "SMART",
+        currency="USD",
+        conId=123,
+    )
+
+
+def _ticker(contract: Contract, *, bid=0.9, ask=1.1, mid=1.0):
+    return SimpleNamespace(
+        contract=contract,
+        bid=bid,
+        ask=ask,
+        midpoint=lambda: mid,
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_orders_applies_per_side_price_strategy(mocker) -> None:
+    config = _config(execution={"buy_price": "ask", "sell_price": "bid"})
+    contract = _option()
+    ibkr = mocker.Mock()
+    ibkr.get_ticker_for_contract = mocker.AsyncMock(
+        return_value=_ticker(contract, bid=0.43, ask=0.57)
+    )
+    manager = OrderExecutionManager(config, ibkr)
+    buy = LimitOrder("BUY", 1, 1.0, account="DUX")
+    sell = LimitOrder("SELL", 1, 1.0, account="DUX")
+
+    await manager.prepare_orders([(contract, buy, None), (contract, sell, None)])
+
+    assert buy.lmtPrice == pytest.approx(0.57)
+    assert sell.lmtPrice == pytest.approx(0.43)
+
+
+@pytest.mark.asyncio
+async def test_prepare_orders_applies_mid_price_strategy(mocker) -> None:
+    config = _config(execution={"buy_price": "mid"})
+    contract = _option()
+    ibkr = mocker.Mock()
+    ibkr.get_ticker_for_contract = mocker.AsyncMock(
+        return_value=_ticker(contract, bid=0.43, ask=0.57, mid=0.51)
+    )
+    manager = OrderExecutionManager(config, ibkr)
+    order = LimitOrder("BUY", 1, 1.0, account="DUX")
+
+    await manager.prepare_orders([(contract, order, None)])
+
+    assert order.lmtPrice == pytest.approx(0.51)
+
+
+@pytest.mark.asyncio
+async def test_prepare_orders_preserves_fallback_for_zero_quote(mocker) -> None:
+    config = _config(execution={"sell_price": "bid"})
+    contract = _option()
+    ibkr = mocker.Mock()
+    ibkr.get_ticker_for_contract = mocker.AsyncMock(
+        return_value=_ticker(contract, bid=0.0)
+    )
+    manager = OrderExecutionManager(config, ibkr)
+    order = LimitOrder("SELL", 1, 0.75, account="DUX")
+
+    await manager.prepare_orders([(contract, order, None)])
+
+    assert order.lmtPrice == pytest.approx(0.75)
+
+
+@pytest.mark.asyncio
+async def test_prepare_orders_preserves_minimum_credit(mocker) -> None:
+    config = _config(execution={"sell_price": "bid"}, minimum_credit=0.05)
+    contract = _option()
+    ibkr = mocker.Mock()
+    ibkr.get_ticker_for_contract = mocker.AsyncMock(
+        return_value=_ticker(contract, bid=0.01)
+    )
+    manager = OrderExecutionManager(config, ibkr)
+    order = LimitOrder("SELL", 1, 0.08, account="DUX")
+
+    await manager.prepare_orders([(contract, order, None)])
+
+    assert order.lmtPrice == pytest.approx(0.05)
+
+
+@pytest.mark.asyncio
+async def test_prepare_orders_leaves_tail_orders_on_specialized_path(mocker) -> None:
+    config = _config(execution={"buy_price": "ask"})
+    contract = _option()
+    ibkr = mocker.Mock()
+    ibkr.get_ticker_for_contract = mocker.AsyncMock()
+    manager = OrderExecutionManager(config, ibkr)
+    order = LimitOrder(
+        "BUY",
+        1,
+        0.75,
+        account="DUX",
+        orderRef=TAIL_HEDGE_ENTRY_ORDER_REF,
+    )
+
+    await manager.prepare_orders([(contract, order, None)])
+
+    assert order.lmtPrice == pytest.approx(0.75)
+    ibkr.get_ticker_for_contract.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_execution_does_not_wait_or_cancel(mocker) -> None:
+    config = _config()
+    ibkr = mocker.Mock()
+    ibkr.wait_for_orders_complete = mocker.AsyncMock()
+    trades = mocker.Mock(spec=Trades)
+    trades.records.return_value = []
+    trades.is_empty.return_value = True
+    manager = OrderExecutionManager(config, ibkr)
+
+    await manager.execute(trades)
+
+    ibkr.wait_for_orders_complete.assert_not_awaited()
+    ibkr.cancel_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_leave_open_timeout_preserves_working_order(mocker) -> None:
+    config = _config(execution={"fill_timeout": 1})
+    contract = _option()
+    order = LimitOrder("SELL", 1, 0.5, account="DUX")
+    trade = mocker.Mock(
+        contract=contract,
+        order=order,
+        orderStatus=SimpleNamespace(status="Submitted", filled=0.0, remaining=1.0),
+    )
+    trade.isDone.return_value = False
+    ibkr = mocker.Mock()
+    ibkr.wait_for_orders_complete = mocker.AsyncMock(return_value=[trade])
+    trades = mocker.Mock(spec=Trades)
+    trades.records.return_value = [trade]
+    trades.is_empty.return_value = False
+    manager = OrderExecutionManager(config, ibkr)
+
+    await manager.execute(trades)
+
+    ibkr.cancel_order.assert_not_called()
+    trades.submit_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_marketable_limit_replaces_only_partially_filled_remainder(
+    mocker,
+) -> None:
+    config = _config(
+        execution={
+            "fill_timeout": 300,
+            "on_timeout": "marketable_limit",
+            "final_wait": 1,
+        }
+    )
+    policy = config.portfolio.symbols["AAA"].execution
+    assert policy is not None
+    contract = _option()
+    original_order = LimitOrder(
+        "SELL",
+        2,
+        0.5,
+        account="DUX",
+        orderRef="tg:test",
+    )
+    original_status = SimpleNamespace(status="Submitted", filled=1.0, remaining=1.0)
+    original_trade = mocker.Mock(
+        contract=contract,
+        order=original_order,
+        orderStatus=original_status,
+    )
+    original_trade.isDone.side_effect = lambda: original_status.status == "Cancelled"
+    records = [original_trade]
+    ibkr = mocker.Mock()
+
+    def cancel_order(_order):
+        original_status.status = "Cancelled"
+
+    ibkr.cancel_order.side_effect = cancel_order
+    ibkr.wait_for_orders_complete = mocker.AsyncMock(return_value=[])
+    ibkr.get_ticker_for_contract = mocker.AsyncMock(
+        return_value=_ticker(contract, bid=0.42)
+    )
+    trades = mocker.Mock(spec=Trades)
+    trades.records.side_effect = lambda: records
+
+    def submit_order(submitted_contract, submitted_order, idx):
+        replacement_status = SimpleNamespace(
+            status="Filled",
+            filled=1.0,
+            remaining=0.0,
+        )
+        replacement_trade = mocker.Mock(
+            contract=submitted_contract,
+            order=submitted_order,
+            orderStatus=replacement_status,
+        )
+        replacement_trade.isDone.return_value = True
+        records[idx] = replacement_trade
+        return True
+
+    trades.submit_order.side_effect = submit_order
+    manager = OrderExecutionManager(config, ibkr)
+
+    await manager._handle_timeout(trades, 0, policy)
+
+    submitted_order = trades.submit_order.call_args.args[1]
+    assert submitted_order.orderType == "LMT"
+    assert submitted_order.totalQuantity == 1
+    assert submitted_order.lmtPrice == pytest.approx(0.42)
+    assert submitted_order.orderRef == "tg:test"
+    assert submitted_order.algoStrategy == ""
+
+
+@pytest.mark.asyncio
+async def test_timeout_does_not_replace_without_confirmed_cancellation(mocker) -> None:
+    config = _config(
+        execution={"fill_timeout": 300, "on_timeout": "market", "final_wait": 1}
+    )
+    policy = config.portfolio.symbols["AAA"].execution
+    assert policy is not None
+    contract = _option()
+    order = LimitOrder("BUY", 1, 0.5, account="DUX")
+    trade = mocker.Mock(
+        contract=contract,
+        order=order,
+        orderStatus=SimpleNamespace(status="Submitted", filled=0.0, remaining=1.0),
+    )
+    trade.isDone.return_value = False
+    ibkr = mocker.Mock()
+    ibkr.wait_for_orders_complete = mocker.AsyncMock(return_value=[trade])
+    trades = mocker.Mock(spec=Trades)
+    trades.records.return_value = [trade]
+    manager = OrderExecutionManager(config, ibkr)
+
+    await manager._handle_timeout(trades, 0, policy)
+
+    ibkr.cancel_order.assert_called_once_with(order)
+    trades.submit_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_market_timeout_replaces_only_confirmed_remainder(mocker) -> None:
+    config = _config(
+        execution={"fill_timeout": 300, "on_timeout": "market", "final_wait": 1}
+    )
+    policy = config.portfolio.symbols["AAA"].execution
+    assert policy is not None
+    contract = _option()
+    original_order = LimitOrder("BUY", 3, 0.5, account="DUX", orderRef="tg:test")
+    original_status = SimpleNamespace(status="Submitted", filled=1.0, remaining=2.0)
+    original_trade = mocker.Mock(
+        contract=contract,
+        order=original_order,
+        orderStatus=original_status,
+    )
+    original_trade.isDone.side_effect = lambda: original_status.status == "Cancelled"
+    records = [original_trade]
+    ibkr = mocker.Mock()
+
+    def cancel_order(_order):
+        original_status.status = "Cancelled"
+
+    ibkr.cancel_order.side_effect = cancel_order
+    ibkr.wait_for_orders_complete = mocker.AsyncMock(return_value=[])
+    trades = mocker.Mock(spec=Trades)
+    trades.records.side_effect = lambda: records
+
+    def submit_order(submitted_contract, submitted_order, idx):
+        replacement_status = SimpleNamespace(
+            status="Filled",
+            filled=2.0,
+            remaining=0.0,
+        )
+        replacement_trade = mocker.Mock(
+            contract=submitted_contract,
+            order=submitted_order,
+            orderStatus=replacement_status,
+        )
+        replacement_trade.isDone.return_value = True
+        records[idx] = replacement_trade
+        return True
+
+    trades.submit_order.side_effect = submit_order
+    manager = OrderExecutionManager(config, ibkr)
+
+    await manager._handle_timeout(trades, 0, policy)
+
+    submitted_order = trades.submit_order.call_args.args[1]
+    assert submitted_order.orderType == "MKT"
+    assert submitted_order.totalQuantity == 2
+    assert submitted_order.orderRef == "tg:test"
+    assert submitted_order.algoStrategy == ""
+
+
+@pytest.mark.asyncio
+async def test_market_timeout_cancels_combo_without_replacement(mocker) -> None:
+    config = _config(
+        execution={"fill_timeout": 300, "on_timeout": "market", "final_wait": 1}
+    )
+    policy = config.portfolio.symbols["AAA"].execution
+    assert policy is not None
+    contract = Contract(secType="BAG", symbol="AAA", exchange="SMART", currency="USD")
+    order = LimitOrder("BUY", 1, -0.5, account="DUX")
+    status = SimpleNamespace(status="Submitted", filled=0.0, remaining=1.0)
+    trade = mocker.Mock(contract=contract, order=order, orderStatus=status)
+    trade.isDone.side_effect = lambda: status.status == "Cancelled"
+    ibkr = mocker.Mock()
+
+    def cancel_order(_order):
+        status.status = "Cancelled"
+
+    ibkr.cancel_order.side_effect = cancel_order
+    ibkr.wait_for_orders_complete = mocker.AsyncMock(return_value=[])
+    trades = mocker.Mock(spec=Trades)
+    trades.records.return_value = [trade]
+    manager = OrderExecutionManager(config, ibkr)
+
+    await manager._handle_timeout(trades, 0, policy)
+
+    ibkr.cancel_order.assert_called_once_with(order)
+    trades.submit_order.assert_not_called()

--- a/tests/test_order_execution.py
+++ b/tests/test_order_execution.py
@@ -125,6 +125,35 @@ async def test_prepare_orders_preserves_minimum_credit(mocker) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("ask", "expected_price"),
+    [(-0.01, -0.05), (0.10, -0.50)],
+)
+async def test_prepare_orders_preserves_combo_credit_safeguards(
+    mocker,
+    ask,
+    expected_price,
+) -> None:
+    config = _config(execution={"buy_price": "ask"}, minimum_credit=0.05)
+    contract = Contract(
+        secType="BAG",
+        symbol="AAA",
+        exchange="SMART",
+        currency="USD",
+    )
+    ibkr = mocker.Mock()
+    ibkr.get_ticker_for_contract = mocker.AsyncMock(
+        return_value=_ticker(contract, ask=ask)
+    )
+    manager = OrderExecutionManager(config, ibkr)
+    order = LimitOrder("BUY", 1, -0.50, account="DUX")
+
+    await manager.prepare_orders([(contract, order, None)])
+
+    assert order.lmtPrice == pytest.approx(expected_price)
+
+
+@pytest.mark.asyncio
 async def test_prepare_orders_leaves_tail_orders_on_specialized_path(mocker) -> None:
     config = _config(execution={"buy_price": "ask"})
     contract = _option()
@@ -148,15 +177,27 @@ async def test_prepare_orders_leaves_tail_orders_on_specialized_path(mocker) -> 
 @pytest.mark.asyncio
 async def test_unconfigured_execution_does_not_wait_or_cancel(mocker) -> None:
     config = _config()
+    contract = _option()
+    order = LimitOrder("SELL", 1, 0.5, account="DUX")
+    trade = mocker.Mock(
+        contract=contract,
+        order=order,
+        orderStatus=SimpleNamespace(status="Submitted", filled=0.0, remaining=1.0),
+    )
+    trade.isDone.return_value = False
     ibkr = mocker.Mock()
+    ibkr.get_ticker_for_contract = mocker.AsyncMock()
     ibkr.wait_for_orders_complete = mocker.AsyncMock()
     trades = mocker.Mock(spec=Trades)
-    trades.records.return_value = []
-    trades.is_empty.return_value = True
+    trades.records.return_value = [trade]
+    trades.is_empty.return_value = False
     manager = OrderExecutionManager(config, ibkr)
 
+    await manager.prepare_orders([(contract, order, None)])
     await manager.execute(trades)
 
+    assert order.lmtPrice == pytest.approx(0.5)
+    ibkr.get_ticker_for_contract.assert_not_awaited()
     ibkr.wait_for_orders_complete.assert_not_awaited()
     ibkr.cancel_order.assert_not_called()
 
@@ -183,6 +224,52 @@ async def test_leave_open_timeout_preserves_working_order(mocker) -> None:
 
     ibkr.cancel_order.assert_not_called()
     trades.submit_order.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fill_timeout_includes_time_spent_repricing(mocker) -> None:
+    config = _config(
+        execution={"buy_price": "ask", "fill_timeout": 10},
+    )
+    policy = config.portfolio.symbols["AAA"].execution
+    assert policy is not None
+    contract = _option()
+    order = LimitOrder("BUY", 1, 0.5, account="DUX")
+    trade = mocker.Mock(
+        contract=contract,
+        order=order,
+        orderStatus=SimpleNamespace(status="Submitted", filled=0.0, remaining=1.0),
+    )
+    trade.isDone.return_value = False
+    trades = mocker.Mock(spec=Trades)
+    trades.records.return_value = [trade]
+    elapsed = 0.0
+
+    async def wait_for_orders_complete(_trades, timeout):
+        nonlocal elapsed
+        elapsed += timeout
+        return [trade]
+
+    async def reprice_trade(*_args, **_kwargs):
+        nonlocal elapsed
+        elapsed += 3.0
+        return True
+
+    ibkr = mocker.Mock()
+    ibkr.wait_for_orders_complete = wait_for_orders_complete
+    manager = OrderExecutionManager(config, ibkr)
+    mocker.patch.object(manager, "reprice_trade", side_effect=reprice_trade)
+    manager._handle_timeout = mocker.AsyncMock()
+    mocker.patch(
+        "thetagang.order_execution.asyncio.get_running_loop",
+        return_value=SimpleNamespace(time=lambda: elapsed),
+    )
+    mocker.patch("thetagang.order_execution.random.randrange", return_value=6)
+
+    await manager._supervise_trade(trades, 0, trade, policy)
+
+    assert elapsed == pytest.approx(10.0)
+    manager._handle_timeout.assert_awaited_once_with(trades, 0, policy)
 
 
 @pytest.mark.asyncio
@@ -253,6 +340,47 @@ async def test_marketable_limit_replaces_only_partially_filled_remainder(
     assert submitted_order.lmtPrice == pytest.approx(0.42)
     assert submitted_order.orderRef == "tg:test"
     assert submitted_order.algoStrategy == ""
+
+
+@pytest.mark.asyncio
+async def test_marketable_limit_does_not_flip_combo_credit_to_debit(mocker) -> None:
+    config = _config(
+        execution={
+            "fill_timeout": 300,
+            "on_timeout": "marketable_limit",
+            "final_wait": 1,
+        }
+    )
+    policy = config.portfolio.symbols["AAA"].execution
+    assert policy is not None
+    contract = Contract(
+        secType="BAG",
+        symbol="AAA",
+        exchange="SMART",
+        currency="USD",
+    )
+    order = LimitOrder("BUY", 1, -0.5, account="DUX")
+    status = SimpleNamespace(status="Submitted", filled=0.0, remaining=1.0)
+    trade = mocker.Mock(contract=contract, order=order, orderStatus=status)
+    trade.isDone.side_effect = lambda: status.status == "Cancelled"
+    ibkr = mocker.Mock()
+
+    def cancel_order(_order):
+        status.status = "Cancelled"
+
+    ibkr.cancel_order.side_effect = cancel_order
+    ibkr.wait_for_orders_complete = mocker.AsyncMock(return_value=[])
+    ibkr.get_ticker_for_contract = mocker.AsyncMock(
+        return_value=_ticker(contract, ask=0.10)
+    )
+    trades = mocker.Mock(spec=Trades)
+    trades.records.return_value = [trade]
+    manager = OrderExecutionManager(config, ibkr)
+
+    await manager._handle_timeout(trades, 0, policy)
+
+    ibkr.cancel_order.assert_called_once_with(order)
+    trades.submit_order.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -522,9 +522,10 @@ daily_stddev_window = "30 D"
   # existing behavior is unchanged: orders may receive the legacy one-time price
   # adjustment above, then unfinished DAY limit orders remain open at the broker.
   #
-  # `buy_price` and `sell_price` select the quote used for initial submission and
-  # subsequent repricing. Valid values are "bid", "ask", and "mid". For a more
-  # aggressive policy, use the ask for buys and the bid for sells.
+  # `buy_price` and `sell_price` select the quote used for initial submission and,
+  # when `fill_timeout` enables supervision, subsequent repricing. Valid values
+  # are "bid", "ask", and "mid". For a more aggressive policy, use the ask for
+  # buys and the bid for sells.
   #
   # `fill_timeout` enables bounded supervision. At the timeout, `on_timeout` may
   # be "leave_open", "cancel", "marketable_limit", or "market". Marketable-limit

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -93,7 +93,8 @@ delay_before_close = 1800
 exchange = "SMART"
 
 # Range of time to delay, in seconds, before resubmitting an order with updated
-# midpoint price if `symbol.<symbol>.adjust_price_after_delay = true`.
+# pricing. This is used by the legacy `adjust_price_after_delay` behavior and by
+# configured per-symbol execution state machines.
 price_update_delay = [30, 60]
 
 # Set a minimum credit order price, to avoid orders where the credit (or debit)
@@ -516,6 +517,27 @@ daily_stddev_window = "30 D"
   # manually) without actually trading them.
   #
   # no_trading = true
+
+  # Optional per-symbol execution policy. When this table is absent, ThetaGang's
+  # existing behavior is unchanged: orders may receive the legacy one-time price
+  # adjustment above, then unfinished DAY limit orders remain open at the broker.
+  #
+  # `buy_price` and `sell_price` select the quote used for initial submission and
+  # subsequent repricing. Valid values are "bid", "ask", and "mid". For a more
+  # aggressive policy, use the ask for buys and the bid for sells.
+  #
+  # `fill_timeout` enables bounded supervision. At the timeout, `on_timeout` may
+  # be "leave_open", "cancel", "marketable_limit", or "market". Marketable-limit
+  # replacements use the current ask for buys and bid for sells. A raw market
+  # fallback is opt-in and is not supported for combo orders. Any replacement that
+  # remains incomplete after `final_wait` seconds is canceled.
+  #
+  # [portfolio.symbols.SPY.execution]
+  # buy_price = "ask"
+  # sell_price = "bid"
+  # fill_timeout = 300
+  # on_timeout = "marketable_limit"
+  # final_wait = 30
 
   [portfolio.symbols.QQQ]
   weight = 0.3

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -622,6 +622,26 @@ class TargetConfig(BaseModel, DisplayMixin):
 
 
 class SymbolConfig(BaseModel):
+    class Execution(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        buy_price: Literal["bid", "ask", "mid"] | None = None
+        sell_price: Literal["bid", "ask", "mid"] | None = None
+        fill_timeout: int | None = Field(default=None, gt=0)
+        on_timeout: Literal["leave_open", "cancel", "marketable_limit", "market"] = (
+            "leave_open"
+        )
+        final_wait: int = Field(default=30, ge=1)
+
+        @model_validator(mode="after")
+        def validate_timeout_action(self) -> Self:
+            if self.fill_timeout is None and self.on_timeout != "leave_open":
+                raise ValueError(
+                    "execution.fill_timeout is required when on_timeout is not "
+                    "leave_open"
+                )
+            return self
+
     class WriteWhen(BaseModel):
         green: bool | None = None
         red: bool | None = None
@@ -682,6 +702,7 @@ class SymbolConfig(BaseModel):
     puts: Optional["SymbolConfig.Puts"] = None
     volatility_weight: Optional["SymbolConfig.VolatilityWeight"] = None
     absolute_trend: Optional["SymbolConfig.AbsoluteTrend"] = None
+    execution: Optional["SymbolConfig.Execution"] = None
     adjust_price_after_delay: bool = Field(default=False)
     no_trading: bool | None = None
     buy_only_rebalancing: bool | None = None

--- a/thetagang/ibkr.py
+++ b/thetagang/ibkr.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 from collections.abc import Awaitable, Callable, Coroutine
 from enum import Enum
 from typing import Any, cast
@@ -35,6 +36,8 @@ MAX_CONCURRENT_MARKET_DATA_STREAMS = 50
 class TickerField(Enum):
     MIDPOINT = "midpoint"
     MARKET_PRICE = "market_price"
+    BID = "bid"
+    ASK = "ask"
     GREEKS = "greeks"
     OPEN_INTEREST = "open_interest"
 
@@ -307,6 +310,33 @@ class IBKR:
             self.api_response_wait_time,
         )
 
+    @staticmethod
+    def __valid_execution_quote__(ticker: Ticker, price: Any) -> bool:
+        try:
+            value = float(price)
+        except (TypeError, ValueError):
+            return False
+        if not math.isfinite(value):
+            return False
+        contract = getattr(ticker, "contract", None)
+        if getattr(contract, "secType", None) == "BAG":
+            return not math.isclose(value, 0.0, abs_tol=1e-12)
+        return value > 0.0
+
+    async def __wait_for_bid__(self, ticker: Ticker) -> bool:
+        return await self.__ticker_wait_for_condition__(
+            ticker,
+            lambda t: self.__valid_execution_quote__(t, t.bid),
+            self.api_response_wait_time,
+        )
+
+    async def __wait_for_ask__(self, ticker: Ticker) -> bool:
+        return await self.__ticker_wait_for_condition__(
+            ticker,
+            lambda t: self.__valid_execution_quote__(t, t.ask),
+            self.api_response_wait_time,
+        )
+
     async def __wait_for_greeks__(self, ticker: Ticker) -> bool:
         return await self.__ticker_wait_for_condition__(
             ticker,
@@ -535,6 +565,10 @@ class IBKR:
             return self.__wait_for_midpoint_price__
         if ticker_field == TickerField.MARKET_PRICE:
             return self.__wait_for_market_price__
+        if ticker_field == TickerField.BID:
+            return self.__wait_for_bid__
+        if ticker_field == TickerField.ASK:
+            return self.__wait_for_ask__
         if ticker_field == TickerField.GREEKS:
             return self.__wait_for_greeks__
         if ticker_field == TickerField.OPEN_INTEREST:

--- a/thetagang/ibkr.py
+++ b/thetagang/ibkr.py
@@ -498,7 +498,7 @@ class IBKR:
             )
 
     async def wait_for_orders_complete(
-        self, trades: list[Trade], timetout: int = 60
+        self, trades: list[Trade], timetout: float = 60
     ) -> list[Trade]:
         tasks: list[Coroutine[Any, Any, bool]] = [
             self.__trade_wait_for_condition__(

--- a/thetagang/order_execution.py
+++ b/thetagang/order_execution.py
@@ -119,16 +119,45 @@ class OrderExecutionManager:
         *,
         include_minimum_credit: bool = False,
     ) -> float:
-        if str(getattr(order, "action", "")).upper() != "SELL":
-            return price
-
-        minimum = getattr(order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR, None)
-        if include_minimum_credit and getattr(contract, "secType", None) == "OPT":
-            minimum_credit = self.config.runtime.orders.minimum_credit
-            minimum = max(float(minimum or 0.0), float(minimum_credit))
+        action = str(getattr(order, "action", "")).upper()
+        sec_type = getattr(contract, "secType", None)
+        minimum = (
+            getattr(order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR, None)
+            if action == "SELL"
+            else None
+        )
+        if include_minimum_credit and sec_type in {"OPT", "BAG"}:
+            minimum_credit = float(self.config.runtime.orders.minimum_credit)
+            if action == "SELL" and price > 0.0:
+                minimum = max(float(minimum or 0.0), minimum_credit)
+            elif action == "BUY" and price < 0.0:
+                return min(price, -minimum_credit)
         if isinstance(minimum, (int, float)) and math.isfinite(float(minimum)):
             return max(price, float(minimum))
         return price
+
+    def _configured_limit_price(
+        self,
+        contract: Contract,
+        order: Order,
+        quoted_price: float,
+    ) -> float:
+        current_price = float(order.lmtPrice or 0.0)
+        if (
+            getattr(contract, "secType", None) == "BAG"
+            and not math.isclose(current_price, 0.0, abs_tol=1e-12)
+            and np.sign(current_price) != np.sign(quoted_price)
+        ):
+            raise RequiredFieldValidationError(
+                f"configured quote changes the order sign for {contract.localSymbol}"
+            )
+        constrained_price = self._apply_price_floor(
+            contract,
+            order,
+            quoted_price,
+            include_minimum_credit=True,
+        )
+        return self._round_limit_price(contract, constrained_price)
 
     def _record_event(self, event_type: str, trade: Any, **details: Any) -> None:
         if self.data_store is None:
@@ -172,14 +201,9 @@ class OrderExecutionManager:
                     raise RequiredFieldValidationError(
                         f"{strategy} quote is invalid for {contract.localSymbol}"
                     )
-                configured_price = self._apply_price_floor(
+                configured_price = self._configured_limit_price(
                     contract,
                     order,
-                    configured_price,
-                    include_minimum_credit=True,
-                )
-                configured_price = self._round_limit_price(
-                    contract,
                     configured_price,
                 )
                 previous_price = float(order.lmtPrice or 0.0)
@@ -286,15 +310,19 @@ class OrderExecutionManager:
                     raise RequiredFieldValidationError(
                         f"{strategy} quote is invalid for {contract.localSymbol}"
                     )
-                updated_price = quoted_price
+                updated_price = self._configured_limit_price(
+                    contract,
+                    order,
+                    quoted_price,
+                )
 
-            updated_price = self._apply_price_floor(
-                contract,
-                order,
-                updated_price,
-                include_minimum_credit=strategy is not None,
-            )
-            updated_price = self._round_limit_price(contract, updated_price)
+            if strategy is None:
+                updated_price = self._apply_price_floor(
+                    contract,
+                    order,
+                    updated_price,
+                )
+                updated_price = self._round_limit_price(contract, updated_price)
 
             if would_increase_spread(order, updated_price):
                 log.warning(
@@ -416,9 +444,14 @@ class OrderExecutionManager:
         except (AttributeError, KeyError):
             legacy_reprice_enabled = False
 
-        wait_budget = policy.fill_timeout
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + policy.fill_timeout
+        wait_budget = float(policy.fill_timeout)
         legacy_repriced = False
         while wait_budget > 0:
+            wait_budget = min(wait_budget, max(0.0, deadline - loop.time()))
+            if wait_budget <= 0:
+                break
             current_trade = trades.records()[idx]
             if self.trade_fully_filled(current_trade):
                 return
@@ -459,15 +492,17 @@ class OrderExecutionManager:
                 return
 
             if should_reprice:
+                wait_budget = min(wait_budget, max(0.0, deadline - loop.time()))
                 if wait_budget <= 0:
                     break
                 await self.reprice_trade(
                     trades,
                     idx,
                     current_trade,
-                    timeout=max(1, wait_budget),
+                    timeout=wait_budget,
                     strategy=strategy,
                 )
+                wait_budget = min(wait_budget, max(0.0, deadline - loop.time()))
                 if strategy is None:
                     legacy_repriced = True
 
@@ -567,13 +602,11 @@ class OrderExecutionManager:
                 raise RequiredFieldValidationError(
                     f"{strategy} quote is invalid for {trade.contract.localSymbol}"
                 )
-            price = self._apply_price_floor(
+            price = self._configured_limit_price(
                 trade.contract,
                 trade.order,
                 price,
-                include_minimum_credit=True,
             )
-            price = self._round_limit_price(trade.contract, price)
         except (
             TimeoutError,
             RequestError,

--- a/thetagang/order_execution.py
+++ b/thetagang/order_execution.py
@@ -1,0 +1,678 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import math
+import random
+from typing import Any, Literal, TypeAlias, cast
+
+import numpy as np
+from ib_async import Contract, LimitOrder, MarketOrder, Order, Ticker
+from ib_async.wrapper import RequestError
+
+from thetagang import log
+from thetagang.config import Config
+from thetagang.config_models import SymbolConfig
+from thetagang.db import DataStore
+from thetagang.fmt import dfmt
+from thetagang.ibkr import IBKR, RequiredFieldValidationError, TickerField
+from thetagang.strategies.tail_hedge_state import (
+    TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
+    is_tail_order_ref,
+)
+from thetagang.trades import Trades
+from thetagang.util import would_increase_spread
+
+PriceStrategy: TypeAlias = Literal["bid", "ask", "mid"]
+
+
+class OrderExecutionManager:
+    """Apply opt-in pricing and supervise configured broker orders."""
+
+    def __init__(
+        self,
+        config: Config,
+        ibkr: IBKR,
+        data_store: DataStore | None = None,
+    ) -> None:
+        self.config = config
+        self.ibkr = ibkr
+        self.data_store = data_store
+
+    def _policy_for_symbol(self, symbol: str) -> SymbolConfig.Execution | None:
+        try:
+            symbol_config = self.config.portfolio.symbols.get(symbol)
+        except AttributeError:
+            return None
+        policy = getattr(symbol_config, "execution", None)
+        if not isinstance(policy, SymbolConfig.Execution):
+            return None
+        if (
+            policy.buy_price is None
+            and policy.sell_price is None
+            and policy.fill_timeout is None
+        ):
+            return None
+        return policy
+
+    @staticmethod
+    def _strategy_for_order(
+        policy: SymbolConfig.Execution,
+        order: Order,
+    ) -> PriceStrategy | None:
+        action = str(getattr(order, "action", "")).upper()
+        if action == "BUY":
+            return policy.buy_price
+        if action == "SELL":
+            return policy.sell_price
+        return None
+
+    @staticmethod
+    def _quote_is_valid(ticker: Ticker, price: Any) -> bool:
+        try:
+            value = float(price)
+        except (TypeError, ValueError):
+            return False
+        if not math.isfinite(value):
+            return False
+        contract = getattr(ticker, "contract", None)
+        if getattr(contract, "secType", None) == "BAG":
+            return not math.isclose(value, 0.0, abs_tol=1e-12)
+        return value > 0.0
+
+    @classmethod
+    def _price_from_ticker(
+        cls,
+        ticker: Ticker,
+        strategy: PriceStrategy,
+    ) -> float | None:
+        if strategy == "bid":
+            price = ticker.bid
+        elif strategy == "ask":
+            price = ticker.ask
+        elif strategy == "mid":
+            price = ticker.midpoint()
+        else:
+            return None
+        return float(price) if cls._quote_is_valid(ticker, price) else None
+
+    @staticmethod
+    def _ticker_field(strategy: PriceStrategy) -> TickerField:
+        if strategy == "bid":
+            return TickerField.BID
+        if strategy == "ask":
+            return TickerField.ASK
+        return TickerField.MIDPOINT
+
+    def _round_limit_price(self, contract: Contract, price: float) -> float:
+        if contract.symbol == "VIX":
+            if price >= 3.0:
+                return round(price * 20) / 20
+            return round(price * 100) / 100
+        return round(price, 2)
+
+    def _apply_price_floor(
+        self,
+        contract: Contract,
+        order: Order,
+        price: float,
+        *,
+        include_minimum_credit: bool = False,
+    ) -> float:
+        if str(getattr(order, "action", "")).upper() != "SELL":
+            return price
+
+        minimum = getattr(order, TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR, None)
+        if include_minimum_credit and getattr(contract, "secType", None) == "OPT":
+            minimum_credit = self.config.runtime.orders.minimum_credit
+            minimum = max(float(minimum or 0.0), float(minimum_credit))
+        if isinstance(minimum, (int, float)) and math.isfinite(float(minimum)):
+            return max(price, float(minimum))
+        return price
+
+    def _record_event(self, event_type: str, trade: Any, **details: Any) -> None:
+        if self.data_store is None:
+            return
+        self.data_store.record_event(
+            event_type,
+            {
+                "symbol": getattr(getattr(trade, "contract", None), "symbol", ""),
+                "order_id": getattr(getattr(trade, "order", None), "orderId", None),
+                "action": getattr(getattr(trade, "order", None), "action", None),
+                **details,
+            },
+        )
+
+    async def prepare_orders(
+        self,
+        records: list[tuple[Contract, LimitOrder, int | None]],
+    ) -> None:
+        """Apply configured initial prices without changing unconfigured orders."""
+
+        async def prepare(
+            record: tuple[Contract, LimitOrder, int | None],
+        ) -> None:
+            contract, order, _intent_id = record
+            if is_tail_order_ref(getattr(order, "orderRef", None)):
+                return
+            policy = self._policy_for_symbol(contract.symbol)
+            if policy is None:
+                return
+            strategy = self._strategy_for_order(policy, order)
+            if strategy is None:
+                return
+            try:
+                ticker = await self.ibkr.get_ticker_for_contract(
+                    contract,
+                    required_fields=[self._ticker_field(strategy)],
+                    optional_fields=[],
+                )
+                configured_price = self._price_from_ticker(ticker, strategy)
+                if configured_price is None:
+                    raise RequiredFieldValidationError(
+                        f"{strategy} quote is invalid for {contract.localSymbol}"
+                    )
+                configured_price = self._apply_price_floor(
+                    contract,
+                    order,
+                    configured_price,
+                    include_minimum_credit=True,
+                )
+                configured_price = self._round_limit_price(
+                    contract,
+                    configured_price,
+                )
+                previous_price = float(order.lmtPrice or 0.0)
+                order.lmtPrice = configured_price
+                log.info(
+                    f"{contract.symbol}: Applying configured {strategy} price "
+                    f"to {order.action} order, old lmtPrice={dfmt(previous_price)} "
+                    f"new lmtPrice={dfmt(configured_price)}"
+                )
+            except (
+                TimeoutError,
+                RequestError,
+                RuntimeError,
+                ValueError,
+                RequiredFieldValidationError,
+            ) as exc:
+                log.warning(
+                    f"{contract.symbol}: Couldn't apply configured {strategy} "
+                    f"price; preserving lmtPrice={dfmt(float(order.lmtPrice or 0.0))}"
+                )
+                if self.data_store:
+                    self.data_store.record_event(
+                        "order_initial_price_strategy_skipped",
+                        {
+                            "symbol": contract.symbol,
+                            "secType": contract.secType,
+                            "strategy": strategy,
+                            "reason": type(exc).__name__,
+                        },
+                    )
+
+        await asyncio.gather(*(prepare(record) for record in records))
+
+    @staticmethod
+    def trade_fully_filled(trade: Any) -> bool:
+        status = str(
+            getattr(getattr(trade, "orderStatus", None), "status", "")
+        ).casefold()
+        try:
+            filled = float(getattr(trade.orderStatus, "filled", 0) or 0)
+            remaining = float(getattr(trade.orderStatus, "remaining", 0) or 0)
+            requested = float(getattr(trade.order, "totalQuantity", 0) or 0)
+        except (AttributeError, TypeError, ValueError):
+            return False
+        if (
+            status != "filled"
+            or not math.isfinite(requested)
+            or requested <= 0
+            or not math.isfinite(filled)
+            or filled < requested
+        ):
+            return False
+        return not math.isfinite(remaining) or math.isclose(
+            remaining,
+            0.0,
+            abs_tol=1e-9,
+        )
+
+    async def reprice_trade(
+        self,
+        trades: Trades,
+        idx: int,
+        trade: Any,
+        *,
+        timeout: float | None = None,
+        strategy: PriceStrategy | None = None,
+    ) -> bool:
+        response_timeout = self.config.runtime.ib_async.api_response_wait_time
+        if timeout is not None:
+            response_timeout = min(response_timeout, timeout)
+        try:
+            required_field = (
+                self._ticker_field(strategy)
+                if strategy is not None
+                else TickerField.MIDPOINT
+            )
+            ticker = await asyncio.wait_for(
+                self.ibkr.get_ticker_for_contract(
+                    trade.contract,
+                    required_fields=[required_field],
+                    optional_fields=(
+                        [TickerField.MARKET_PRICE] if strategy is None else []
+                    ),
+                ),
+                timeout=response_timeout,
+            )
+
+            contract, order = trade.contract, trade.order
+            old_price = float(order.lmtPrice or 0.0)
+            if strategy is None:
+                updated_price = np.sign(old_price) * max(
+                    [
+                        (
+                            self.config.runtime.orders.minimum_credit
+                            if order.action == "BUY" and old_price <= 0.0
+                            else 0.0
+                        ),
+                        math.fabs(round((old_price + ticker.midpoint()) / 2.0, 2)),
+                    ]
+                )
+            else:
+                quoted_price = self._price_from_ticker(ticker, strategy)
+                if quoted_price is None:
+                    raise RequiredFieldValidationError(
+                        f"{strategy} quote is invalid for {contract.localSymbol}"
+                    )
+                updated_price = quoted_price
+
+            updated_price = self._apply_price_floor(
+                contract,
+                order,
+                updated_price,
+                include_minimum_credit=strategy is not None,
+            )
+            updated_price = self._round_limit_price(contract, updated_price)
+
+            if would_increase_spread(order, updated_price):
+                log.warning(
+                    f"Skipping order for {contract.symbol}"
+                    f" with old lmtPrice={dfmt(old_price)} "
+                    f"updated lmtPrice={dfmt(updated_price)}, because updated "
+                    "price would increase spread"
+                )
+                return False
+
+            if old_price != updated_price and np.sign(old_price) == np.sign(
+                updated_price
+            ):
+                log.info(
+                    f"{contract.symbol}: Resubmitting {order.action} "
+                    f"{contract.secType} order with old "
+                    f"lmtPrice={dfmt(old_price)} "
+                    f"updated lmtPrice={dfmt(updated_price)}"
+                )
+                updated_order = copy.deepcopy(cast(LimitOrder, order))
+                updated_order.lmtPrice = float(updated_price)
+                trades.submit_order(contract, updated_order, idx)
+                log.info(f"{contract.symbol}: Order updated, order={updated_order}")
+        except (
+            TimeoutError,
+            RequestError,
+            RuntimeError,
+            ValueError,
+            RequiredFieldValidationError,
+        ) as exc:
+            log.warning(
+                f"Couldn't generate execution price for {trade.contract}, "
+                "skipping repricing"
+            )
+            self._record_event(
+                "order_price_adjustment_skipped",
+                trade,
+                secType=getattr(trade.contract, "secType", ""),
+                strategy=strategy or "legacy_midpoint",
+                reason=type(exc).__name__,
+            )
+        return True
+
+    def _legacy_adjustment_candidates(
+        self,
+        trades: Trades,
+    ) -> list[tuple[int, Any]]:
+        candidates: list[tuple[int, Any]] = []
+        for idx, trade in enumerate(trades.records()):
+            if not trade or is_tail_order_ref(getattr(trade.order, "orderRef", None)):
+                continue
+            symbol = trade.contract.symbol
+            try:
+                symbol_config = self.config.portfolio.symbols.get(symbol)
+            except AttributeError:
+                continue
+            if (
+                symbol_config is not None
+                and self._policy_for_symbol(symbol) is None
+                and symbol_config.adjust_price_after_delay
+                and not trade.isDone()
+            ):
+                candidates.append((idx, trade))
+        return candidates
+
+    async def _adjust_legacy_prices(self, trades: Trades) -> None:
+        try:
+            adjustment_enabled = any(
+                symbol_config.adjust_price_after_delay
+                and self._policy_for_symbol(symbol) is None
+                for symbol, symbol_config in self.config.portfolio.symbols.items()
+            )
+        except AttributeError:
+            adjustment_enabled = False
+        if not adjustment_enabled or trades.is_empty():
+            log.warning("Skipping order price adjustments...")
+            return
+
+        delay = random.randrange(
+            self.config.runtime.orders.price_update_delay[0],
+            self.config.runtime.orders.price_update_delay[1],
+        )
+        await self.ibkr.wait_for_orders_complete(trades.records(), delay)
+
+        for idx, current_trade in self._legacy_adjustment_candidates(trades):
+            if not await self.reprice_trade(trades, idx, current_trade):
+                return
+
+    async def execute(self, trades: Trades) -> None:
+        """Run legacy adjustment and opt-in per-symbol execution state machines."""
+
+        supervised: list[tuple[int, Any, SymbolConfig.Execution]] = []
+        for idx, trade in enumerate(trades.records()):
+            if not trade or is_tail_order_ref(getattr(trade.order, "orderRef", None)):
+                continue
+            policy = self._policy_for_symbol(trade.contract.symbol)
+            if policy is not None and policy.fill_timeout is not None:
+                supervised.append((idx, trade, policy))
+
+        tasks: list[Any] = [self._adjust_legacy_prices(trades)]
+        tasks.extend(
+            self._supervise_trade(trades, idx, trade, policy)
+            for idx, trade, policy in supervised
+        )
+        await asyncio.gather(*tasks)
+
+    async def _supervise_trade(
+        self,
+        trades: Trades,
+        idx: int,
+        trade: Any,
+        policy: SymbolConfig.Execution,
+    ) -> None:
+        assert policy.fill_timeout is not None
+        strategy = self._strategy_for_order(policy, trade.order)
+        try:
+            symbol_config = self.config.portfolio.symbols[trade.contract.symbol]
+            legacy_reprice_enabled = symbol_config.adjust_price_after_delay
+        except (AttributeError, KeyError):
+            legacy_reprice_enabled = False
+
+        wait_budget = policy.fill_timeout
+        legacy_repriced = False
+        while wait_budget > 0:
+            current_trade = trades.records()[idx]
+            if self.trade_fully_filled(current_trade):
+                return
+            if current_trade.isDone():
+                log.warning(
+                    f"{current_trade.contract.symbol}: Configured order reached "
+                    f"terminal status={current_trade.orderStatus.status} without a "
+                    "complete fill."
+                )
+                return
+
+            should_reprice = strategy is not None or (
+                legacy_reprice_enabled and not legacy_repriced
+            )
+            if should_reprice:
+                delay = max(
+                    1,
+                    random.randrange(
+                        self.config.runtime.orders.price_update_delay[0],
+                        self.config.runtime.orders.price_update_delay[1],
+                    ),
+                )
+                wait_time = min(delay, wait_budget)
+            else:
+                wait_time = wait_budget
+
+            await self.ibkr.wait_for_orders_complete([current_trade], wait_time)
+            wait_budget -= wait_time
+            current_trade = trades.records()[idx]
+            if self.trade_fully_filled(current_trade):
+                return
+            if current_trade.isDone():
+                log.warning(
+                    f"{current_trade.contract.symbol}: Configured order reached "
+                    f"terminal status={current_trade.orderStatus.status} without a "
+                    "complete fill."
+                )
+                return
+
+            if should_reprice:
+                if wait_budget <= 0:
+                    break
+                await self.reprice_trade(
+                    trades,
+                    idx,
+                    current_trade,
+                    timeout=max(1, wait_budget),
+                    strategy=strategy,
+                )
+                if strategy is None:
+                    legacy_repriced = True
+
+        await self._handle_timeout(trades, idx, policy)
+
+    @staticmethod
+    def _cancellation_confirmed(trade: Any) -> bool:
+        status = str(
+            getattr(getattr(trade, "orderStatus", None), "status", "")
+        ).casefold()
+        return status in {"cancelled", "canceled", "apicancelled", "apicanceled"}
+
+    async def _cancel_and_get_remaining(self, trade: Any) -> float | None:
+        if self.trade_fully_filled(trade):
+            return 0.0
+        if not trade.isDone():
+            self.ibkr.cancel_order(trade.order)
+            incomplete = await self.ibkr.wait_for_orders_complete(
+                [trade],
+                max(
+                    1,
+                    min(60, self.config.runtime.ib_async.api_response_wait_time),
+                ),
+            )
+            if incomplete:
+                log.error(
+                    f"{trade.contract.symbol}: Cancellation was not confirmed; "
+                    "not submitting a replacement order."
+                )
+                return None
+
+        if self.trade_fully_filled(trade):
+            return 0.0
+        if not self._cancellation_confirmed(trade):
+            log.error(
+                f"{trade.contract.symbol}: Order ended with "
+                f"status={getattr(trade.orderStatus, 'status', 'UNKNOWN')}; "
+                "not submitting a replacement order."
+            )
+            return None
+
+        try:
+            requested = float(trade.order.totalQuantity)
+            filled = float(trade.orderStatus.filled or 0.0)
+        except (AttributeError, TypeError, ValueError):
+            return None
+        if (
+            not math.isfinite(requested)
+            or requested <= 0
+            or not math.isfinite(filled)
+            or filled < 0
+            or filled > requested
+        ):
+            log.error(
+                f"{trade.contract.symbol}: Invalid fill quantities after "
+                "cancellation; not submitting a replacement order."
+            )
+            return None
+        return max(0.0, requested - filled)
+
+    @staticmethod
+    def _replacement_order_kwargs(order: Order, *, market: bool) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "account": getattr(order, "account", ""),
+            "tif": "DAY" if market else (getattr(order, "tif", "DAY") or "DAY"),
+            "transmit": getattr(order, "transmit", True),
+        }
+        order_ref = getattr(order, "orderRef", None)
+        if order_ref:
+            kwargs["orderRef"] = order_ref
+        if getattr(order, "outsideRth", False):
+            kwargs["outsideRth"] = True
+        return kwargs
+
+    @staticmethod
+    def _normalized_quantity(quantity: float) -> int | float:
+        rounded = round(quantity)
+        if math.isclose(quantity, rounded, abs_tol=1e-9):
+            return int(rounded)
+        return quantity
+
+    async def _marketable_limit_order(
+        self,
+        trade: Any,
+        quantity: float,
+    ) -> LimitOrder | None:
+        action = str(trade.order.action).upper()
+        strategy = "ask" if action == "BUY" else "bid"
+        try:
+            ticker = await self.ibkr.get_ticker_for_contract(
+                trade.contract,
+                required_fields=[self._ticker_field(strategy)],
+                optional_fields=[],
+            )
+            price = self._price_from_ticker(ticker, strategy)
+            if price is None:
+                raise RequiredFieldValidationError(
+                    f"{strategy} quote is invalid for {trade.contract.localSymbol}"
+                )
+            price = self._apply_price_floor(
+                trade.contract,
+                trade.order,
+                price,
+                include_minimum_credit=True,
+            )
+            price = self._round_limit_price(trade.contract, price)
+        except (
+            TimeoutError,
+            RequestError,
+            RuntimeError,
+            ValueError,
+            RequiredFieldValidationError,
+        ) as exc:
+            log.error(
+                f"{trade.contract.symbol}: Couldn't create marketable limit "
+                f"replacement ({type(exc).__name__})."
+            )
+            return None
+        return LimitOrder(
+            action,
+            self._normalized_quantity(quantity),
+            price,
+            **self._replacement_order_kwargs(trade.order, market=False),
+        )
+
+    async def _handle_timeout(
+        self,
+        trades: Trades,
+        idx: int,
+        policy: SymbolConfig.Execution,
+    ) -> None:
+        trade = trades.records()[idx]
+        if self.trade_fully_filled(trade):
+            return
+        if policy.on_timeout == "leave_open":
+            log.info(
+                f"{trade.contract.symbol}: Fill timeout expired; leaving configured "
+                "limit order open at the broker."
+            )
+            return
+
+        original_order = trade.order
+        remaining = await self._cancel_and_get_remaining(trade)
+        if remaining is None or math.isclose(remaining, 0.0, abs_tol=1e-9):
+            return
+        self._record_event(
+            "order_execution_timeout",
+            trade,
+            timeout_action=policy.on_timeout,
+            remaining=remaining,
+        )
+        if policy.on_timeout == "cancel":
+            log.warning(
+                f"{trade.contract.symbol}: Fill timeout expired; canceled "
+                f"remaining quantity={remaining:g}."
+            )
+            return
+
+        if policy.on_timeout == "market":
+            if getattr(trade.contract, "secType", None) == "BAG":
+                log.error(
+                    f"{trade.contract.symbol}: Market fallback is not supported "
+                    "for combo orders; the unfilled remainder was canceled."
+                )
+                return
+            replacement: Order | None = MarketOrder(
+                str(original_order.action).upper(),
+                self._normalized_quantity(remaining),
+                **self._replacement_order_kwargs(original_order, market=True),
+            )
+        else:
+            replacement = await self._marketable_limit_order(trade, remaining)
+
+        if replacement is None:
+            return
+        if not trades.submit_order(trade.contract, replacement, idx):
+            log.error(
+                f"{trade.contract.symbol}: Failed to submit timeout replacement order."
+            )
+            return
+
+        replacement_trade = trades.records()[idx]
+        incomplete = await self.ibkr.wait_for_orders_complete(
+            [replacement_trade],
+            policy.final_wait,
+        )
+        replacement_trade = trades.records()[idx]
+        if not incomplete and self.trade_fully_filled(replacement_trade):
+            log.notice(
+                f"{replacement_trade.contract.symbol}: Timeout replacement order "
+                "filled completely."
+            )
+            return
+
+        remaining_after_replacement = await self._cancel_and_get_remaining(
+            replacement_trade
+        )
+        if remaining_after_replacement is None:
+            log.error(
+                f"{replacement_trade.contract.symbol}: Timeout replacement did "
+                "not fill completely and cancellation could not be confirmed."
+            )
+        else:
+            log.error(
+                f"{replacement_trade.contract.symbol}: Timeout replacement did "
+                "not fill completely; canceled remaining "
+                f"quantity={remaining_after_replacement:g}."
+            )

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -40,7 +40,8 @@ from thetagang.config import (
 )
 from thetagang.db import DataStore
 from thetagang.fmt import dfmt, ffmt, ifmt, pfmt
-from thetagang.ibkr import IBKR, RequiredFieldValidationError, TickerField
+from thetagang.ibkr import IBKR
+from thetagang.order_execution import OrderExecutionManager
 from thetagang.orders import Orders
 from thetagang.strategies import (
     EquityStrategyDeps,
@@ -68,7 +69,6 @@ from thetagang.strategies.tail_hedge_state import (
     TAIL_HEDGE_CLOSE_ORDER_REF,
     TAIL_HEDGE_ENTRY_ORDER_REF,
     TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX,
-    TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
     TailHedgeStateStore,
     is_tail_order_ref,
     is_tail_reduction_ref,
@@ -84,7 +84,6 @@ from thetagang.util import (
     portfolio_positions_to_dict,
     position_pnl,
     working_stock_order_symbols,
-    would_increase_spread,
 )
 
 from .options import option_dte
@@ -135,6 +134,11 @@ class PortfolioManager:
         self.has_excess_puts: set[str] = set()
         self.orders: Orders = Orders()
         self.trades: Trades = Trades(self.ibkr, data_store=data_store)
+        self.execution_manager = OrderExecutionManager(
+            config=self.config,
+            ibkr=self.ibkr,
+            data_store=self.data_store,
+        )
         self.target_quantities: dict[str, int] = {}
         self.qualified_contracts: dict[int, Contract] = {}
         self.dry_run = dry_run
@@ -880,6 +884,8 @@ class PortfolioManager:
                 if stage_id in pre_management_trade_stage_ids:
                     positions_might_be_stale = True
 
+            await self.execution_manager.prepare_orders(self.orders.records())
+
             if self.dry_run:
                 log.warning("Dry run enabled, no trades will be executed.")
 
@@ -1087,28 +1093,7 @@ class PortfolioManager:
 
     @staticmethod
     def _trade_fully_filled(trade: Any) -> bool:
-        status = str(
-            getattr(getattr(trade, "orderStatus", None), "status", "")
-        ).casefold()
-        try:
-            filled = float(getattr(trade.orderStatus, "filled", 0) or 0)
-            remaining = float(getattr(trade.orderStatus, "remaining", 0) or 0)
-            requested = float(getattr(trade.order, "totalQuantity", 0) or 0)
-        except (AttributeError, TypeError, ValueError):
-            return False
-        if (
-            status != "filled"
-            or not math.isfinite(requested)
-            or requested <= 0
-            or not math.isfinite(filled)
-            or filled < requested
-        ):
-            return False
-        return not math.isfinite(remaining) or math.isclose(
-            remaining,
-            0.0,
-            abs_tol=1e-9,
-        )
+        return OrderExecutionManager.trade_fully_filled(trade)
 
     async def _cancel_incomplete_trades(self, trades: list[Any]) -> None:
         canceled_trades = []
@@ -1395,123 +1380,15 @@ class PortfolioManager:
         *,
         timeout: float | None = None,
     ) -> bool:
-        response_timeout = self.config.runtime.ib_async.api_response_wait_time
-        if timeout is not None:
-            response_timeout = min(response_timeout, timeout)
-        try:
-            ticker = await asyncio.wait_for(
-                self.ibkr.get_ticker_for_contract(
-                    trade.contract,
-                    required_fields=[TickerField.MIDPOINT],
-                    optional_fields=[TickerField.MARKET_PRICE],
-                ),
-                timeout=response_timeout,
-            )
-
-            contract, order = trade.contract, trade.order
-            updated_price = np.sign(float(order.lmtPrice or 0)) * max(
-                [
-                    (
-                        self.config.runtime.orders.minimum_credit
-                        if order.action == "BUY" and float(order.lmtPrice or 0) <= 0.0
-                        else 0.0
-                    ),
-                    math.fabs(
-                        round(
-                            (float(order.lmtPrice or 0) + ticker.midpoint()) / 2.0,
-                            2,
-                        )
-                    ),
-                ]
-            )
-            minimum_limit_price = getattr(
-                order,
-                TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
-                None,
-            )
-            if (
-                order.action == "SELL"
-                and isinstance(minimum_limit_price, (int, float))
-                and math.isfinite(float(minimum_limit_price))
-            ):
-                updated_price = max(updated_price, float(minimum_limit_price))
-
-            if trade.contract.symbol == "VIX":
-                updated_price = self.order_ops.round_vix_price(updated_price)
-
-            if would_increase_spread(order, updated_price):
-                log.warning(
-                    f"Skipping order for {contract.symbol}"
-                    f" with old lmtPrice={dfmt(float(order.lmtPrice or 0))} "
-                    f"updated lmtPrice={dfmt(updated_price)}, because updated "
-                    "price would increase spread"
-                )
-                return False
-
-            if float(order.lmtPrice or 0) != updated_price and np.sign(
-                float(order.lmtPrice or 0)
-            ) == np.sign(updated_price):
-                log.info(
-                    f"{contract.symbol}: Resubmitting {order.action} "
-                    f"{contract.secType} order with old "
-                    f"lmtPrice={dfmt(float(order.lmtPrice or 0))} "
-                    f"updated lmtPrice={dfmt(updated_price)}"
-                )
-                updated_order = copy.deepcopy(cast(LimitOrder, order))
-                updated_order.lmtPrice = float(updated_price)
-                self.trades.submit_order(contract, updated_order, idx)
-                log.info(f"{contract.symbol}: Order updated, order={updated_order}")
-        except (TimeoutError, RuntimeError, RequiredFieldValidationError) as exc:
-            log.warning(
-                f"Couldn't generate midpoint price for {trade.contract}, "
-                "skipping repricing"
-            )
-            if self.data_store:
-                self.data_store.record_event(
-                    "order_price_adjustment_skipped",
-                    {
-                        "symbol": getattr(trade.contract, "symbol", ""),
-                        "secType": getattr(trade.contract, "secType", ""),
-                        "reason": type(exc).__name__,
-                    },
-                )
-        return True
-
-    async def adjust_prices(self) -> None:
-        if (
-            all(
-                [  # noqa: C419
-                    not self.config.portfolio.symbols[symbol].adjust_price_after_delay
-                    for symbol in self.config.portfolio.symbols
-                ]
-            )
-            or self.trades.is_empty()
-        ):
-            log.warning("Skipping order price adjustments...")
-            return
-
-        delay = random.randrange(
-            self.config.runtime.orders.price_update_delay[0],
-            self.config.runtime.orders.price_update_delay[1],
+        return await self.execution_manager.reprice_trade(
+            self.trades,
+            idx,
+            trade,
+            timeout=timeout,
         )
 
-        await self.ibkr.wait_for_orders_complete(self.trades.records(), delay)
-
-        unfilled = [
-            (idx, trade)
-            for idx, trade in enumerate(self.trades.records())
-            if trade
-            and trade.contract.symbol in self.config.portfolio.symbols
-            and self.config.portfolio.symbols[
-                trade.contract.symbol
-            ].adjust_price_after_delay
-            and not is_tail_order_ref(getattr(trade.order, "orderRef", None))
-            and not trade.isDone()
-        ]
-
-        for idx, trade in unfilled:
-            if not await self._reprice_trade(idx, trade):
-                return
+    async def adjust_prices(self) -> None:
+        await self.execution_manager.execute(self.trades)
 
     async def get_write_threshold(
         self, ticker: Ticker, right: str

--- a/thetagang/trades.py
+++ b/thetagang/trades.py
@@ -1,4 +1,4 @@
-from ib_async import Contract, LimitOrder, Trade
+from ib_async import Contract, Order, Trade
 from rich import box
 from rich.pretty import Pretty
 from rich.table import Table
@@ -18,7 +18,7 @@ class Trades:
     def submit_order(
         self,
         contract: Contract,
-        order: LimitOrder,
+        order: Order,
         idx: int | None = None,
         intent_id: int | None = None,
     ) -> bool:


### PR DESCRIPTION
## Summary

Add opt-in, per-symbol order pricing and fill supervision while preserving ThetaGang's existing default execution behavior.

## User Impact

Operators can configure less-liquid symbols to start or reprice at the bid, ask, or midpoint and choose what happens when an order remains unfilled for a bounded period.

Symbols without an `execution` table are unchanged: ThetaGang performs any existing one-time price adjustment, then leaves unfinished DAY limit orders working at the broker when the run ends.

## Root Cause

Order handling previously stopped after submission and an optional one-time midpoint adjustment. It did not own a general fill lifecycle, so an order could remain open indefinitely as its limit became stale.

## Fix

- Add an `OrderExecutionManager` that owns initial pricing, repricing, timeout handling, cancellation, and replacement state.
- Add independent per-symbol `buy_price` and `sell_price` strategies for bid, ask, or midpoint pricing.
- Add configurable `fill_timeout`, `on_timeout`, and `final_wait` controls.
- Support leave-open, cancel, marketable-limit, and explicit market timeout actions.
- Confirm cancellation and replace only the verified unfilled quantity after partial fills.
- Refuse raw market replacements for combo orders and leave tail-hedge orders on their specialized execution path.
- Preserve minimum-credit safeguards and fall back to the existing computed limit when a configured quote is unavailable.
- Document the configuration and cover the state-machine safety cases with focused tests.

## Validation

- `uv run --with pytest-cov pytest --cov=thetagang --cov-report=term -q` — 554 passed, 81% total coverage
- `uv run pre-commit run --all-files` — all hooks passed
- `uv lock --check` — passed
- `git diff --check` — passed
