### PR TITLE
feat: add external decision hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ config:
 - [Long-put tail hedging](docs/tail-hedging.md)
 - [Portfolio accounting model](docs/accounting.md)
 - Regime-aware rebalancing gates
+- [External decision providers](docs/external-decisions.md)
 - Exchange-hours enforcement
 
 ThetaGang will try to acquire your desired allocation of each stock or ETF
@@ -239,6 +240,15 @@ stage; it does not enable wheel option writing or management. The historical
 `strategies.regime_rebalance.shares_only` setting is deprecated and ignored.
 Existing schema-v2 configurations that still include it load with a warning and
 should remove it.
+
+Regime target weights can be adjusted by a bounded external decision provider
+after volatility targeting. An external provider can also approve or veto an
+otherwise eligible tail-hedge harvest. ThetaGang supplies completed-session
+market history and the decision-specific portfolio context, then retains
+authority over allocation bounds, risk gates, contract selection, sizing, and
+order execution. See
+[External decision providers](docs/external-decisions.md) for the command
+protocol and configuration.
 
 ### Exchange Hours Management
 

--- a/docs/external-decisions.md
+++ b/docs/external-decisions.md
@@ -22,6 +22,10 @@ from stdout. Provider diagnostics should be written to stderr. Each invocation
 must be side-effect free and deterministic for the supplied completed-session
 data.
 
+Timeouts, cancellation, and oversized responses terminate the command and drain
+its pipes. On POSIX systems, cleanup also terminates its process group so child
+processes cannot keep those pipes open.
+
 Every request uses a generic versioned envelope:
 
 ```json
@@ -52,6 +56,9 @@ The `input` for `regime_target_weights` contains:
 - Aligned completed-session daily close history for the configured feature
   universe. All close arrays correspond exactly to the supplied `sessions`
   array. Data is fetched from IBKR as regular-trading-hours `TRADES` bars.
+
+Explicit primary-exchange overrides use separate persistent history entries,
+so missing API bars cannot be filled with another listing's cached prices.
 
 The listed TQQQ sizing features—returns, moving-average distance, trend,
 realized volatility, volatility acceleration, drawdown, close-based choppiness,
@@ -106,6 +113,8 @@ would violate that mode's required 100% total.
 The accepted decision is reused for any replanning within the same ThetaGang
 run. This prevents a tail-harvest replan from receiving a different model signal
 mid-execution.
+Its expiry is checked again before reuse; an expired decision follows the
+configured failure policy without invoking the provider again.
 
 ## Tail-harvest decision
 
@@ -128,7 +137,8 @@ current host-selected limit-price quote. The request `input` contains:
   plus optional feature-only reference symbols.
 
 The response must match the request identity, use the latest permitted supplied
-session, and return a JSON boolean:
+session, and return a JSON boolean. Expiry is rechecked after the final quote
+refresh; if it has elapsed, the configured failure policy applies:
 
 ```json
 {

--- a/docs/external-decisions.md
+++ b/docs/external-decisions.md
@@ -1,0 +1,222 @@
+# External decision providers
+
+ThetaGang can delegate narrowly scoped decisions to an external process while
+retaining control of validation, risk limits, and order execution. Providers are
+registered once under `runtime.external_decisions.providers`, so future decision
+points can reuse the same transport without sharing their decision-specific
+schemas.
+
+The supported decision types are `regime_target_weights` and
+`tail_hedge_harvest`. Target-weight decisions apply bounded per-symbol
+multipliers after volatility weighting and before the built-in absolute-trend
+modifier. Tail-harvest decisions approve or veto an opportunity that already
+passed ThetaGang's allocation gates. External processes cannot submit orders or
+bypass drift bands, cooldowns, ratio gates, cash-flow rails, ownership checks,
+or execution policies.
+
+## Command protocol
+
+A command provider is executed directly without a shell. ThetaGang writes one
+JSON request to stdin, waits for the process to exit, and reads one JSON response
+from stdout. Provider diagnostics should be written to stderr. Each invocation
+must be side-effect free and deterministic for the supplied completed-session
+data.
+
+Every request uses a generic versioned envelope:
+
+```json
+{
+  "schema_version": 1,
+  "request_id": "3b93bda0-f5f0-4bb7-a40e-34b04733b29a",
+  "decision_type": "regime_target_weights",
+  "generated_at": "2026-09-03T14:30:00Z",
+  "dry_run": true,
+  "input": {}
+}
+```
+
+All envelope datetimes must include a UTC offset. ThetaGang emits
+`generated_at` in UTC.
+
+The `input` for `regime_target_weights` contains:
+
+- Strategy settings that affect the eventual rebalance, including the capital
+  base, margin usage, drift bands, and cooldown.
+- Available broker account metrics, the resolved rebalance base, and excluded
+  option value. The broker account number is not sent.
+- Configured, current, and post-volatility weights for every managed regime
+  symbol, along with shares, prices, values, the volatility configuration and
+  calculation, the configured absolute-trend rule, and effective trading and
+  minimum-order constraints.
+- The host-enforced multiplier constraints for adjustable symbols.
+- Aligned completed-session daily close history for the configured feature
+  universe. All close arrays correspond exactly to the supplied `sessions`
+  array. Data is fetched from IBKR as regular-trading-hours `TRADES` bars.
+
+The listed TQQQ sizing features—returns, moving-average distance, trend,
+realized volatility, volatility acceleration, drawdown, close-based choppiness,
+efficiency, relative trends, correlations, and PCA concentration—can all be
+derived from this aligned close matrix. A future schema version can add other
+bar fields without changing the provider transport.
+
+The response uses the same generic envelope and a decision-specific `output`.
+`as_of_session` is optional in the reusable envelope, but required for
+`regime_target_weights`:
+
+```json
+{
+  "schema_version": 1,
+  "request_id": "3b93bda0-f5f0-4bb7-a40e-34b04733b29a",
+  "decision_type": "regime_target_weights",
+  "as_of_session": "2026-09-02",
+  "expires_at": "2026-09-04T14:30:00Z",
+  "producer": {
+    "name": "tqqq-xgboost-sizing",
+    "version": "2026-08-31"
+  },
+  "output": {
+    "adjustments": {
+      "TQQQ": {
+        "multiplier": 1.07,
+        "reason": "moderate-risk-on"
+      }
+    }
+  }
+}
+```
+
+The response must contain exactly the symbols configured for that decision
+point, and every multiplier must be a JSON number rather than a string or
+boolean. ThetaGang rejects stale, expired, future-dated, non-finite, unbounded,
+or otherwise malformed decisions. It then calculates the target itself:
+
+```text
+raw target = post-volatility target * multiplier
+effective target = raw target clamped to configured volatility bounds
+```
+
+By default an external decision may fill unused allocation up to 100%, but it
+cannot increase total exposure beyond the larger of 100% or the pre-decision
+total. The request reports this resolved ceiling as
+`total_weight_constraint.effective_max_total_weight`.
+`max_total_weight` explicitly authorizes a higher ceiling. The
+`managed_stocks` capital base is not supported because changing only one symbol
+would violate that mode's required 100% total.
+
+The accepted decision is reused for any replanning within the same ThetaGang
+run. This prevents a tail-harvest replan from receiving a different model signal
+mid-execution.
+
+## Tail-harvest decision
+
+ThetaGang requests `tail_hedge_harvest` only after the existing strategy has an
+approved same-symbol hard-underweight stock buy, the state-owned tail sleeve is
+above its trigger, and at least one active state-owned put is profitable at its
+current host-selected limit-price quote. The request `input` contains:
+
+- The harvest trigger and target, resolved regime base, current sleeve value and
+  weight, target sleeve value, sale budget, approved stock-rebalance value, and
+  the exact host-planned contracts and quantities at the current quotes.
+- Every open state-owned hedge cohort with its option contract, entry and
+  recovery cost, state-owned quantity and value, full broker quantity, value
+  and P&L, current quote, and the host's net-profit candidate calculation.
+- Each protected underlying's configured and effective target context, broker
+  shares, value, cost basis and P&L, live or planned shares and values, approved
+  buy size, tail-program parameters, and volatility, external-weight, and
+  absolute-trend modifier details.
+- Aligned regular-hours completed-session closes for every protected underlying
+  plus optional feature-only reference symbols.
+
+The response must match the request identity, use the latest permitted supplied
+session, and return a JSON boolean:
+
+```json
+{
+  "schema_version": 1,
+  "request_id": "3b93bda0-f5f0-4bb7-a40e-34b04733b29a",
+  "decision_type": "tail_hedge_harvest",
+  "as_of_session": "2026-09-02",
+  "expires_at": "2026-09-04T14:30:00Z",
+  "producer": {
+    "name": "tail-harvest-policy",
+    "version": "2026-08-31"
+  },
+  "output": {
+    "harvest": false,
+    "reason": "drawdown-still-accelerating"
+  }
+}
+```
+
+This is an approval gate, not a sizing API. A provider cannot turn `false` host
+eligibility into a harvest, name contracts, choose quantities, or set prices.
+After a valid approval, ThetaGang re-quotes the options and repeats all band,
+ownership, conflict, and profitability checks before persisting recovery intent
+or queuing an order.
+
+## Configuration
+
+```toml
+[runtime.external_decisions.providers.tqqq_sizing]
+transport = "command"
+command = ["/opt/tqqq-policy/.venv/bin/python", "-m", "tqqq_policy"]
+timeout_seconds = 10
+max_response_bytes = 1048576
+# working_directory = "/opt/tqqq-policy"
+
+[strategies.regime_rebalance.target_weight_policy]
+enabled = true
+provider = "tqqq_sizing"
+on_error = "baseline" # baseline | abort
+max_signal_age_sessions = 0
+# max_total_weight = 1.10
+
+[strategies.regime_rebalance.target_weight_policy.symbols.TQQQ]
+min_multiplier = 0.80
+max_multiplier = 1.10
+clamp_to_volatility_bounds = true
+
+[strategies.regime_rebalance.target_weight_policy.market_data]
+lookback_days = 252
+include_strategy_symbols = true
+
+# Reference symbols need not be traded portfolio symbols, but they need an IBKR
+# primary exchange so ThetaGang can request unambiguous contracts.
+[strategies.regime_rebalance.target_weight_policy.market_data.symbols.QQQ]
+primary_exchange = "NASDAQ"
+
+[strategies.regime_rebalance.target_weight_policy.market_data.symbols.IBIT]
+primary_exchange = "NASDAQ"
+
+[runtime.external_decisions.providers.tail_harvest]
+command = ["/opt/tail-policy/.venv/bin/python", "-m", "tail_policy"]
+timeout_seconds = 10
+
+[strategies.tail_hedge.harvest_decision]
+enabled = true
+provider = "tail_harvest"
+on_error = "baseline" # baseline | skip | abort
+max_signal_age_sessions = 0
+
+[strategies.tail_hedge.harvest_decision.market_data]
+lookback_days = 252
+include_strategy_symbols = true
+
+[strategies.tail_hedge.harvest_decision.market_data.symbols.SPY]
+primary_exchange = "ARCA"
+```
+
+`on_error = "baseline"` retains the unmodified post-volatility target when
+history collection, process execution, or response validation fails. The
+failure is visible in logs and persisted decision telemetry. When that target
+policy controls a tail-hedge underlying, harvesting is not allowed to fund the
+symbol unless the sizing signal was fresh and valid. `on_error = "abort"`
+aborts regime-rebalance planning instead.
+
+For `tail_hedge_harvest`, `baseline` preserves the existing eligible harvest,
+`skip` declines it, and `abort` stops planning. A valid provider veto is not an
+error and is honored regardless of the failure setting.
+
+The provider is trusted local code and runs with the same operating-system
+permissions as ThetaGang. Process separation isolates Python dependencies; it is
+not a security sandbox.

--- a/docs/external-decisions.md
+++ b/docs/external-decisions.md
@@ -6,6 +6,10 @@ registered once under `runtime.external_decisions.providers`, so future decision
 points can reuse the same transport without sharing their decision-specific
 schemas.
 
+The versioned [JSON schemas](external-decisions/schemas/) and
+[complete request/response examples](../examples/external_decisions/) are the
+provider-facing contract. Providers do not need to import or install ThetaGang.
+
 The supported decision types are `regime_target_weights` and
 `tail_hedge_harvest`. Target-weight decisions apply bounded per-symbol
 multipliers after volatility weighting and before the built-in absolute-trend
@@ -18,9 +22,11 @@ or execution policies.
 
 A command provider is executed directly without a shell. ThetaGang writes one
 JSON request to stdin, waits for the process to exit, and reads one JSON response
-from stdout. Provider diagnostics should be written to stderr. Each invocation
-must be side-effect free and deterministic for the supplied completed-session
-data.
+from stdout. Provider diagnostics should be written to stderr. Inference must not
+submit trades or mutate ThetaGang's strategy state. Keep training, feature
+engineering, model artifacts, and model dependencies in the provider project.
+With a fixed model artifact, inference should be deterministic for the complete
+supplied request context; the request ID is for correlation, not a model feature.
 
 Timeouts, cancellation, and oversized responses terminate the command and drain
 its pipes. On POSIX systems, cleanup also terminates its process group so child
@@ -230,3 +236,102 @@ error and is honored regardless of the failure setting.
 The provider is trusted local code and runs with the same operating-system
 permissions as ThetaGang. Process separation isolates Python dependencies; it is
 not a security sandbox.
+
+## Build and check a provider offline
+
+The [reference provider](../examples/external_decisions/provider.py) uses only
+Python's standard library. It returns a neutral target multiplier and vetoes
+harvesting, demonstrating both response shapes. Replace its `decide()` function
+in your own project with feature preparation and inference using a fixed model
+artifact. Use `producer.version` to identify the code/model artifact that
+produced a decision.
+
+From the repository root, run the real command transport and validators without
+starting the trading runtime or connecting to IBKR:
+
+```sh
+uv run python -m thetagang.decision_check check \
+  --request examples/external_decisions/regime_target_weights.request.json \
+  -- python3 -I -S examples/external_decisions/provider.py
+
+uv run python -m thetagang.decision_check check \
+  --request examples/external_decisions/tail_hedge_harvest.request.json \
+  -- python3 -I -S examples/external_decisions/provider.py
+```
+
+`-I -S` demonstrates that the reference provider needs no installed packages.
+For your real provider, replace the command after `--` with its environment's
+Python and entry point, for example `/opt/my-policy/.venv/bin/python -m my_policy`.
+Options such as `--timeout-seconds`, `--max-response-bytes`, and
+`--working-directory` configure the same transport used during live planning.
+
+You can also replay a captured response without executing a provider:
+
+```sh
+uv run python -m thetagang.decision_check check \
+  --request examples/external_decisions/regime_target_weights.request.json \
+  --response examples/external_decisions/regime_target_weights.response.json \
+  --at 2026-09-04T14:30:00Z
+```
+
+The checker defaults to the request's `generated_at` as the replay validation
+time and prints the time it used. Use `--at` to reproduce validation at a later
+instant, including expiry during inference. Historical replay does not establish
+that a signal is fresh today. `--max-signal-age-sessions` defaults to `0` and
+`--weight-epsilon` to `1e-8`; set these to the deployment's policy age limit and
+regime `eps` when they differ. Multiplier limits and volatility bounds come from
+the saved request.
+
+A successful check prints JSON and exits `0`. Invalid requests, failed commands,
+and rejected responses exit nonzero; the checker does not hide errors behind the
+deployment's baseline fallback. Target checks include the production multiplier,
+clamping, and total-exposure checks. `post_policy_weights` are the targets before
+absolute-trend controls and subsequent trading gates. A valid harvest response
+only passes the external approval contract; it does not replay live ownership,
+quotes, allocation bands, or order execution.
+
+## Field semantics and compatibility
+
+Both requests contain all named fields shown in the examples. Nullable fields
+are explicitly `null` when that context is unavailable or inapplicable. An
+unavailable account metric is omitted from `account.metrics`. Optional response
+fields (`expires_at` and `reason`) may be omitted or null.
+
+| Field group | Meaning |
+| --- | --- |
+| Weights, allocation bands, budgets, drawdowns and percentage thresholds | Fractions: `0.05` means 5%. Regime drift bands compare relative deviation from the target. `margin_usage` is the host capital-base multiplier. |
+| Market closes and stock `market_price` | Per-share prices. The current history adapter requests USD stock contracts and regular-hours `TRADES` closes. |
+| Stock values, capital bases, costs, proceeds and P&L | Monetary amounts in the host/broker accounting units. Account metrics retain broker units; `Cushion` is a fraction. The decision adapter performs no currency conversion. |
+| Option `limit_price`, `quoted_limit_price`, `entry_limit_price` | Quote price before the contract multiplier. Per-contract proceeds/cost fields already include it. Multiply by contract quantity for totals. |
+| `current_shares`, broker `shares`, option `quantity` | Stock share counts and option contract counts respectively. `state_owned_quantity` may be less than the full broker position. |
+| `sessions` and `closes` | Strictly aligned completed-session history, ordered oldest to newest. A history lookback of N returns normally supplies N+1 closes. No intraday bars are included. |
+| Lookbacks, cooldowns and signal age | Trading-session counts. DTE settings use calendar days. Option `expiration` is an IBKR `YYYYMMDD` string. |
+| Volatility settings/calculations | Annualized fractional volatility, using 252 trading days. Smoothing factors and efficiency values are dimensionless fractions; choppiness and ratio drift statistics are dimensionless. |
+| Datetimes and snapshot context | Offset-aware instants; requests emit `generated_at` in UTC. It is the assembly time, not a guarantee that every broker observation arrived simultaneously. |
+
+`volatility_weight.config = null` means no volatility configuration;
+`calculation = null` means no successful calculation is supplied. Protected
+underlyings outside the active regime may have null target fields. Underlying
+`broker_position` aggregates retain the host's existing zero-filled sums: a zero
+does not distinguish an empty position set from unavailable marks. Individual
+hedge observations retain nulls for unavailable/non-finite broker values.
+
+Calculation diagnostics (`volatility_weight.calculation` and
+`target_modifiers`) have variable keys describing host calculations. Providers
+should tolerate new diagnostic keys and use the explicit target and constraint
+fields for allocation decisions.
+
+`schema_version = 1` covers both the envelope and the decision-specific shape.
+Changes to defined fields, types, units, or meanings require a new contract
+version; entries in the explicitly open symbol, metric, and diagnostic maps may
+vary within v1. `producer.version` identifies the provider artifact independently
+of the protocol version. The checker and runtime request builders validate
+against the same models. Regenerate the published schemas with:
+
+```sh
+uv run python -m thetagang.decision_check schemas \
+  --output-dir docs/external-decisions/schemas
+```
+
+Tests check that the published schemas match the models, the complete examples
+validate, and the reference provider runs without third-party dependencies.

--- a/docs/external-decisions.md
+++ b/docs/external-decisions.md
@@ -46,7 +46,8 @@ Every request uses a generic versioned envelope:
 ```
 
 All envelope datetimes must include a UTC offset. ThetaGang emits
-`generated_at` in UTC.
+`generated_at` in UTC. Both requests and responses must explicitly include
+`schema_version` as the integer `1`; omitted or coerced versions are rejected.
 
 The `input` for `regime_target_weights` contains:
 
@@ -121,6 +122,9 @@ run. This prevents a tail-harvest replan from receiving a different model signal
 mid-execution.
 Its expiry is checked again before reuse; an expired decision follows the
 configured failure policy without invoking the provider again.
+Any response or target-application failure keeps the hook in its configured
+failure behavior for the rest of that run, even if later baseline weights would
+make a rejected adjustment fit within the exposure ceiling.
 
 ## Tail-harvest decision
 
@@ -304,7 +308,7 @@ fields (`expires_at` and `reason`) may be omitted or null.
 | Stock values, capital bases, costs, proceeds and P&L | Monetary amounts in the host/broker accounting units. Account metrics retain broker units; `Cushion` is a fraction. The decision adapter performs no currency conversion. |
 | Option `limit_price`, `quoted_limit_price`, `entry_limit_price` | Quote price before the contract multiplier. Per-contract proceeds/cost fields already include it. Multiply by contract quantity for totals. |
 | `current_shares`, broker `shares`, option `quantity` | Stock share counts and option contract counts respectively. `state_owned_quantity` may be less than the full broker position. |
-| `sessions` and `closes` | Strictly aligned completed-session history, ordered oldest to newest. A history lookback of N returns normally supplies N+1 closes. No intraday bars are included. |
+| `sessions` and `closes` | Strictly aligned completed-session history with unique sessions ordered oldest to newest and finite positive numeric closes. A history lookback of N returns normally supplies N+1 closes. No intraday bars are included. |
 | Lookbacks, cooldowns and signal age | Trading-session counts. DTE settings use calendar days. Option `expiration` is an IBKR `YYYYMMDD` string. |
 | Volatility settings/calculations | Annualized fractional volatility, using 252 trading days. Smoothing factors and efficiency values are dimensionless fractions; choppiness and ratio drift statistics are dimensionless. |
 | Datetimes and snapshot context | Offset-aware instants; requests emit `generated_at` in UTC. It is the assembly time, not a guarantee that every broker observation arrived simultaneously. |

--- a/docs/external-decisions.md
+++ b/docs/external-decisions.md
@@ -59,7 +59,8 @@ The `input` for `regime_target_weights` contains:
   symbol, along with shares, prices, values, the volatility configuration and
   calculation, the configured absolute-trend rule, and effective trading and
   minimum-order constraints.
-- The host-enforced multiplier constraints for adjustable symbols.
+- The host-enforced multiplier constraints and optional target-weight bounds for
+  adjustable symbols.
 - Aligned completed-session daily close history for the configured feature
   universe. All close arrays correspond exactly to the supplied `sessions`
   array. Data is fetched from IBKR as regular-trading-hours `TRADES` bars.
@@ -106,8 +107,25 @@ or otherwise malformed decisions. It then calculates the target itself:
 
 ```text
 raw target = post-volatility target * multiplier
-effective target = raw target clamped to configured volatility bounds
+effective target = raw target clamped to the enabled target and volatility bounds
+final target = effective target * absolute-trend multiplier
 ```
+
+Each symbol may set `min_target_weight` and/or `max_target_weight`, independently
+of its multiplier limits and volatility configuration. These are absolute
+fractions of the strategy's configured capital base (`weight_base` with its
+resolved `margin_usage`), applied after multiplication and before absolute trend.
+Each omitted bound imposes no additional limit. Bounds must be finite values in
+`[0, 1]`, and the minimum cannot exceed the maximum. The original volatility
+calculation, bounds, and smoothing state remain unchanged.
+
+`clamp_to_volatility_bounds = true` retains the original volatility clamp as
+well: the effective interval is the intersection of the two sets of bounds.
+Conflicting intervals are rejected. Set it to `false` to let the external policy
+use a wider target interval. For example, with IBIT target bounds `[0.10, 0.36]`,
+`0.1875 * 0.50` is floored from `0.09375` to `0.10`. Absolute trend can subsequently
+reduce the target below this floor. These bounds apply to accepted external
+adjustments; `on_error = "baseline"` still uses the post-volatility baseline.
 
 By default an external decision may fill unused allocation up to 100%, but it
 cannot increase total exposure beyond the larger of 100% or the pre-decision
@@ -192,9 +210,18 @@ max_signal_age_sessions = 0
 # max_total_weight = 1.10
 
 [strategies.regime_rebalance.target_weight_policy.symbols.TQQQ]
-min_multiplier = 0.80
-max_multiplier = 1.10
-clamp_to_volatility_bounds = true
+min_multiplier = 0.50
+max_multiplier = 1.20
+min_target_weight = 0.15
+max_target_weight = 0.55
+clamp_to_volatility_bounds = false
+
+[strategies.regime_rebalance.target_weight_policy.symbols.IBIT]
+min_multiplier = 0.50
+max_multiplier = 1.20
+min_target_weight = 0.10
+max_target_weight = 0.36
+clamp_to_volatility_bounds = false
 
 [strategies.regime_rebalance.target_weight_policy.market_data]
 lookback_days = 252
@@ -283,8 +310,9 @@ time and prints the time it used. Use `--at` to reproduce validation at a later
 instant, including expiry during inference. Historical replay does not establish
 that a signal is fresh today. `--max-signal-age-sessions` defaults to `0` and
 `--weight-epsilon` to `1e-8`; set these to the deployment's policy age limit and
-regime `eps` when they differ. Multiplier limits and volatility bounds come from
-the saved request.
+regime `eps` when they differ. Multiplier limits, optional target bounds, and
+volatility bounds come from the saved request. The checker applies the same
+clamps and aggregate exposure ceiling as live planning.
 
 A successful check prints JSON and exits `0`. Invalid requests, failed commands,
 and rejected responses exit nonzero; the checker does not hide errors behind the

--- a/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
+++ b/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
@@ -171,9 +171,39 @@
           "title": "Max Multiplier",
           "type": "number"
         },
+        "max_target_weight": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional ceiling as a fraction of the regime capital base, before absolute trend.",
+          "title": "Max Target Weight"
+        },
         "min_multiplier": {
           "title": "Min Multiplier",
           "type": "number"
+        },
+        "min_target_weight": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional floor as a fraction of the regime capital base, before absolute trend.",
+          "title": "Min Target Weight"
         }
       },
       "required": [

--- a/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
+++ b/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
@@ -104,6 +104,7 @@
         "closes": {
           "additionalProperties": {
             "items": {
+              "exclusiveMinimum": 0,
               "type": "number"
             },
             "type": "array"
@@ -126,6 +127,7 @@
           "type": "boolean"
         },
         "sessions": {
+          "description": "Unique sessions ordered oldest to newest.",
           "items": {
             "format": "date",
             "type": "string"
@@ -645,12 +647,12 @@
     },
     "schema_version": {
       "const": 1,
-      "default": 1,
       "title": "Schema Version",
       "type": "integer"
     }
   },
   "required": [
+    "schema_version",
     "request_id",
     "decision_type",
     "generated_at",

--- a/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
+++ b/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
@@ -1,0 +1,662 @@
+{
+  "$defs": {
+    "AbsoluteTrendInput": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "lookback_days": {
+          "title": "Lookback Days",
+          "type": "integer"
+        },
+        "risk_off_multiplier": {
+          "title": "Risk Off Multiplier",
+          "type": "number"
+        }
+      },
+      "required": [
+        "enabled",
+        "lookback_days",
+        "risk_off_multiplier"
+      ],
+      "title": "AbsoluteTrendInput",
+      "type": "object"
+    },
+    "ExecutionConstraints": {
+      "additionalProperties": false,
+      "properties": {
+        "min_threshold_amount": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Min Threshold Amount"
+        },
+        "min_threshold_percent": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Min Threshold Percent"
+        },
+        "min_threshold_percent_relative": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Min Threshold Percent Relative"
+        },
+        "min_threshold_shares": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Min Threshold Shares"
+        },
+        "rebalance_mode": {
+          "enum": [
+            "both",
+            "buy_only",
+            "sell_only",
+            "off"
+          ],
+          "title": "Rebalance Mode",
+          "type": "string"
+        },
+        "trading_allowed": {
+          "title": "Trading Allowed",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "trading_allowed",
+        "rebalance_mode",
+        "min_threshold_shares",
+        "min_threshold_amount",
+        "min_threshold_percent",
+        "min_threshold_percent_relative"
+      ],
+      "title": "ExecutionConstraints",
+      "type": "object"
+    },
+    "ExternalDecisionMarketData": {
+      "additionalProperties": false,
+      "description": "Aligned completed-session data shared by market-based decisions.",
+      "properties": {
+        "closes": {
+          "additionalProperties": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "minProperties": 1,
+          "title": "Closes",
+          "type": "object"
+        },
+        "primary_exchanges": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "minProperties": 1,
+          "title": "Primary Exchanges",
+          "type": "object"
+        },
+        "regular_trading_hours_only": {
+          "default": true,
+          "title": "Regular Trading Hours Only",
+          "type": "boolean"
+        },
+        "sessions": {
+          "items": {
+            "format": "date",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Sessions",
+          "type": "array"
+        },
+        "source": {
+          "default": "ibkr",
+          "title": "Source",
+          "type": "string"
+        },
+        "timeframe": {
+          "title": "Timeframe",
+          "type": "string"
+        },
+        "what_to_show": {
+          "default": "TRADES",
+          "title": "What To Show",
+          "type": "string"
+        }
+      },
+      "required": [
+        "timeframe",
+        "sessions",
+        "closes",
+        "primary_exchanges"
+      ],
+      "title": "ExternalDecisionMarketData",
+      "type": "object"
+    },
+    "MultiplierConstraints": {
+      "additionalProperties": false,
+      "properties": {
+        "clamp_to_volatility_bounds": {
+          "title": "Clamp To Volatility Bounds",
+          "type": "boolean"
+        },
+        "max_multiplier": {
+          "title": "Max Multiplier",
+          "type": "number"
+        },
+        "min_multiplier": {
+          "title": "Min Multiplier",
+          "type": "number"
+        }
+      },
+      "required": [
+        "min_multiplier",
+        "max_multiplier",
+        "clamp_to_volatility_bounds"
+      ],
+      "title": "MultiplierConstraints",
+      "type": "object"
+    },
+    "RatioGateInput": {
+      "additionalProperties": false,
+      "properties": {
+        "anchor": {
+          "title": "Anchor",
+          "type": "string"
+        },
+        "drift_max": {
+          "title": "Drift Max",
+          "type": "number"
+        },
+        "enabled": {
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "vol_min": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Vol Min"
+        }
+      },
+      "required": [
+        "enabled",
+        "anchor",
+        "drift_max",
+        "vol_min"
+      ],
+      "title": "RatioGateInput",
+      "type": "object"
+    },
+    "TargetWeightAccountInput": {
+      "additionalProperties": false,
+      "properties": {
+        "excluded_option_value": {
+          "title": "Excluded Option Value",
+          "type": "number"
+        },
+        "metrics": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Available IBKR metrics; missing metrics are omitted, never zero-filled.",
+          "title": "Metrics",
+          "type": "object"
+        },
+        "rebalance_base_value": {
+          "title": "Rebalance Base Value",
+          "type": "number"
+        }
+      },
+      "required": [
+        "metrics",
+        "rebalance_base_value",
+        "excluded_option_value"
+      ],
+      "title": "TargetWeightAccountInput",
+      "type": "object"
+    },
+    "TargetWeightDecisionInput": {
+      "additionalProperties": false,
+      "description": "USD values and fractional weights for the regime target multiplier hook.",
+      "properties": {
+        "account": {
+          "$ref": "#/$defs/TargetWeightAccountInput"
+        },
+        "adjustment_constraints": {
+          "additionalProperties": {
+            "$ref": "#/$defs/MultiplierConstraints"
+          },
+          "title": "Adjustment Constraints",
+          "type": "object"
+        },
+        "market_data": {
+          "$ref": "#/$defs/ExternalDecisionMarketData"
+        },
+        "portfolio": {
+          "$ref": "#/$defs/TargetWeightPortfolioInput"
+        },
+        "strategy": {
+          "$ref": "#/$defs/TargetWeightStrategyInput"
+        },
+        "symbols": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TargetWeightSymbolInput"
+          },
+          "title": "Symbols",
+          "type": "object"
+        },
+        "total_weight_constraint": {
+          "$ref": "#/$defs/TotalWeightConstraint"
+        }
+      },
+      "required": [
+        "strategy",
+        "account",
+        "portfolio",
+        "symbols",
+        "adjustment_constraints",
+        "total_weight_constraint",
+        "market_data"
+      ],
+      "title": "TargetWeightDecisionInput",
+      "type": "object"
+    },
+    "TargetWeightPortfolioInput": {
+      "additionalProperties": false,
+      "properties": {
+        "configured_total_weight": {
+          "title": "Configured Total Weight",
+          "type": "number"
+        },
+        "post_volatility_total_weight": {
+          "title": "Post Volatility Total Weight",
+          "type": "number"
+        }
+      },
+      "required": [
+        "configured_total_weight",
+        "post_volatility_total_weight"
+      ],
+      "title": "TargetWeightPortfolioInput",
+      "type": "object"
+    },
+    "TargetWeightStrategyInput": {
+      "additionalProperties": false,
+      "properties": {
+        "choppiness_min": {
+          "title": "Choppiness Min",
+          "type": "number"
+        },
+        "cooldown_days": {
+          "title": "Cooldown Days",
+          "type": "integer"
+        },
+        "deficit_rail_start": {
+          "title": "Deficit Rail Start",
+          "type": "number"
+        },
+        "deficit_rail_stop": {
+          "title": "Deficit Rail Stop",
+          "type": "number"
+        },
+        "efficiency_max": {
+          "title": "Efficiency Max",
+          "type": "number"
+        },
+        "flow_imbalance_tau": {
+          "title": "Flow Imbalance Tau",
+          "type": "number"
+        },
+        "flow_trade_min": {
+          "title": "Flow Trade Min",
+          "type": "number"
+        },
+        "flow_trade_stop": {
+          "title": "Flow Trade Stop",
+          "type": "number"
+        },
+        "hard_band": {
+          "title": "Hard Band",
+          "type": "number"
+        },
+        "hard_band_rebalance_fraction": {
+          "title": "Hard Band Rebalance Fraction",
+          "type": "number"
+        },
+        "last_rebalance_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Last Rebalance At"
+        },
+        "lookback_days": {
+          "title": "Lookback Days",
+          "type": "integer"
+        },
+        "margin_usage": {
+          "title": "Margin Usage",
+          "type": "number"
+        },
+        "name": {
+          "const": "regime_rebalance",
+          "title": "Name",
+          "type": "string"
+        },
+        "ratio_gate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RatioGateInput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "soft_band": {
+          "title": "Soft Band",
+          "type": "number"
+        },
+        "weight_base": {
+          "enum": [
+            "net_liq",
+            "net_liq_ex_options"
+          ],
+          "title": "Weight Base",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "weight_base",
+        "margin_usage",
+        "lookback_days",
+        "soft_band",
+        "hard_band",
+        "hard_band_rebalance_fraction",
+        "cooldown_days",
+        "last_rebalance_at",
+        "choppiness_min",
+        "efficiency_max",
+        "flow_trade_min",
+        "flow_trade_stop",
+        "flow_imbalance_tau",
+        "deficit_rail_start",
+        "deficit_rail_stop",
+        "ratio_gate"
+      ],
+      "title": "TargetWeightStrategyInput",
+      "type": "object"
+    },
+    "TargetWeightSymbolInput": {
+      "additionalProperties": false,
+      "properties": {
+        "absolute_trend": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AbsoluteTrendInput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "configured_weight": {
+          "title": "Configured Weight",
+          "type": "number"
+        },
+        "current_shares": {
+          "title": "Current Shares",
+          "type": "integer"
+        },
+        "current_value": {
+          "title": "Current Value",
+          "type": "number"
+        },
+        "current_weight": {
+          "title": "Current Weight",
+          "type": "number"
+        },
+        "execution_constraints": {
+          "$ref": "#/$defs/ExecutionConstraints"
+        },
+        "market_price": {
+          "title": "Market Price",
+          "type": "number"
+        },
+        "post_volatility_weight": {
+          "title": "Post Volatility Weight",
+          "type": "number"
+        },
+        "volatility_weight": {
+          "$ref": "#/$defs/VolatilityContext"
+        }
+      },
+      "required": [
+        "configured_weight",
+        "post_volatility_weight",
+        "current_weight",
+        "current_value",
+        "current_shares",
+        "market_price",
+        "volatility_weight",
+        "absolute_trend",
+        "execution_constraints"
+      ],
+      "title": "TargetWeightSymbolInput",
+      "type": "object"
+    },
+    "TotalWeightConstraint": {
+      "additionalProperties": false,
+      "properties": {
+        "default_prevents_additional_leverage": {
+          "title": "Default Prevents Additional Leverage",
+          "type": "boolean"
+        },
+        "effective_max_total_weight": {
+          "title": "Effective Max Total Weight",
+          "type": "number"
+        },
+        "max_total_weight": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Max Total Weight"
+        }
+      },
+      "required": [
+        "max_total_weight",
+        "effective_max_total_weight",
+        "default_prevents_additional_leverage"
+      ],
+      "title": "TotalWeightConstraint",
+      "type": "object"
+    },
+    "VolatilityContext": {
+      "additionalProperties": false,
+      "properties": {
+        "calculation": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "number"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Host calculation diagnostics; absent when unavailable.",
+          "title": "Calculation"
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VolatilityWeightInput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "config",
+        "calculation"
+      ],
+      "title": "VolatilityContext",
+      "type": "object"
+    },
+    "VolatilityWeightInput": {
+      "additionalProperties": false,
+      "properties": {
+        "decrease_smoothing_factor": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Decrease Smoothing Factor"
+        },
+        "enabled": {
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "increase_smoothing_factor": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Increase Smoothing Factor"
+        },
+        "lookback_days": {
+          "title": "Lookback Days",
+          "type": "integer"
+        },
+        "max_weight": {
+          "title": "Max Weight",
+          "type": "number"
+        },
+        "min_weight": {
+          "title": "Min Weight",
+          "type": "number"
+        },
+        "rebalance_band": {
+          "title": "Rebalance Band",
+          "type": "number"
+        },
+        "smoothing_factor": {
+          "title": "Smoothing Factor",
+          "type": "number"
+        },
+        "target_vol": {
+          "title": "Target Vol",
+          "type": "number"
+        }
+      },
+      "required": [
+        "enabled",
+        "target_vol",
+        "lookback_days",
+        "min_weight",
+        "max_weight",
+        "rebalance_band",
+        "smoothing_factor",
+        "increase_smoothing_factor",
+        "decrease_smoothing_factor"
+      ],
+      "title": "VolatilityWeightInput",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "decision_type": {
+      "const": "regime_target_weights",
+      "title": "Decision Type",
+      "type": "string"
+    },
+    "dry_run": {
+      "title": "Dry Run",
+      "type": "boolean"
+    },
+    "generated_at": {
+      "format": "date-time",
+      "title": "Generated At",
+      "type": "string"
+    },
+    "input": {
+      "$ref": "#/$defs/TargetWeightDecisionInput"
+    },
+    "request_id": {
+      "minLength": 1,
+      "title": "Request Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1,
+      "default": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "request_id",
+    "decision_type",
+    "generated_at",
+    "dry_run",
+    "input"
+  ],
+  "title": "TargetWeightDecisionRequest",
+  "type": "object"
+}

--- a/docs/external-decisions/schemas/regime_target_weights.response.v1.schema.json
+++ b/docs/external-decisions/schemas/regime_target_weights.response.v1.schema.json
@@ -105,12 +105,12 @@
     },
     "schema_version": {
       "const": 1,
-      "default": 1,
       "title": "Schema Version",
       "type": "integer"
     }
   },
   "required": [
+    "schema_version",
     "request_id",
     "decision_type",
     "as_of_session",

--- a/docs/external-decisions/schemas/regime_target_weights.response.v1.schema.json
+++ b/docs/external-decisions/schemas/regime_target_weights.response.v1.schema.json
@@ -1,0 +1,122 @@
+{
+  "$defs": {
+    "ExternalDecisionProducer": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "title": "ExternalDecisionProducer",
+      "type": "object"
+    },
+    "TargetWeightDecisionOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "adjustments": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TargetWeightMultiplier"
+          },
+          "title": "Adjustments",
+          "type": "object"
+        }
+      },
+      "required": [
+        "adjustments"
+      ],
+      "title": "TargetWeightDecisionOutput",
+      "type": "object"
+    },
+    "TargetWeightMultiplier": {
+      "additionalProperties": false,
+      "properties": {
+        "multiplier": {
+          "minimum": 0.0,
+          "title": "Multiplier",
+          "type": "number"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reason"
+        }
+      },
+      "required": [
+        "multiplier"
+      ],
+      "title": "TargetWeightMultiplier",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "as_of_session": {
+      "format": "date",
+      "title": "As Of Session",
+      "type": "string"
+    },
+    "decision_type": {
+      "const": "regime_target_weights",
+      "title": "Decision Type",
+      "type": "string"
+    },
+    "expires_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "output": {
+      "$ref": "#/$defs/TargetWeightDecisionOutput"
+    },
+    "producer": {
+      "$ref": "#/$defs/ExternalDecisionProducer"
+    },
+    "request_id": {
+      "minLength": 1,
+      "title": "Request Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1,
+      "default": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "request_id",
+    "decision_type",
+    "as_of_session",
+    "producer",
+    "output"
+  ],
+  "title": "TargetWeightDecisionResponse",
+  "type": "object"
+}

--- a/docs/external-decisions/schemas/tail_hedge_harvest.request.v1.schema.json
+++ b/docs/external-decisions/schemas/tail_hedge_harvest.request.v1.schema.json
@@ -7,6 +7,7 @@
         "closes": {
           "additionalProperties": {
             "items": {
+              "exclusiveMinimum": 0,
               "type": "number"
             },
             "type": "array"
@@ -29,6 +30,7 @@
           "type": "boolean"
         },
         "sessions": {
+          "description": "Unique sessions ordered oldest to newest.",
           "items": {
             "format": "date",
             "type": "string"
@@ -941,12 +943,12 @@
     },
     "schema_version": {
       "const": 1,
-      "default": 1,
       "title": "Schema Version",
       "type": "integer"
     }
   },
   "required": [
+    "schema_version",
     "request_id",
     "decision_type",
     "generated_at",

--- a/docs/external-decisions/schemas/tail_hedge_harvest.request.v1.schema.json
+++ b/docs/external-decisions/schemas/tail_hedge_harvest.request.v1.schema.json
@@ -1,0 +1,958 @@
+{
+  "$defs": {
+    "ExternalDecisionMarketData": {
+      "additionalProperties": false,
+      "description": "Aligned completed-session data shared by market-based decisions.",
+      "properties": {
+        "closes": {
+          "additionalProperties": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "minProperties": 1,
+          "title": "Closes",
+          "type": "object"
+        },
+        "primary_exchanges": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "minProperties": 1,
+          "title": "Primary Exchanges",
+          "type": "object"
+        },
+        "regular_trading_hours_only": {
+          "default": true,
+          "title": "Regular Trading Hours Only",
+          "type": "boolean"
+        },
+        "sessions": {
+          "items": {
+            "format": "date",
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Sessions",
+          "type": "array"
+        },
+        "source": {
+          "default": "ibkr",
+          "title": "Source",
+          "type": "string"
+        },
+        "timeframe": {
+          "title": "Timeframe",
+          "type": "string"
+        },
+        "what_to_show": {
+          "default": "TRADES",
+          "title": "What To Show",
+          "type": "string"
+        }
+      },
+      "required": [
+        "timeframe",
+        "sessions",
+        "closes",
+        "primary_exchanges"
+      ],
+      "title": "ExternalDecisionMarketData",
+      "type": "object"
+    },
+    "HarvestCandidateInput": {
+      "additionalProperties": false,
+      "properties": {
+        "cost_basis_per_contract": {
+          "title": "Cost Basis Per Contract",
+          "type": "number"
+        },
+        "estimated_fee_per_contract": {
+          "title": "Estimated Fee Per Contract",
+          "type": "number"
+        },
+        "gross_proceeds_per_contract": {
+          "title": "Gross Proceeds Per Contract",
+          "type": "number"
+        },
+        "net_proceeds_per_contract": {
+          "title": "Net Proceeds Per Contract",
+          "type": "number"
+        },
+        "profit_multiple": {
+          "title": "Profit Multiple",
+          "type": "number"
+        },
+        "quantity": {
+          "title": "Quantity",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "quantity",
+        "gross_proceeds_per_contract",
+        "estimated_fee_per_contract",
+        "net_proceeds_per_contract",
+        "cost_basis_per_contract",
+        "profit_multiple"
+      ],
+      "title": "HarvestCandidateInput",
+      "type": "object"
+    },
+    "HarvestOpportunityInput": {
+      "additionalProperties": false,
+      "properties": {
+        "approved_rebalance_value": {
+          "title": "Approved Rebalance Value",
+          "type": "number"
+        },
+        "harvest_target_weight": {
+          "title": "Harvest Target Weight",
+          "type": "number"
+        },
+        "harvest_trigger_weight": {
+          "title": "Harvest Trigger Weight",
+          "type": "number"
+        },
+        "planned_sales": {
+          "items": {
+            "$ref": "#/$defs/PlannedHarvestSale"
+          },
+          "title": "Planned Sales",
+          "type": "array"
+        },
+        "sale_budget": {
+          "title": "Sale Budget",
+          "type": "number"
+        },
+        "sleeve_value": {
+          "title": "Sleeve Value",
+          "type": "number"
+        },
+        "sleeve_weight": {
+          "title": "Sleeve Weight",
+          "type": "number"
+        },
+        "target_sleeve_value": {
+          "title": "Target Sleeve Value",
+          "type": "number"
+        }
+      },
+      "required": [
+        "sleeve_value",
+        "sleeve_weight",
+        "harvest_trigger_weight",
+        "harvest_target_weight",
+        "target_sleeve_value",
+        "sale_budget",
+        "approved_rebalance_value",
+        "planned_sales"
+      ],
+      "title": "HarvestOpportunityInput",
+      "type": "object"
+    },
+    "HedgeContractInput": {
+      "additionalProperties": false,
+      "properties": {
+        "con_id": {
+          "title": "Con Id",
+          "type": "integer"
+        },
+        "expiration": {
+          "title": "Expiration",
+          "type": "string"
+        },
+        "multiplier": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Multiplier"
+        },
+        "right": {
+          "const": "P",
+          "title": "Right",
+          "type": "string"
+        },
+        "strike": {
+          "title": "Strike",
+          "type": "number"
+        }
+      },
+      "required": [
+        "con_id",
+        "expiration",
+        "strike",
+        "right",
+        "multiplier"
+      ],
+      "title": "HedgeContractInput",
+      "type": "object"
+    },
+    "HedgePositionInput": {
+      "additionalProperties": false,
+      "properties": {
+        "candidate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HarvestCandidateInput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "contract": {
+          "$ref": "#/$defs/HedgeContractInput"
+        },
+        "entered_at": {
+          "format": "date-time",
+          "title": "Entered At",
+          "type": "string"
+        },
+        "entry_id": {
+          "title": "Entry Id",
+          "type": "string"
+        },
+        "entry_limit_price": {
+          "title": "Entry Limit Price",
+          "type": "number"
+        },
+        "estimated_cost": {
+          "title": "Estimated Cost",
+          "type": "number"
+        },
+        "host_candidate": {
+          "title": "Host Candidate",
+          "type": "boolean"
+        },
+        "live_average_cost_per_contract": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Live Average Cost Per Contract"
+        },
+        "live_position_market_value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Live Position Market Value"
+        },
+        "live_position_quantity": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Live Position Quantity"
+        },
+        "live_realized_pnl": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Live Realized Pnl"
+        },
+        "quoted_limit_price": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Quoted Limit Price"
+        },
+        "recovered_cost": {
+          "title": "Recovered Cost",
+          "type": "number"
+        },
+        "reported_owned_market_value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Reported Owned Market Value"
+        },
+        "state_owned_quantity": {
+          "title": "State Owned Quantity",
+          "type": "integer"
+        },
+        "state_owned_unrealized_pnl": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "State Owned Unrealized Pnl"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        },
+        "symbol": {
+          "title": "Symbol",
+          "type": "string"
+        },
+        "unrecovered_cost": {
+          "title": "Unrecovered Cost",
+          "type": "number"
+        }
+      },
+      "required": [
+        "entry_id",
+        "symbol",
+        "status",
+        "contract",
+        "state_owned_quantity",
+        "live_position_quantity",
+        "reported_owned_market_value",
+        "live_position_market_value",
+        "live_average_cost_per_contract",
+        "live_realized_pnl",
+        "state_owned_unrealized_pnl",
+        "quoted_limit_price",
+        "entered_at",
+        "entry_limit_price",
+        "estimated_cost",
+        "recovered_cost",
+        "unrecovered_cost",
+        "host_candidate",
+        "candidate"
+      ],
+      "title": "HedgePositionInput",
+      "type": "object"
+    },
+    "PlannedHarvestSale": {
+      "additionalProperties": false,
+      "properties": {
+        "con_id": {
+          "title": "Con Id",
+          "type": "integer"
+        },
+        "entry_id": {
+          "title": "Entry Id",
+          "type": "string"
+        },
+        "estimated_fees": {
+          "title": "Estimated Fees",
+          "type": "number"
+        },
+        "estimated_gross_proceeds": {
+          "title": "Estimated Gross Proceeds",
+          "type": "number"
+        },
+        "estimated_net_proceeds": {
+          "title": "Estimated Net Proceeds",
+          "type": "number"
+        },
+        "expiration": {
+          "title": "Expiration",
+          "type": "string"
+        },
+        "limit_price": {
+          "title": "Limit Price",
+          "type": "number"
+        },
+        "quantity": {
+          "title": "Quantity",
+          "type": "integer"
+        },
+        "symbol": {
+          "title": "Symbol",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entry_id",
+        "symbol",
+        "con_id",
+        "expiration",
+        "quantity",
+        "limit_price",
+        "estimated_gross_proceeds",
+        "estimated_fees",
+        "estimated_net_proceeds"
+      ],
+      "title": "PlannedHarvestSale",
+      "type": "object"
+    },
+    "ProtectedUnderlyingInput": {
+      "additionalProperties": false,
+      "properties": {
+        "approved_buy_shares": {
+          "title": "Approved Buy Shares",
+          "type": "integer"
+        },
+        "approved_buy_value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Approved Buy Value"
+        },
+        "broker_position": {
+          "$ref": "#/$defs/UnderlyingBrokerPosition"
+        },
+        "configured_weight": {
+          "title": "Configured Weight",
+          "type": "number"
+        },
+        "current_shares": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Current Shares"
+        },
+        "current_value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Current Value"
+        },
+        "current_weight": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Current Weight"
+        },
+        "market_price": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Market Price"
+        },
+        "primary_exchange": {
+          "title": "Primary Exchange",
+          "type": "string"
+        },
+        "tail_program": {
+          "$ref": "#/$defs/TailProgramInput"
+        },
+        "target_modifiers": {
+          "$ref": "#/$defs/TargetModifierInputs"
+        },
+        "target_shares": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Target Shares"
+        },
+        "target_value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Target Value"
+        },
+        "target_weight": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Target Weight"
+        }
+      },
+      "required": [
+        "configured_weight",
+        "primary_exchange",
+        "market_price",
+        "current_shares",
+        "current_value",
+        "broker_position",
+        "current_weight",
+        "target_weight",
+        "target_value",
+        "target_shares",
+        "approved_buy_shares",
+        "approved_buy_value",
+        "tail_program",
+        "target_modifiers"
+      ],
+      "title": "ProtectedUnderlyingInput",
+      "type": "object"
+    },
+    "TailHarvestAccountInput": {
+      "additionalProperties": false,
+      "properties": {
+        "excluded_option_value": {
+          "title": "Excluded Option Value",
+          "type": "number"
+        },
+        "net_liquidation": {
+          "title": "Net Liquidation",
+          "type": "number"
+        },
+        "regime_rebalance_base": {
+          "title": "Regime Rebalance Base",
+          "type": "number"
+        }
+      },
+      "required": [
+        "net_liquidation",
+        "regime_rebalance_base",
+        "excluded_option_value"
+      ],
+      "title": "TailHarvestAccountInput",
+      "type": "object"
+    },
+    "TailHarvestDecisionInput": {
+      "additionalProperties": false,
+      "description": "USD values, fractional weights, and whole option contract quantities.",
+      "properties": {
+        "account": {
+          "$ref": "#/$defs/TailHarvestAccountInput"
+        },
+        "hedge_positions": {
+          "items": {
+            "$ref": "#/$defs/HedgePositionInput"
+          },
+          "title": "Hedge Positions",
+          "type": "array"
+        },
+        "host_constraints": {
+          "$ref": "#/$defs/TailHarvestHostConstraints"
+        },
+        "market_data": {
+          "$ref": "#/$defs/ExternalDecisionMarketData"
+        },
+        "opportunity": {
+          "$ref": "#/$defs/HarvestOpportunityInput"
+        },
+        "strategy": {
+          "$ref": "#/$defs/TailHarvestStrategyInput"
+        },
+        "underlyings": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ProtectedUnderlyingInput"
+          },
+          "title": "Underlyings",
+          "type": "object"
+        }
+      },
+      "required": [
+        "strategy",
+        "host_constraints",
+        "account",
+        "opportunity",
+        "underlyings",
+        "hedge_positions",
+        "market_data"
+      ],
+      "title": "TailHarvestDecisionInput",
+      "type": "object"
+    },
+    "TailHarvestHostConstraints": {
+      "additionalProperties": false,
+      "properties": {
+        "baseline_band_triggered": {
+          "const": true,
+          "title": "Baseline Band Triggered",
+          "type": "boolean"
+        },
+        "host_selects_contracts_quantities_and_limit_prices": {
+          "const": true,
+          "title": "Host Selects Contracts Quantities And Limit Prices",
+          "type": "boolean"
+        },
+        "requires_approved_same_symbol_hard_underweight_buy": {
+          "const": true,
+          "title": "Requires Approved Same Symbol Hard Underweight Buy",
+          "type": "boolean"
+        },
+        "state_owned_active_profitable_puts_only": {
+          "const": true,
+          "title": "State Owned Active Profitable Puts Only",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "baseline_band_triggered",
+        "requires_approved_same_symbol_hard_underweight_buy",
+        "state_owned_active_profitable_puts_only",
+        "host_selects_contracts_quantities_and_limit_prices"
+      ],
+      "title": "TailHarvestHostConstraints",
+      "type": "object"
+    },
+    "TailHarvestStrategyInput": {
+      "additionalProperties": false,
+      "properties": {
+        "annual_budget": {
+          "title": "Annual Budget",
+          "type": "number"
+        },
+        "name": {
+          "const": "tail_hedge",
+          "title": "Name",
+          "type": "string"
+        },
+        "regime_margin_usage": {
+          "title": "Regime Margin Usage",
+          "type": "number"
+        },
+        "regime_weight_base": {
+          "enum": [
+            "net_liq",
+            "net_liq_ex_options",
+            "managed_stocks"
+          ],
+          "title": "Regime Weight Base",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "annual_budget",
+        "regime_weight_base",
+        "regime_margin_usage"
+      ],
+      "title": "TailHarvestStrategyInput",
+      "type": "object"
+    },
+    "TailProgramInput": {
+      "additionalProperties": false,
+      "properties": {
+        "budget_weight": {
+          "title": "Budget Weight",
+          "type": "number"
+        },
+        "catastrophe_drawdowns": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Catastrophe Drawdowns",
+          "type": "array"
+        },
+        "entries_per_year": {
+          "title": "Entries Per Year",
+          "type": "integer"
+        },
+        "entry_gate": {
+          "enum": [
+            "vix",
+            "none"
+          ],
+          "title": "Entry Gate",
+          "type": "string"
+        },
+        "entry_vix_max": {
+          "title": "Entry Vix Max",
+          "type": "number"
+        },
+        "exit_dte": {
+          "title": "Exit Dte",
+          "type": "integer"
+        },
+        "max_bid_ask_ratio": {
+          "title": "Max Bid Ask Ratio",
+          "type": "number"
+        },
+        "max_dte": {
+          "title": "Max Dte",
+          "type": "integer"
+        },
+        "max_premium_ratio": {
+          "title": "Max Premium Ratio",
+          "type": "number"
+        },
+        "min_dte": {
+          "title": "Min Dte",
+          "type": "integer"
+        },
+        "minimum_bid": {
+          "title": "Minimum Bid",
+          "type": "number"
+        },
+        "minimum_open_interest": {
+          "title": "Minimum Open Interest",
+          "type": "integer"
+        },
+        "target_dte": {
+          "title": "Target Dte",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "budget_weight",
+        "entries_per_year",
+        "entry_gate",
+        "entry_vix_max",
+        "target_dte",
+        "min_dte",
+        "max_dte",
+        "exit_dte",
+        "minimum_open_interest",
+        "minimum_bid",
+        "max_bid_ask_ratio",
+        "max_premium_ratio",
+        "catastrophe_drawdowns"
+      ],
+      "title": "TailProgramInput",
+      "type": "object"
+    },
+    "TargetModifierInputs": {
+      "additionalProperties": false,
+      "properties": {
+        "absolute_trend": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "format": "date",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Absolute Trend"
+        },
+        "target_weight_policy": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "format": "date",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Target Weight Policy"
+        },
+        "volatility_weight": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "format": "date",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Volatility Weight"
+        }
+      },
+      "required": [
+        "volatility_weight",
+        "target_weight_policy",
+        "absolute_trend"
+      ],
+      "title": "TargetModifierInputs",
+      "type": "object"
+    },
+    "UnderlyingBrokerPosition": {
+      "additionalProperties": false,
+      "properties": {
+        "average_cost_per_share": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Average Cost Per Share"
+        },
+        "market_value": {
+          "title": "Market Value",
+          "type": "number"
+        },
+        "realized_pnl": {
+          "title": "Realized Pnl",
+          "type": "number"
+        },
+        "shares": {
+          "title": "Shares",
+          "type": "number"
+        },
+        "unrealized_pnl": {
+          "title": "Unrealized Pnl",
+          "type": "number"
+        }
+      },
+      "required": [
+        "shares",
+        "market_value",
+        "average_cost_per_share",
+        "unrealized_pnl",
+        "realized_pnl"
+      ],
+      "title": "UnderlyingBrokerPosition",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "decision_type": {
+      "const": "tail_hedge_harvest",
+      "title": "Decision Type",
+      "type": "string"
+    },
+    "dry_run": {
+      "title": "Dry Run",
+      "type": "boolean"
+    },
+    "generated_at": {
+      "format": "date-time",
+      "title": "Generated At",
+      "type": "string"
+    },
+    "input": {
+      "$ref": "#/$defs/TailHarvestDecisionInput"
+    },
+    "request_id": {
+      "minLength": 1,
+      "title": "Request Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1,
+      "default": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "request_id",
+    "decision_type",
+    "generated_at",
+    "dry_run",
+    "input"
+  ],
+  "title": "TailHarvestDecisionRequest",
+  "type": "object"
+}

--- a/docs/external-decisions/schemas/tail_hedge_harvest.response.v1.schema.json
+++ b/docs/external-decisions/schemas/tail_hedge_harvest.response.v1.schema.json
@@ -1,0 +1,104 @@
+{
+  "$defs": {
+    "ExternalDecisionProducer": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "title": "ExternalDecisionProducer",
+      "type": "object"
+    },
+    "TailHarvestDecisionOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "harvest": {
+          "title": "Harvest",
+          "type": "boolean"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reason"
+        }
+      },
+      "required": [
+        "harvest"
+      ],
+      "title": "TailHarvestDecisionOutput",
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "as_of_session": {
+      "format": "date",
+      "title": "As Of Session",
+      "type": "string"
+    },
+    "decision_type": {
+      "const": "tail_hedge_harvest",
+      "title": "Decision Type",
+      "type": "string"
+    },
+    "expires_at": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "output": {
+      "$ref": "#/$defs/TailHarvestDecisionOutput"
+    },
+    "producer": {
+      "$ref": "#/$defs/ExternalDecisionProducer"
+    },
+    "request_id": {
+      "minLength": 1,
+      "title": "Request Id",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": 1,
+      "default": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "request_id",
+    "decision_type",
+    "as_of_session",
+    "producer",
+    "output"
+  ],
+  "title": "TailHarvestDecisionResponse",
+  "type": "object"
+}

--- a/docs/external-decisions/schemas/tail_hedge_harvest.response.v1.schema.json
+++ b/docs/external-decisions/schemas/tail_hedge_harvest.response.v1.schema.json
@@ -87,12 +87,12 @@
     },
     "schema_version": {
       "const": 1,
-      "default": 1,
       "title": "Schema Version",
       "type": "integer"
     }
   },
   "required": [
+    "schema_version",
     "request_id",
     "decision_type",
     "as_of_session",

--- a/docs/tail-hedging.md
+++ b/docs/tail-hedging.md
@@ -160,6 +160,16 @@ harvest in a flat or recovering market. A later sale requires the remaining
 sleeve to be above 5% again and the same-symbol hard-underweight buy to remain
 approved. No crash episode, trough, profit-tier, or recovery state is needed.
 
+An optional external decision provider can add an approval gate after these
+conditions are satisfied. It receives the current state-owned hedge cohorts,
+broker position values and P&L, host-selected put limit-price quotes,
+host-computed profitable candidates, underlying allocation and sizing context,
+and aligned completed-session closes for the protected assets and configured
+reference symbols. Its response is only `harvest = true` or `false`: it cannot
+create an opportunity, select a contract, choose a quantity or limit price, or
+submit an order. See
+[External decision providers](external-decisions.md) for the protocol.
+
 Harvesting uses the exact same `weight_base` calculation as regime rebalancing.
 With the default `net_liq_ex_options`, options on active regime symbols and all
 state-owned tail puts are removed from broker `NetLiquidation`. Unrelated
@@ -178,6 +188,12 @@ preliminary size of the stock order. After option quotes return, ThetaGang
 rechecks both the live sleeve and the latest available NLV and rebuilds the
 regime base before committing a sale, so the two sides of the ratio are not
 intentionally taken from different market moments.
+
+When the external gate is enabled and approves a harvest, ThetaGang quotes the
+puts again and repeats the ownership, conflict, profitability, allocation-band,
+and sizing checks after the provider returns. A stale approval therefore cannot
+bypass a material state or price change while history and policy evaluation are
+in flight.
 
 After a fill, excluded put value has become included cash, so the refreshed
 regime base can increase. The target weight is therefore a sale-sizing reference
@@ -274,6 +290,20 @@ annual_budget = 0.005
 harvest_trigger_weight = 0.05
 harvest_target_weight = 0.03
 
+# Optional when regime_rebalance is also configured and running:
+# [strategies.tail_hedge.harvest_decision]
+# enabled = true
+# provider = "tail_harvest"
+# on_error = "baseline" # baseline | skip | abort
+# max_signal_age_sessions = 0
+#
+# [strategies.tail_hedge.harvest_decision.market_data]
+# lookback_days = 252
+# include_strategy_symbols = true
+#
+# [strategies.tail_hedge.harvest_decision.market_data.symbols.SPY]
+# primary_exchange = "ARCA"
+
 [[strategies.tail_hedge.targets]]
 symbol = "QQQ"
 budget_weight = 1.0
@@ -290,6 +320,12 @@ max_bid_ask_ratio = 0.50
 max_premium_ratio = 0.05
 catastrophe_drawdowns = [0.40, 0.50, 0.60]
 ```
+
+The named provider must be configured under
+`runtime.external_decisions.providers`. `on_error = "baseline"` keeps the
+existing harvest behavior if the provider fails, `skip` declines that harvest,
+and `abort` stops regime-rebalance planning. These are failure policies only; a
+valid `harvest = false` always vetoes the opportunity.
 
 When tail hedging is enabled, each target symbol must also appear in
 `portfolio.symbols`. Enable `regime_rebalance` and add it alongside `tail_hedge`

--- a/examples/external_decisions/provider.py
+++ b/examples/external_decisions/provider.py
@@ -1,0 +1,45 @@
+"""Standard-library protocol example; replace decide() with your model inference.
+
+Run with your provider environment's Python. No ThetaGang imports are needed.
+This is a neutral sizing / harvest-veto example, not a trading recommendation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def decide(request: dict[str, Any]) -> dict[str, Any]:
+    context = request["input"]
+    if request["decision_type"] == "regime_target_weights":
+        return {
+            "adjustments": {
+                symbol: {"multiplier": 1.0, "reason": "reference-baseline"}
+                for symbol in context["adjustment_constraints"]
+            }
+        }
+    if request["decision_type"] == "tail_hedge_harvest":
+        return {"harvest": False, "reason": "reference-veto"}
+    raise ValueError("Unsupported decision_type")
+
+
+def main() -> None:
+    request = json.load(sys.stdin)
+    if type(request["schema_version"]) is not int or request["schema_version"] != 1:
+        raise ValueError("Unsupported schema_version")
+    response = {
+        "schema_version": 1,
+        "request_id": request["request_id"],
+        "decision_type": request["decision_type"],
+        "as_of_session": request["input"]["market_data"]["sessions"][-1],
+        "producer": {"name": "reference-provider", "version": "1"},
+        "output": decide(request),
+    }
+    json.dump(response, sys.stdout, allow_nan=False)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/external_decisions/regime_target_weights.request.json
+++ b/examples/external_decisions/regime_target_weights.request.json
@@ -107,6 +107,8 @@
       "TQQQ": {
         "min_multiplier": 0.8,
         "max_multiplier": 1.1,
+        "min_target_weight": null,
+        "max_target_weight": null,
         "clamp_to_volatility_bounds": true
       }
     },

--- a/examples/external_decisions/regime_target_weights.request.json
+++ b/examples/external_decisions/regime_target_weights.request.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": 1,
+  "request_id": "example-regime_target_weights-v1",
+  "decision_type": "regime_target_weights",
+  "generated_at": "2026-09-04T14:30:00Z",
+  "dry_run": true,
+  "input": {
+    "strategy": {
+      "name": "regime_rebalance",
+      "weight_base": "net_liq_ex_options",
+      "margin_usage": 1.0,
+      "lookback_days": 40,
+      "soft_band": 0.1,
+      "hard_band": 0.5,
+      "hard_band_rebalance_fraction": 1.0,
+      "cooldown_days": 5,
+      "last_rebalance_at": null,
+      "choppiness_min": 3.0,
+      "efficiency_max": 0.3,
+      "flow_trade_min": 0.025,
+      "flow_trade_stop": 0.0125,
+      "flow_imbalance_tau": 0.7,
+      "deficit_rail_start": 0.06,
+      "deficit_rail_stop": 0.03,
+      "ratio_gate": null
+    },
+    "account": {
+      "metrics": {
+        "NetLiquidation": 100000.0,
+        "TotalCashValue": 7000.0,
+        "Cushion": 0.9
+      },
+      "rebalance_base_value": 98000.0,
+      "excluded_option_value": 2000.0
+    },
+    "portfolio": {
+      "configured_total_weight": 1.0,
+      "post_volatility_total_weight": 0.9
+    },
+    "symbols": {
+      "TQQQ": {
+        "configured_weight": 0.5,
+        "post_volatility_weight": 0.4,
+        "current_weight": 0.42857142857142855,
+        "current_value": 42000.0,
+        "current_shares": 1000,
+        "market_price": 42.0,
+        "volatility_weight": {
+          "config": {
+            "enabled": true,
+            "target_vol": 0.55,
+            "lookback_days": 3,
+            "min_weight": 0.25,
+            "max_weight": 0.5,
+            "rebalance_band": 0.0,
+            "smoothing_factor": 1.0,
+            "increase_smoothing_factor": null,
+            "decrease_smoothing_factor": null
+          },
+          "calculation": {
+            "base_weight": 0.5,
+            "effective_weight": 0.4,
+            "realized_vol": 0.6875,
+            "raw_weight": 0.4,
+            "target_weight": 0.4,
+            "previous_weight": 0.5,
+            "smoothing_factor": 1.0
+          }
+        },
+        "absolute_trend": {
+          "enabled": true,
+          "lookback_days": 168,
+          "risk_off_multiplier": 0.15
+        },
+        "execution_constraints": {
+          "trading_allowed": true,
+          "rebalance_mode": "both",
+          "min_threshold_shares": null,
+          "min_threshold_amount": null,
+          "min_threshold_percent": null,
+          "min_threshold_percent_relative": null
+        }
+      },
+      "QQQ": {
+        "configured_weight": 0.5,
+        "post_volatility_weight": 0.5,
+        "current_weight": 0.5,
+        "current_value": 49000.0,
+        "current_shares": 100,
+        "market_price": 490.0,
+        "volatility_weight": {
+          "config": null,
+          "calculation": null
+        },
+        "absolute_trend": null,
+        "execution_constraints": {
+          "trading_allowed": true,
+          "rebalance_mode": "both",
+          "min_threshold_shares": null,
+          "min_threshold_amount": null,
+          "min_threshold_percent": null,
+          "min_threshold_percent_relative": null
+        }
+      }
+    },
+    "adjustment_constraints": {
+      "TQQQ": {
+        "min_multiplier": 0.8,
+        "max_multiplier": 1.1,
+        "clamp_to_volatility_bounds": true
+      }
+    },
+    "total_weight_constraint": {
+      "max_total_weight": null,
+      "effective_max_total_weight": 1.0,
+      "default_prevents_additional_leverage": true
+    },
+    "market_data": {
+      "source": "ibkr",
+      "timeframe": "1 day",
+      "what_to_show": "TRADES",
+      "regular_trading_hours_only": true,
+      "sessions": [
+        "2026-08-31",
+        "2026-09-01",
+        "2026-09-02",
+        "2026-09-03"
+      ],
+      "closes": {
+        "TQQQ": [
+          45.0,
+          44.0,
+          43.0,
+          42.0
+        ],
+        "QQQ": [
+          505.0,
+          500.0,
+          495.0,
+          490.0
+        ]
+      },
+      "primary_exchanges": {
+        "TQQQ": "NASDAQ",
+        "QQQ": "NASDAQ"
+      }
+    }
+  }
+}

--- a/examples/external_decisions/regime_target_weights.response.json
+++ b/examples/external_decisions/regime_target_weights.response.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "request_id": "example-regime_target_weights-v1",
+  "decision_type": "regime_target_weights",
+  "as_of_session": "2026-09-03",
+  "producer": {
+    "name": "reference-provider",
+    "version": "1"
+  },
+  "output": {
+    "adjustments": {
+      "TQQQ": {
+        "multiplier": 1.0,
+        "reason": "reference-baseline"
+      }
+    }
+  }
+}

--- a/examples/external_decisions/tail_hedge_harvest.request.json
+++ b/examples/external_decisions/tail_hedge_harvest.request.json
@@ -1,0 +1,153 @@
+{
+  "schema_version": 1,
+  "request_id": "example-tail_hedge_harvest-v1",
+  "decision_type": "tail_hedge_harvest",
+  "generated_at": "2026-09-04T14:30:00Z",
+  "dry_run": true,
+  "input": {
+    "strategy": {
+      "name": "tail_hedge",
+      "annual_budget": 0.005,
+      "regime_weight_base": "net_liq_ex_options",
+      "regime_margin_usage": 1.0
+    },
+    "host_constraints": {
+      "baseline_band_triggered": true,
+      "requires_approved_same_symbol_hard_underweight_buy": true,
+      "state_owned_active_profitable_puts_only": true,
+      "host_selects_contracts_quantities_and_limit_prices": true
+    },
+    "account": {
+      "net_liquidation": 100000.0,
+      "regime_rebalance_base": 94000.0,
+      "excluded_option_value": 6000.0
+    },
+    "opportunity": {
+      "sleeve_value": 6000.0,
+      "sleeve_weight": 0.06382978723404255,
+      "harvest_trigger_weight": 0.05,
+      "harvest_target_weight": 0.03,
+      "target_sleeve_value": 2820.0,
+      "sale_budget": 3180.0,
+      "approved_rebalance_value": 28000.0,
+      "planned_sales": [
+        {
+          "entry_id": "TQQQ-tail-example",
+          "symbol": "TQQQ",
+          "con_id": 123456,
+          "expiration": "20261120",
+          "quantity": 3,
+          "limit_price": 15.0,
+          "estimated_gross_proceeds": 4500.0,
+          "estimated_fees": 3.0,
+          "estimated_net_proceeds": 4497.0
+        }
+      ]
+    },
+    "underlyings": {
+      "TQQQ": {
+        "configured_weight": 0.5,
+        "primary_exchange": "NASDAQ",
+        "market_price": 40.0,
+        "current_shares": 400.0,
+        "current_value": 16000.0,
+        "broker_position": {
+          "shares": 400.0,
+          "market_value": 16000.0,
+          "average_cost_per_share": 60.0,
+          "unrealized_pnl": -8000.0,
+          "realized_pnl": 0.0
+        },
+        "current_weight": 0.1702127659574468,
+        "target_weight": 0.5,
+        "target_value": 47000.0,
+        "target_shares": 1175.0,
+        "approved_buy_shares": 700,
+        "approved_buy_value": 28000.0,
+        "tail_program": {
+          "budget_weight": 1.0,
+          "entries_per_year": 6,
+          "entry_gate": "vix",
+          "entry_vix_max": 20.0,
+          "target_dte": 180,
+          "min_dte": 120,
+          "max_dte": 240,
+          "exit_dte": 30,
+          "minimum_open_interest": 50,
+          "minimum_bid": 0.01,
+          "max_bid_ask_ratio": 0.5,
+          "max_premium_ratio": 0.05,
+          "catastrophe_drawdowns": [
+            0.4,
+            0.5,
+            0.6
+          ]
+        },
+        "target_modifiers": {
+          "volatility_weight": null,
+          "target_weight_policy": null,
+          "absolute_trend": null
+        }
+      }
+    },
+    "hedge_positions": [
+      {
+        "entry_id": "TQQQ-tail-example",
+        "symbol": "TQQQ",
+        "status": "active",
+        "contract": {
+          "con_id": 123456,
+          "expiration": "20261120",
+          "strike": 50.0,
+          "right": "P",
+          "multiplier": 100.0
+        },
+        "state_owned_quantity": 4,
+        "live_position_quantity": 4.0,
+        "reported_owned_market_value": 6000.0,
+        "live_position_market_value": 6000.0,
+        "live_average_cost_per_contract": 300.0,
+        "live_realized_pnl": 0.0,
+        "state_owned_unrealized_pnl": 4800.0,
+        "quoted_limit_price": 15.0,
+        "entered_at": "2026-06-01T14:30:00Z",
+        "entry_limit_price": 3.0,
+        "estimated_cost": 1200.0,
+        "recovered_cost": 0.0,
+        "unrecovered_cost": 1200.0,
+        "host_candidate": true,
+        "candidate": {
+          "quantity": 4,
+          "gross_proceeds_per_contract": 1500.0,
+          "estimated_fee_per_contract": 1.0,
+          "net_proceeds_per_contract": 1499.0,
+          "cost_basis_per_contract": 300.0,
+          "profit_multiple": 4.996666666666667
+        }
+      }
+    ],
+    "market_data": {
+      "source": "ibkr",
+      "timeframe": "1 day",
+      "what_to_show": "TRADES",
+      "regular_trading_hours_only": true,
+      "sessions": [
+        "2026-08-31",
+        "2026-09-01",
+        "2026-09-02",
+        "2026-09-03"
+      ],
+      "closes": {
+        "TQQQ": [
+          50.0,
+          46.0,
+          43.0,
+          40.0
+        ]
+      },
+      "primary_exchanges": {
+        "TQQQ": "NASDAQ"
+      }
+    }
+  }
+}

--- a/examples/external_decisions/tail_hedge_harvest.response.json
+++ b/examples/external_decisions/tail_hedge_harvest.response.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "request_id": "example-tail_hedge_harvest-v1",
+  "decision_type": "tail_hedge_harvest",
+  "as_of_session": "2026-09-03",
+  "producer": {
+    "name": "reference-provider",
+    "version": "1"
+  },
+  "output": {
+    "harvest": false,
+    "reason": "reference-veto"
+  }
+}

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -12,6 +12,7 @@ from thetagang.config import (
     stage_enabled_map,
     stage_enabled_map_from_run,
 )
+from thetagang.config_models import TargetWeightPolicySymbolConfig
 
 
 def _base_config(run):
@@ -657,6 +658,47 @@ def test_target_weight_policy_accepts_named_provider_and_market_universe() -> No
     assert policy.symbols["AAA"].min_multiplier == pytest.approx(0.8)
     assert policy.market_data.lookback_days == 252
     assert policy.market_data.symbols["QQQ"].primary_exchange == "NASDAQ"
+    assert policy.symbols["AAA"].min_target_weight is None
+    assert policy.symbols["AAA"].max_target_weight is None
+
+
+@pytest.mark.parametrize("field", ["min_target_weight", "max_target_weight"])
+@pytest.mark.parametrize("value", [-0.01, 1.01, float("nan"), float("inf")])
+def test_target_weight_policy_rejects_invalid_target_bound(
+    field: str, value: float
+) -> None:
+    with pytest.raises(ValueError, match=field):
+        TargetWeightPolicySymbolConfig.model_validate({field: value})
+
+
+def test_target_weight_policy_rejects_reversed_target_bounds() -> None:
+    with pytest.raises(ValueError, match="max_target_weight must be >="):
+        TargetWeightPolicySymbolConfig(min_target_weight=0.36, max_target_weight=0.10)
+
+
+@pytest.mark.parametrize(
+    "bounds", [{"min_target_weight": 0.6}, {"max_target_weight": 0.2}]
+)
+def test_target_weight_bounds_must_overlap_enabled_volatility_clamp(
+    bounds: dict[str, float],
+) -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_target_weight_policy(data)
+    data["portfolio"]["symbols"]["AAA"]["volatility_weight"]["max_weight"] = 0.5
+    limits = data["strategies"]["regime_rebalance"]["target_weight_policy"]["symbols"][
+        "AAA"
+    ]
+    limits.update(bounds)
+    with pytest.raises(ValueError, match="do not overlap volatility bounds"):
+        Config(**data)
+
+    limits["clamp_to_volatility_bounds"] = False
+    config = Config(**data)
+    symbol_policy = config.strategies.regime_rebalance.target_weight_policy.symbols[
+        "AAA"
+    ]
+    for name, expected in bounds.items():
+        assert getattr(symbol_policy, name) == expected
 
 
 def test_target_weight_policy_rejects_unknown_provider() -> None:

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from typing import Any
 
 import pytest
 from rich.console import Console
@@ -612,6 +613,203 @@ def test_symbol_absolute_trend_allows_zero_risk_off_multiplier() -> None:
     absolute_trend = config.portfolio.symbols["AAA"].absolute_trend
     assert absolute_trend is not None
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.0)
+
+
+def _enable_target_weight_policy(data: dict[str, Any]) -> None:
+    data["runtime"]["external_decisions"] = {
+        "providers": {
+            "tqqq_sizing": {
+                "command": ["/opt/tqqq-policy/bin/predict"],
+                "timeout_seconds": 5,
+            }
+        }
+    }
+    data["portfolio"]["symbols"]["AAA"]["volatility_weight"] = {
+        "enabled": True,
+        "target_vol": 0.55,
+        "lookback_days": 20,
+        "min_weight": 0.25,
+        "max_weight": 1.0,
+    }
+    data["strategies"]["regime_rebalance"] = {
+        "enabled": True,
+        "symbols": ["AAA"],
+        "target_weight_policy": {
+            "enabled": True,
+            "provider": "tqqq_sizing",
+            "symbols": {"AAA": {"min_multiplier": 0.8, "max_multiplier": 1.1}},
+            "market_data": {
+                "lookback_days": 252,
+                "symbols": {"QQQ": {"primary_exchange": "NASDAQ"}},
+            },
+        },
+    }
+
+
+def test_target_weight_policy_accepts_named_provider_and_market_universe() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_target_weight_policy(data)
+
+    config = Config(**data)
+    policy = config.strategies.regime_rebalance.target_weight_policy
+
+    assert policy.provider == "tqqq_sizing"
+    assert policy.symbols["AAA"].min_multiplier == pytest.approx(0.8)
+    assert policy.market_data.lookback_days == 252
+    assert policy.market_data.symbols["QQQ"].primary_exchange == "NASDAQ"
+
+
+def test_target_weight_policy_rejects_unknown_provider() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_target_weight_policy(data)
+    data["strategies"]["regime_rebalance"]["target_weight_policy"]["provider"] = (
+        "missing"
+    )
+
+    with pytest.raises(ValueError, match="provider must exist"):
+        Config(**data)
+
+
+def test_target_weight_policy_rejects_managed_stocks_weight_base() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_target_weight_policy(data)
+    data["strategies"]["regime_rebalance"]["weight_base"] = "managed_stocks"
+
+    with pytest.raises(ValueError, match="does not support weight_base=managed_stocks"):
+        Config(**data)
+
+
+def test_target_weight_policy_rejects_total_weight_ceiling_below_one() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_target_weight_policy(data)
+    data["strategies"]["regime_rebalance"]["target_weight_policy"][
+        "max_total_weight"
+    ] = 0.9
+
+    with pytest.raises(ValueError, match="max_total_weight"):
+        Config(**data)
+
+
+def test_target_weight_policy_rejects_signal_age_beyond_supplied_history() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_target_weight_policy(data)
+    policy = data["strategies"]["regime_rebalance"]["target_weight_policy"]
+    policy["max_signal_age_sessions"] = 253
+    policy["market_data"]["lookback_days"] = 252
+
+    with pytest.raises(ValueError, match="max_signal_age_sessions"):
+        Config(**data)
+
+
+def test_target_weight_policy_requires_exchange_for_reference_symbol() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_target_weight_policy(data)
+    data["strategies"]["regime_rebalance"]["target_weight_policy"]["market_data"][
+        "symbols"
+    ]["QQQ"] = {}
+
+    with pytest.raises(ValueError, match="QQQ requires primary_exchange"):
+        Config(**data)
+
+
+def test_target_weight_policy_rejects_target_missing_from_portfolio() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_target_weight_policy(data)
+    policy = data["strategies"]["regime_rebalance"]["target_weight_policy"]
+    policy["symbols"] = {
+        "ZZZ": {
+            "min_multiplier": 0.8,
+            "max_multiplier": 1.1,
+            "clamp_to_volatility_bounds": False,
+        }
+    }
+    data["strategies"]["regime_rebalance"]["symbols"] = ["AAA", "ZZZ"]
+
+    with pytest.raises(ValueError, match="must be in portfolio.symbols: ZZZ"):
+        Config(**data)
+
+
+def test_target_weight_policy_rejects_zero_weight_target() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    data["portfolio"]["symbols"] = {
+        "AAA": {"weight": 0.0},
+        "BBB": {"weight": 1.0},
+    }
+    _enable_target_weight_policy(data)
+
+    with pytest.raises(ValueError, match="must have positive configured weights: AAA"):
+        Config(**data)
+
+
+def _enable_tail_harvest_decision(data: dict[str, Any]) -> None:
+    data["runtime"]["external_decisions"] = {
+        "providers": {
+            "tail_harvest": {
+                "command": ["/opt/tail-policy/bin/decide"],
+                "timeout_seconds": 5,
+            }
+        }
+    }
+    data["strategies"]["regime_rebalance"] = {
+        "enabled": True,
+        "symbols": ["AAA"],
+    }
+    data["strategies"]["tail_hedge"] = {
+        "enabled": True,
+        "targets": [_tail_target()],
+        "harvest_decision": {
+            "enabled": True,
+            "provider": "tail_harvest",
+            "on_error": "skip",
+            "market_data": {
+                "lookback_days": 100,
+                "symbols": {"QQQ": {"primary_exchange": "NASDAQ"}},
+            },
+        },
+    }
+
+
+def test_tail_harvest_decision_accepts_named_provider_and_market_data() -> None:
+    data = _base_config({"strategies": ["regime_rebalance", "tail_hedge"]})
+    _enable_tail_harvest_decision(data)
+
+    config = Config(**data)
+    policy = config.strategies.tail_hedge.harvest_decision
+
+    assert policy.provider == "tail_harvest"
+    assert policy.on_error == "skip"
+    assert policy.market_data.include_strategy_symbols is True
+    assert policy.market_data.lookback_days == 100
+    assert policy.market_data.symbols["QQQ"].primary_exchange == "NASDAQ"
+
+
+def test_tail_harvest_decision_rejects_unknown_provider() -> None:
+    data = _base_config({"strategies": ["regime_rebalance", "tail_hedge"]})
+    _enable_tail_harvest_decision(data)
+    data["strategies"]["tail_hedge"]["harvest_decision"]["provider"] = "missing"
+
+    with pytest.raises(ValueError, match="provider must exist"):
+        Config(**data)
+
+
+def test_tail_harvest_decision_requires_tail_hedge_strategy() -> None:
+    data = _base_config({"strategies": ["regime_rebalance"]})
+    _enable_tail_harvest_decision(data)
+    data["strategies"]["tail_hedge"]["enabled"] = False
+
+    with pytest.raises(ValueError, match="requires strategies.tail_hedge.enabled"):
+        Config(**data)
+
+
+def test_tail_harvest_decision_requires_exchange_for_reference_symbol() -> None:
+    data = _base_config({"strategies": ["regime_rebalance", "tail_hedge"]})
+    _enable_tail_harvest_decision(data)
+    data["strategies"]["tail_hedge"]["harvest_decision"]["market_data"]["symbols"][
+        "QQQ"
+    ] = {}
+
+    with pytest.raises(ValueError, match="QQQ requires primary_exchange"):
+        Config(**data)
 
 
 def test_portfolio_configured_weights_must_sum_to_100() -> None:

--- a/tests/test_decision_check.py
+++ b/tests/test_decision_check.py
@@ -197,6 +197,81 @@ def test_replay_uses_host_total_weight_limit(tmp_path: Path) -> None:
     assert json.loads(result.output)["post_policy_weights"] == {"TQQQ": 0.8, "QQQ": 0.5}
 
 
+@pytest.mark.parametrize(
+    ("symbol", "baseline", "multiplier", "minimum", "maximum", "expected"),
+    [
+        ("IBIT", 0.1875, 0.50, 0.10, 0.36, 0.10),
+        ("IBIT", 0.30, 1.20, 0.10, 0.36, 0.36),
+        ("TQQQ", 0.25, 0.50, 0.15, 0.55, 0.15),
+        ("TQQQ", 0.50, 1.20, 0.15, 0.55, 0.55),
+    ],
+)
+def test_replay_enforces_model_target_bounds(
+    tmp_path: Path,
+    symbol: str,
+    baseline: float,
+    multiplier: float,
+    minimum: float,
+    maximum: float,
+    expected: float,
+) -> None:
+    request = json.loads((EXAMPLES / "regime_target_weights.request.json").read_text())
+    context = request["input"]
+    for mapping in (
+        context["symbols"],
+        context["adjustment_constraints"],
+        context["market_data"]["closes"],
+        context["market_data"]["primary_exchanges"],
+    ):
+        mapping[symbol] = mapping.pop("TQQQ")
+    context["symbols"][symbol]["post_volatility_weight"] = baseline
+    context["portfolio"]["post_volatility_total_weight"] = baseline + 0.5
+    context["adjustment_constraints"][symbol].update(
+        min_multiplier=0.5,
+        max_multiplier=1.2,
+        min_target_weight=minimum,
+        max_target_weight=maximum,
+        clamp_to_volatility_bounds=False,
+    )
+    # Preserve room for the 55% target plus the fixture's 50% QQQ allocation.
+    context["total_weight_constraint"].update(
+        max_total_weight=1.1,
+        effective_max_total_weight=1.1,
+        default_prevents_additional_leverage=False,
+    )
+    response = json.loads(
+        (EXAMPLES / "regime_target_weights.response.json").read_text()
+    )
+    response["output"]["adjustments"] = {symbol: {"multiplier": multiplier}}
+    result = replay(tmp_path, request=request, response=response)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["post_policy_weights"][symbol] == pytest.approx(
+        expected
+    )
+
+
+def test_replay_preserves_requests_without_optional_target_bounds(
+    tmp_path: Path,
+) -> None:
+    request = json.loads((EXAMPLES / "regime_target_weights.request.json").read_text())
+    limits = request["input"]["adjustment_constraints"]["TQQQ"]
+    del limits["min_target_weight"]
+    del limits["max_target_weight"]
+    result = replay(tmp_path, request=request)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["post_policy_weights"] == {"TQQQ": 0.4, "QQQ": 0.5}
+
+
+def test_replay_rejects_conflicting_target_and_volatility_bounds(
+    tmp_path: Path,
+) -> None:
+    request = json.loads((EXAMPLES / "regime_target_weights.request.json").read_text())
+    request["input"]["adjustment_constraints"]["TQQQ"]["max_target_weight"] = 0.20
+    result = replay(tmp_path, request=request)
+    assert result.exit_code == 1
+    assert "do not overlap volatility bounds" in result.output
+
+
 @pytest.mark.parametrize("decision", DECISIONS)
 def test_invalid_request_is_rejected_before_provider_execution(
     tmp_path: Path, decision: str

--- a/tests/test_decision_check.py
+++ b/tests/test_decision_check.py
@@ -1,0 +1,221 @@
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from thetagang.decision_check import (
+    CONTRACT_MODELS,
+    cli,
+    published_schemas,
+    read_request,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "examples" / "external_decisions"
+DECISIONS = ("regime_target_weights", "tail_hedge_harvest")
+
+
+@pytest.mark.parametrize("name", CONTRACT_MODELS)
+def test_published_fixtures_and_schemas_match_contract(name: str) -> None:
+    model = CONTRACT_MODELS[name]
+    fixture = EXAMPLES / f"{name}.json"
+    model.model_validate_json(fixture.read_bytes())
+    filename = f"{name}.v1.schema.json"
+    checked_in = ROOT / "docs" / "external-decisions" / "schemas" / filename
+    assert json.loads(checked_in.read_text()) == published_schemas()[filename]
+
+
+@pytest.mark.parametrize("decision", DECISIONS)
+def test_reference_provider_runs_with_only_standard_library(decision: str) -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "check",
+            "--request",
+            str(EXAMPLES / f"{decision}.request.json"),
+            "--",
+            sys.executable,
+            "-I",
+            "-S",
+            str(EXAMPLES / "provider.py"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["valid"] is True
+    assert report["decision_type"] == decision
+    expected = json.loads((EXAMPLES / f"{decision}.response.json").read_text())
+    assert report["output"] == expected["output"]
+    if decision == "regime_target_weights":
+        assert report["post_policy_weights"] == {"TQQQ": 0.4, "QQQ": 0.5}
+
+
+def replay(
+    tmp_path: Path,
+    *,
+    decision: str = "regime_target_weights",
+    request: dict[str, Any] | None = None,
+    response: dict[str, Any] | None = None,
+    options: tuple[str, ...] = (),
+) -> Any:
+    request_path = EXAMPLES / f"{decision}.request.json"
+    if request is not None:
+        request_path = tmp_path / "request.json"
+        request_path.write_text(json.dumps(request))
+    response_path = EXAMPLES / f"{decision}.response.json"
+    if response is not None:
+        response_path = tmp_path / "response.json"
+        response_path.write_text(json.dumps(response))
+    return CliRunner().invoke(
+        cli,
+        [
+            "check",
+            "--request",
+            str(request_path),
+            "--response",
+            str(response_path),
+            *options,
+        ],
+    )
+
+
+@pytest.mark.parametrize("decision", DECISIONS)
+def test_saved_response_replay_uses_request_time(tmp_path: Path, decision: str) -> None:
+    result = replay(tmp_path, decision=decision)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["validated_at"] == "2026-09-04T14:30:00+00:00"
+
+
+@pytest.mark.parametrize("decision", DECISIONS)
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("request_id", "another-request", "request_id mismatch"),
+        ("decision_type", "another-hook", "type mismatch"),
+        ("schema_version", 2, "invalid response envelope"),
+        ("as_of_session", "2026-09-02", "signal is stale"),
+        ("expires_at", "2026-09-04T14:29:00Z", "signal has expired"),
+    ],
+)
+def test_replay_rejects_invalid_response(
+    tmp_path: Path, decision: str, field: str, value: object, error: str
+) -> None:
+    response = json.loads((EXAMPLES / f"{decision}.response.json").read_text())
+    response[field] = value
+    result = replay(tmp_path, decision=decision, response=response)
+    assert result.exit_code == 1
+    assert error in result.output
+
+
+def test_replay_can_select_signal_age_and_validation_time(tmp_path: Path) -> None:
+    response = json.loads(
+        (EXAMPLES / "regime_target_weights.response.json").read_text()
+    )
+    response["as_of_session"] = "2026-09-02"
+    response["expires_at"] = "2026-09-05T00:00:00Z"
+    accepted = replay(
+        tmp_path, response=response, options=("--max-signal-age-sessions", "1")
+    )
+    assert accepted.exit_code == 0, accepted.output
+    expired = replay(
+        tmp_path,
+        response=response,
+        options=(
+            "--max-signal-age-sessions",
+            "1",
+            "--at",
+            "2026-09-05T00:00:00Z",
+        ),
+    )
+    assert expired.exit_code == 1
+    assert "signal has expired" in expired.output
+
+
+@pytest.mark.parametrize("multiplier", [True, "1.0", 1.2, float("nan")])
+def test_replay_rejects_invalid_multiplier(tmp_path: Path, multiplier: object) -> None:
+    response = json.loads(
+        (EXAMPLES / "regime_target_weights.response.json").read_text()
+    )
+    response["output"]["adjustments"]["TQQQ"]["multiplier"] = multiplier
+    result = replay(tmp_path, response=response)
+    assert result.exit_code == 1
+
+
+def test_replay_uses_host_total_weight_limit(tmp_path: Path) -> None:
+    request = json.loads((EXAMPLES / "regime_target_weights.request.json").read_text())
+    limits = request["input"]["adjustment_constraints"]["TQQQ"]
+    limits.update(max_multiplier=2.0, clamp_to_volatility_bounds=False)
+    response = json.loads(
+        (EXAMPLES / "regime_target_weights.response.json").read_text()
+    )
+    response["output"]["adjustments"]["TQQQ"]["multiplier"] = 2.0
+    result = replay(tmp_path, request=request, response=response)
+    assert result.exit_code == 1
+    assert "exceeds the permitted total weight" in result.output
+
+    request["input"]["total_weight_constraint"].update(
+        max_total_weight=1.3,
+        effective_max_total_weight=1.3,
+        default_prevents_additional_leverage=False,
+    )
+    result = replay(tmp_path, request=request, response=response)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["post_policy_weights"] == {"TQQQ": 0.8, "QQQ": 0.5}
+
+
+@pytest.mark.parametrize("decision", DECISIONS)
+def test_invalid_request_is_rejected_before_provider_execution(
+    tmp_path: Path, decision: str
+) -> None:
+    request = json.loads((EXAMPLES / f"{decision}.request.json").read_text())
+    request["input"]["market_data"]["closes"]["TQQQ"].pop()
+    path = tmp_path / "bad-request.json"
+    path.write_text(json.dumps(request))
+    result = CliRunner().invoke(
+        cli, ["check", "--request", str(path), "--", "nonexistent-provider"]
+    )
+    assert result.exit_code == 1
+    assert "align with sessions" in result.output
+    assert "could not be started" not in result.output
+
+
+def test_contract_rejects_missing_nested_context(tmp_path: Path) -> None:
+    request = json.loads((EXAMPLES / "tail_hedge_harvest.request.json").read_text())
+    del request["input"]["hedge_positions"][0]["contract"]["multiplier"]
+    path = tmp_path / "request.json"
+    path.write_text(json.dumps(request))
+    with pytest.raises(ValueError, match="multiplier"):
+        read_request(path)
+
+
+def test_provider_failure_does_not_report_baseline_success() -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "check",
+            "--request",
+            str(EXAMPLES / "regime_target_weights.request.json"),
+            "--",
+            sys.executable,
+            "-c",
+            "print('not JSON')",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "invalid JSON" in result.output
+
+
+@pytest.mark.parametrize("epsilon", ["nan", "inf", "-1", "0"])
+def test_replay_rejects_invalid_weight_tolerance(tmp_path: Path, epsilon: str) -> None:
+    result = replay(tmp_path, options=("--weight-epsilon", epsilon))
+    assert result.exit_code == 2
+    assert "finite and positive" in result.output
+
+
+def test_schema_export(tmp_path: Path) -> None:
+    result = CliRunner().invoke(cli, ["schemas", "--output-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert len(list(tmp_path.glob("*.schema.json"))) == 4

--- a/tests/test_decision_check.py
+++ b/tests/test_decision_check.py
@@ -45,6 +45,20 @@ def test_response_contract_rejects_coerced_decisions(
         CONTRACT_MODELS[f"{decision}.response"].model_validate(response)
 
 
+@pytest.mark.parametrize("name", CONTRACT_MODELS)
+@pytest.mark.parametrize("version", [None, True, 1.0, "1", 2])
+def test_contract_requires_explicit_integer_schema_version(
+    name: str, version: object
+) -> None:
+    payload = json.loads((EXAMPLES / f"{name}.json").read_text())
+    if version is None:
+        del payload["schema_version"]
+    else:
+        payload["schema_version"] = version
+    with pytest.raises(ValueError, match="schema_version"):
+        CONTRACT_MODELS[name].model_validate(payload)
+
+
 @pytest.mark.parametrize("decision", DECISIONS)
 def test_reference_provider_runs_with_only_standard_library(decision: str) -> None:
     result = CliRunner().invoke(
@@ -197,6 +211,24 @@ def test_invalid_request_is_rejected_before_provider_execution(
     assert result.exit_code == 1
     assert "align with sessions" in result.output
     assert "could not be started" not in result.output
+
+
+@pytest.mark.parametrize("decision", DECISIONS)
+@pytest.mark.parametrize("failure", ["duplicate", "unsorted", "zero", "negative"])
+def test_replay_rejects_invalid_market_history(
+    tmp_path: Path, decision: str, failure: str
+) -> None:
+    request = json.loads((EXAMPLES / f"{decision}.request.json").read_text())
+    history = request["input"]["market_data"]
+    if failure == "duplicate":
+        history["sessions"][-1] = history["sessions"][-2]
+    elif failure == "unsorted":
+        history["sessions"].reverse()
+    else:
+        history["closes"]["TQQQ"][-1] = 0.0 if failure == "zero" else -1.0
+    result = replay(tmp_path, decision=decision, request=request)
+    assert result.exit_code == 1
+    assert "strictly increasing" in result.output or "greater than 0" in result.output
 
 
 def test_contract_rejects_missing_nested_context(tmp_path: Path) -> None:

--- a/tests/test_decision_check.py
+++ b/tests/test_decision_check.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 
 from thetagang.decision_check import (
     CONTRACT_MODELS,
@@ -26,6 +26,23 @@ def test_published_fixtures_and_schemas_match_contract(name: str) -> None:
     filename = f"{name}.v1.schema.json"
     checked_in = ROOT / "docs" / "external-decisions" / "schemas" / filename
     assert json.loads(checked_in.read_text()) == published_schemas()[filename]
+
+
+@pytest.mark.parametrize(
+    ("decision", "output"),
+    [
+        ("regime_target_weights", {"adjustments": {"TQQQ": {"multiplier": value}}})
+        for value in (True, "1.0", float("nan"), float("inf"))
+    ]
+    + [("tail_hedge_harvest", {"harvest": value}) for value in (1, 0, "true", None)],
+)
+def test_response_contract_rejects_coerced_decisions(
+    decision: str, output: dict[str, Any]
+) -> None:
+    response = json.loads((EXAMPLES / f"{decision}.response.json").read_text())
+    response["output"] = output
+    with pytest.raises(ValueError):
+        CONTRACT_MODELS[f"{decision}.response"].model_validate(response)
 
 
 @pytest.mark.parametrize("decision", DECISIONS)
@@ -60,7 +77,7 @@ def replay(
     request: dict[str, Any] | None = None,
     response: dict[str, Any] | None = None,
     options: tuple[str, ...] = (),
-) -> Any:
+) -> Result:
     request_path = EXAMPLES / f"{decision}.request.json"
     if request is not None:
         request_path = tmp_path / "request.json"

--- a/tests/test_external_decisions.py
+++ b/tests/test_external_decisions.py
@@ -1,3 +1,5 @@
+import os
+import subprocess
 import sys
 from datetime import UTC, datetime
 
@@ -145,6 +147,63 @@ async def test_command_provider_stops_oversized_response() -> None:
 
     with pytest.raises(ExternalDecisionError, match="too large"):
         await providers.decide("fixture", _request())
+
+
+@pytest.mark.parametrize("failure", ["stdout", "stderr", "descendant", "cancel"])
+def test_command_provider_cleanup_cannot_hang(failure: str) -> None:
+    if failure == "descendant" and os.name != "posix":
+        pytest.skip("Process-group cleanup requires POSIX")
+    # Isolate the event loop so a pipe-draining regression fails within a hard
+    # deadline, even if cancellation of decide() itself deadlocks.
+    driver = """
+import asyncio
+import sys
+import time
+from datetime import UTC, datetime
+from thetagang.config_models import ExternalDecisionProviderConfig
+from thetagang.external_decisions import (
+    CommandExternalDecisionProvider, ExternalDecisionError, ExternalDecisionRequest,
+)
+
+async def main():
+    failure = sys.argv[1]
+    scripts = {
+        'stdout': 'import sys; sys.stdout.write("x" * 2_000_000); sys.stdout.flush()',
+        'stderr': 'import sys, time; sys.stderr.write("x" * 2_000_000); time.sleep(2)',
+        'descendant': 'import subprocess, sys; subprocess.Popen([sys.executable, "-c", "import time; time.sleep(2)"])',
+        'cancel': 'import time; time.sleep(2)',
+    }
+    provider = CommandExternalDecisionProvider(ExternalDecisionProviderConfig(
+        command=[sys.executable, '-c', scripts[failure]],
+        max_response_bytes=1024, timeout_seconds=0.3 if failure != 'stdout' else 1,
+    ))
+    request = ExternalDecisionRequest(request_id='test', decision_type='test',
+        generated_at=datetime.now(UTC), dry_run=True, input={})
+    start = time.monotonic()
+    task = asyncio.create_task(provider.decide(request))
+    if failure == 'cancel':
+        await asyncio.sleep(0.1)
+        task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        assert failure == 'cancel'
+    except ExternalDecisionError as exc:
+        assert ('too large' if failure == 'stdout' else 'timed out') in str(exc)
+    else:
+        raise AssertionError('Provider unexpectedly succeeded')
+    assert time.monotonic() - start < 1.5
+
+asyncio.run(main())
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", driver, failure],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.asyncio

--- a/tests/test_external_decisions.py
+++ b/tests/test_external_decisions.py
@@ -1,0 +1,175 @@
+import sys
+from datetime import UTC, datetime
+
+import pytest
+
+from thetagang.config_models import ExternalDecisionProviderConfig
+from thetagang.external_decisions import (
+    ExternalDecisionError,
+    ExternalDecisionMarketData,
+    ExternalDecisionProviders,
+    ExternalDecisionRequest,
+)
+
+
+def _request() -> ExternalDecisionRequest:
+    return ExternalDecisionRequest(
+        request_id="request-1",
+        decision_type="test_decision",
+        generated_at=datetime(2026, 9, 3, tzinfo=UTC),
+        dry_run=True,
+        input={"value": 7},
+    )
+
+
+def test_external_request_requires_timezone() -> None:
+    with pytest.raises(ValueError, match="generated_at must include a timezone"):
+        ExternalDecisionRequest(
+            request_id="request-1",
+            decision_type="test_decision",
+            generated_at=datetime(2026, 9, 3),  # noqa: DTZ001
+            dry_run=True,
+            input={},
+        )
+
+
+def test_external_market_data_serializes_aligned_sessions() -> None:
+    market_data = ExternalDecisionMarketData(
+        timeframe="1 day",
+        sessions=[datetime(2026, 9, 2, tzinfo=UTC).date()],
+        closes={"TQQQ": [42.0]},
+        primary_exchanges={"TQQQ": "NASDAQ"},
+    )
+
+    assert market_data.request_input() == {
+        "source": "ibkr",
+        "timeframe": "1 day",
+        "what_to_show": "TRADES",
+        "regular_trading_hours_only": True,
+        "sessions": ["2026-09-02"],
+        "closes": {"TQQQ": [42.0]},
+        "primary_exchanges": {"TQQQ": "NASDAQ"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("closes", "primary_exchanges", "error"),
+    [
+        ({"TQQQ": [42.0, 43.0]}, {"TQQQ": "NASDAQ"}, "align"),
+        ({"TQQQ": [42.0]}, {"QQQ": "NASDAQ"}, "symbols"),
+    ],
+)
+def test_external_market_data_rejects_inconsistent_symbols_or_lengths(
+    closes: dict[str, list[float]],
+    primary_exchanges: dict[str, str],
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        ExternalDecisionMarketData(
+            timeframe="1 day",
+            sessions=[datetime(2026, 9, 2, tzinfo=UTC).date()],
+            closes=closes,
+            primary_exchanges=primary_exchanges,
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_provider_round_trips_versioned_json() -> None:
+    script = """
+import json
+import sys
+
+request = json.load(sys.stdin)
+json.dump({
+    "schema_version": 1,
+    "request_id": request["request_id"],
+    "decision_type": request["decision_type"],
+    "producer": {"name": "fixture", "version": "1"},
+    "output": {"answer": request["input"]["value"] * 2},
+}, sys.stdout)
+"""
+    providers = ExternalDecisionProviders(
+        {
+            "fixture": ExternalDecisionProviderConfig(
+                command=[sys.executable, "-c", script]
+            )
+        }
+    )
+
+    response = await providers.decide("fixture", _request())
+
+    assert response.producer.name == "fixture"
+    assert response.output == {"answer": 14}
+    assert response.as_of_session is None
+
+
+@pytest.mark.asyncio
+async def test_command_provider_rejects_non_json_output() -> None:
+    providers = ExternalDecisionProviders(
+        {
+            "fixture": ExternalDecisionProviderConfig(
+                command=[sys.executable, "-c", "print('not json')"]
+            )
+        }
+    )
+
+    with pytest.raises(ExternalDecisionError, match="invalid JSON"):
+        await providers.decide("fixture", _request())
+
+
+@pytest.mark.asyncio
+async def test_command_provider_enforces_timeout() -> None:
+    providers = ExternalDecisionProviders(
+        {
+            "fixture": ExternalDecisionProviderConfig(
+                command=[sys.executable, "-c", "import time; time.sleep(1)"],
+                timeout_seconds=0.01,
+            )
+        }
+    )
+
+    with pytest.raises(ExternalDecisionError, match="timed out"):
+        await providers.decide("fixture", _request())
+
+
+@pytest.mark.asyncio
+async def test_command_provider_stops_oversized_response() -> None:
+    providers = ExternalDecisionProviders(
+        {
+            "fixture": ExternalDecisionProviderConfig(
+                command=[sys.executable, "-c", "print('x' * 2048)"],
+                max_response_bytes=1024,
+            )
+        }
+    )
+
+    with pytest.raises(ExternalDecisionError, match="too large"):
+        await providers.decide("fixture", _request())
+
+
+@pytest.mark.asyncio
+async def test_provider_registry_checks_response_identity() -> None:
+    script = """
+import json
+import sys
+
+json.load(sys.stdin)
+json.dump({
+    "schema_version": 1,
+    "request_id": "wrong-request",
+    "decision_type": "test_decision",
+    "as_of_session": "2026-09-02",
+    "producer": {"name": "fixture", "version": "1"},
+    "output": {},
+}, sys.stdout)
+"""
+    providers = ExternalDecisionProviders(
+        {
+            "fixture": ExternalDecisionProviderConfig(
+                command=[sys.executable, "-c", script]
+            )
+        }
+    )
+
+    with pytest.raises(ExternalDecisionError, match="request_id mismatch"):
+        await providers.decide("fixture", _request())

--- a/tests/test_external_decisions.py
+++ b/tests/test_external_decisions.py
@@ -16,6 +16,7 @@ from thetagang.external_decisions import (
 
 def _request() -> ExternalDecisionRequest:
     return ExternalDecisionRequest(
+        schema_version=1,
         request_id="request-1",
         decision_type="test_decision",
         generated_at=datetime(2026, 9, 3, tzinfo=UTC),
@@ -27,6 +28,7 @@ def _request() -> ExternalDecisionRequest:
 def test_external_request_requires_timezone() -> None:
     with pytest.raises(ValueError, match="generated_at must include a timezone"):
         ExternalDecisionRequest(
+            schema_version=1,
             request_id="request-1",
             decision_type="test_decision",
             generated_at=datetime(2026, 9, 3),  # noqa: DTZ001
@@ -177,7 +179,7 @@ async def main():
         command=[sys.executable, '-c', scripts[failure]],
         max_response_bytes=1024, timeout_seconds=0.3 if failure != 'stdout' else 1,
     ))
-    request = ExternalDecisionRequest(request_id='test', decision_type='test',
+    request = ExternalDecisionRequest(schema_version=1, request_id='test', decision_type='test',
         generated_at=datetime.now(UTC), dry_run=True, input={})
     start = time.monotonic()
     task = asyncio.create_task(provider.decide(request))

--- a/tests/test_legacy_config.py
+++ b/tests/test_legacy_config.py
@@ -1,5 +1,6 @@
 from polyfactory.factories.pydantic_factory import ModelFactory
 
+from thetagang.config_models import TargetWeightPolicyConfig
 from thetagang.legacy_config import (
     AccountConfig,
     LegacyConfig,
@@ -51,6 +52,7 @@ class RegimeRebalanceConfigFactory(ModelFactory[RegimeRebalanceConfig]):
     deficit_rail_start = 0.06
     deficit_rail_stop = 0.03
     ratio_gate = None
+    target_weight_policy = TargetWeightPolicyConfig()
 
 
 class LegacyConfigFactory(ModelFactory[LegacyConfig]):

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -1144,6 +1144,7 @@ class TestPortfolioManager:
             {
                 "absolute_trend_state",
                 "regime_rebalance_state",
+                "target_weight_policy_state",
                 "volatility_weight_state",
             }
         )

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1,7 +1,7 @@
 import math
 from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -9,8 +9,13 @@ from ib_async import IB, AccountValue, Option, Stock
 
 import thetagang.portfolio_manager as pm_module
 import thetagang.strategies.regime_engine as regime_engine_module
+from thetagang.accounting import BrokerAccountSnapshot
 from thetagang.config import Config
 from thetagang.db import DataStore, ExecutionRecord
+from thetagang.external_decisions import (
+    ExternalDecisionRequest,
+    ExternalDecisionResponse,
+)
 from thetagang.legacy_config import (
     RatioGateConfig,
     RegimeRebalanceBaseEnum,
@@ -31,6 +36,7 @@ from thetagang.strategies.tail_hedge_state import (
     TailHedgeCohort,
     TailHedgeState,
 )
+from thetagang.target_weight_policy import TARGET_WEIGHT_POLICY_STATE_EVENT
 
 
 def _naive_utc(
@@ -49,6 +55,60 @@ def _naive_utc(
 
 REGIME_HISTORY_START = _naive_utc(2024, 1, 2)
 REGIME_SYMBOLS = ("AAA", "BBB")
+
+
+class _FixedTargetWeightProvider:
+    def __init__(
+        self,
+        multiplier: float,
+        symbols: tuple[str, ...] = ("AAA",),
+        expires_at: datetime | None = None,
+    ) -> None:
+        self.multiplier = multiplier
+        self.symbols = symbols
+        self.expires_at = expires_at
+        self.requests: list[ExternalDecisionRequest] = []
+
+    async def decide(
+        self, request: ExternalDecisionRequest
+    ) -> ExternalDecisionResponse:
+        self.requests.append(request)
+        sessions = request.input["market_data"]["sessions"]
+        return ExternalDecisionResponse(
+            request_id=request.request_id,
+            decision_type=request.decision_type,
+            as_of_session=sessions[-1],
+            expires_at=self.expires_at,
+            producer={"name": "fixture-policy", "version": "model-1"},
+            output={
+                "adjustments": {
+                    symbol: {
+                        "multiplier": self.multiplier,
+                        "reason": "test-signal",
+                    }
+                    for symbol in self.symbols
+                }
+            },
+        )
+
+
+class _FixedTailHarvestProvider:
+    def __init__(self, harvest: object) -> None:
+        self.harvest = harvest
+        self.requests: list[ExternalDecisionRequest] = []
+
+    async def decide(
+        self, request: ExternalDecisionRequest
+    ) -> ExternalDecisionResponse:
+        self.requests.append(request)
+        sessions = request.input["market_data"]["sessions"]
+        return ExternalDecisionResponse(
+            request_id=request.request_id,
+            decision_type=request.decision_type,
+            as_of_session=sessions[-1],
+            producer={"name": "fixture-harvest", "version": "policy-1"},
+            output={"harvest": self.harvest, "reason": "test-signal"},
+        )
 
 
 @pytest.fixture
@@ -440,6 +500,56 @@ def _volatility_weight(
         increase_smoothing_factor=increase_smoothing_factor,
         decrease_smoothing_factor=decrease_smoothing_factor,
     )
+
+
+def _target_weight_policy(
+    *,
+    symbols: tuple[str, ...] = ("AAA",),
+    min_multiplier: float = 0.8,
+    max_multiplier: float = 1.1,
+    clamp_to_volatility_bounds: bool = False,
+    market_symbols: dict[str, SimpleNamespace] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        enabled=True,
+        provider="fixture",
+        on_error="baseline",
+        max_signal_age_sessions=0,
+        max_total_weight=None,
+        market_data=SimpleNamespace(
+            lookback_days=3,
+            include_strategy_symbols=True,
+            symbols=market_symbols or {},
+        ),
+        symbols={
+            symbol: SimpleNamespace(
+                min_multiplier=min_multiplier,
+                max_multiplier=max_multiplier,
+                clamp_to_volatility_bounds=clamp_to_volatility_bounds,
+            )
+            for symbol in symbols
+        },
+    )
+
+
+def _target_weight_policy_context(
+    portfolio_manager,
+    *,
+    volatility_details: dict[str, dict[str, float]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "symbols": list(REGIME_SYMBOLS),
+        "symbol_configs": portfolio_manager.config.portfolio.symbols,
+        "volatility_details": volatility_details or {},
+        "account": BrokerAccountSnapshot(_regime_account_summary("1000")),
+        "regime_margin_usage": 1.0,
+        "total_value": 1000.0,
+        "excluded_value": 0.0,
+        "last_rebalance": None,
+        "current_positions": {"AAA": 4, "BBB": 5},
+        "current_values": {"AAA": 400.0, "BBB": 500.0},
+        "market_prices": {"AAA": 100.0, "BBB": 100.0},
+    }
 
 
 def _absolute_trend(
@@ -845,6 +955,274 @@ async def test_regime_rebalance_volatility_weight_restores_only_to_base_weight(
     )
 
     assert orders == []
+
+
+@pytest.mark.asyncio
+async def test_external_target_weight_policy_adjusts_post_volatility_target(
+    portfolio_manager_with_db, mocker
+):
+    portfolio_manager = portfolio_manager_with_db
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 0.10
+    regime_rebalance.choppiness_min = 0.0
+    regime_rebalance.efficiency_max = 1.0
+    regime_rebalance.target_weight_policy = _target_weight_policy(
+        market_symbols={"QQQ": SimpleNamespace(primary_exchange="NASDAQ")}
+    )
+    provider = _FixedTargetWeightProvider(0.8)
+    portfolio_manager.external_decisions.replace("fixture", provider)
+
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(
+        portfolio_manager,
+        mocker,
+        [100.0, 110.0, 100.0, 110.0],
+    )
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+        _regime_account_summary("400"),
+        _regime_stock_positions(aaa=2, bbb=2),
+    )
+
+    assert orders == [("AAA", "NYSE", -1)]
+    assert len(provider.requests) == 1
+    request_input = provider.requests[0].input
+    assert request_input["symbols"]["AAA"]["post_volatility_weight"] == 0.5
+    assert request_input["symbols"]["AAA"]["current_weight"] == 0.5
+    assert request_input["account"]["rebalance_base_value"] == 400.0
+    assert request_input["market_data"]["closes"] == {
+        "AAA": [100.0, 110.0, 100.0, 110.0],
+        "BBB": [100.0, 110.0, 100.0, 110.0],
+        "QQQ": [100.0, 110.0, 100.0, 110.0],
+    }
+    assert request_input["market_data"]["primary_exchanges"]["QQQ"] == "NASDAQ"
+    state = portfolio_manager.data_store.get_last_event_payload(
+        TARGET_WEIGHT_POLICY_STATE_EVENT
+    )
+    assert state["symbols"]["AAA"]["multiplier"] == pytest.approx(0.8)
+    assert state["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.4)
+
+
+@pytest.mark.asyncio
+async def test_external_target_weight_policy_can_target_all_cash(
+    portfolio_manager, mocker
+):
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.soft_band = 0.10
+    regime_rebalance.choppiness_min = 0.0
+    regime_rebalance.efficiency_max = 1.0
+    regime_rebalance.target_weight_policy = _target_weight_policy(
+        symbols=REGIME_SYMBOLS,
+        min_multiplier=0.0,
+        max_multiplier=1.0,
+    )
+    portfolio_manager.external_decisions.replace(
+        "fixture", _FixedTargetWeightProvider(0.0, REGIME_SYMBOLS)
+    )
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(
+        portfolio_manager,
+        mocker,
+        [100.0, 110.0, 100.0, 110.0],
+    )
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+
+    _, orders = await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+        _regime_account_summary("400"),
+        _regime_stock_positions(aaa=2, bbb=2),
+    )
+
+    assert orders == [("AAA", "NYSE", -2), ("BBB", "NYSE", -2)]
+
+
+@pytest.mark.asyncio
+async def test_external_target_weight_policy_reuses_decision_during_replanning(
+    portfolio_manager, mocker
+):
+    portfolio_manager.config.portfolio.symbols[
+        "AAA"
+    ].volatility_weight = _volatility_weight()
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.target_weight_policy = _target_weight_policy()
+    provider = _FixedTargetWeightProvider(1.07)
+    portfolio_manager.external_decisions.replace("fixture", provider)
+    history_dates = _required_regime_history_dates(4)
+    portfolio_manager.regime_engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            history_dates,
+            {
+                "AAA": [100.0, 101.0, 102.0, 103.0],
+                "BBB": [100.0, 100.0, 100.0, 100.0],
+            },
+        )
+    )
+    kwargs = _target_weight_policy_context(
+        portfolio_manager,
+        volatility_details={
+            "AAA": {
+                "base_weight": 0.5,
+                "effective_weight": 0.36,
+                "realized_vol": 0.44,
+            }
+        },
+    )
+
+    first, _ = await portfolio_manager.regime_engine._apply_target_weight_policy(
+        {"AAA": 0.36, "BBB": 0.45},
+        **kwargs,
+    )
+    second, _ = await portfolio_manager.regime_engine._apply_target_weight_policy(
+        {"AAA": 0.40, "BBB": 0.45},
+        **kwargs,
+    )
+    portfolio_manager.regime_engine.begin_run()
+    third, _ = await portfolio_manager.regime_engine._apply_target_weight_policy(
+        {"AAA": 0.36, "BBB": 0.45},
+        **kwargs,
+    )
+
+    assert first["AAA"] == pytest.approx(0.3852)
+    assert second["AAA"] == pytest.approx(0.428)
+    assert third["AAA"] == pytest.approx(0.3852)
+    assert len(provider.requests) == 2
+    symbol_input = provider.requests[0].input["symbols"]["AAA"]
+    assert symbol_input["volatility_weight"]["config"]["target_vol"] == 0.32
+    assert symbol_input["volatility_weight"]["calculation"]["realized_vol"] == 0.44
+    assert symbol_input["execution_constraints"] == {
+        "trading_allowed": True,
+        "rebalance_mode": "both",
+        "min_threshold_shares": None,
+        "min_threshold_amount": None,
+        "min_threshold_percent": None,
+        "min_threshold_percent_relative": None,
+    }
+    assert provider.requests[0].input["total_weight_constraint"] == {
+        "max_total_weight": None,
+        "effective_max_total_weight": 1.0,
+        "default_prevents_additional_leverage": True,
+    }
+
+
+def test_external_target_weight_policy_converts_naive_local_time_to_utc(
+    portfolio_manager,
+) -> None:
+    local_time = _naive_utc(2026, 9, 3, 10, 30)
+
+    assert portfolio_manager.regime_engine._as_utc(local_time) == (
+        local_time.astimezone(UTC)
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_target_weight_policy_checks_expiry_after_provider_returns(
+    portfolio_manager, mocker
+):
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.target_weight_policy = _target_weight_policy()
+    request_time = datetime(2026, 9, 3, 14, 30, tzinfo=UTC)
+    validation_time = request_time + timedelta(seconds=10)
+    provider = _FixedTargetWeightProvider(
+        1.07,
+        expires_at=request_time + timedelta(seconds=5),
+    )
+    portfolio_manager.external_decisions.replace("fixture", provider)
+    portfolio_manager.regime_engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            _required_regime_history_dates(4),
+            {
+                "AAA": [100.0, 101.0, 102.0, 103.0],
+                "BBB": [100.0, 100.0, 100.0, 100.0],
+            },
+        )
+    )
+    portfolio_manager.regime_engine._now = mocker.Mock(
+        side_effect=[request_time, validation_time]
+    )
+    baseline = {"AAA": 0.36, "BBB": 0.45}
+
+    (
+        adjusted,
+        details,
+    ) = await portfolio_manager.regime_engine._apply_target_weight_policy(
+        baseline,
+        **_target_weight_policy_context(portfolio_manager),
+    )
+
+    assert provider.requests[0].generated_at == request_time
+    assert adjusted == baseline
+    assert details["AAA"]["status"] == "baseline"
+    assert "signal has expired" in details["AAA"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_external_target_weight_policy_clamps_to_volatility_bounds(
+    portfolio_manager, mocker
+):
+    portfolio_manager.config.portfolio.symbols[
+        "AAA"
+    ].volatility_weight = _volatility_weight(max_weight=0.38)
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.target_weight_policy = _target_weight_policy(
+        clamp_to_volatility_bounds=True
+    )
+    provider = _FixedTargetWeightProvider(1.1)
+    portfolio_manager.external_decisions.replace("fixture", provider)
+    portfolio_manager.regime_engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            _required_regime_history_dates(4),
+            {
+                "AAA": [100.0, 101.0, 102.0, 103.0],
+                "BBB": [100.0, 100.0, 100.0, 100.0],
+            },
+        )
+    )
+
+    (
+        adjusted,
+        details,
+    ) = await portfolio_manager.regime_engine._apply_target_weight_policy(
+        {"AAA": 0.36, "BBB": 0.45},
+        **_target_weight_policy_context(portfolio_manager),
+    )
+
+    assert details["AAA"]["raw_weight"] == pytest.approx(0.396)
+    assert adjusted["AAA"] == pytest.approx(0.38)
+
+
+@pytest.mark.asyncio
+async def test_external_target_weight_policy_falls_back_on_invalid_signal(
+    portfolio_manager, mocker
+):
+    regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
+    regime_rebalance.target_weight_policy = _target_weight_policy()
+    portfolio_manager.external_decisions.replace(
+        "fixture", _FixedTargetWeightProvider(1.2)
+    )
+    portfolio_manager.regime_engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            _required_regime_history_dates(4),
+            {
+                "AAA": [100.0, 101.0, 102.0, 103.0],
+                "BBB": [100.0, 100.0, 100.0, 100.0],
+            },
+        )
+    )
+    baseline = {"AAA": 0.36, "BBB": 0.45}
+
+    (
+        adjusted,
+        details,
+    ) = await portfolio_manager.regime_engine._apply_target_weight_policy(
+        baseline,
+        **_target_weight_policy_context(portfolio_manager),
+    )
+
+    assert adjusted == baseline
+    assert details["AAA"]["status"] == "baseline"
+    assert details["AAA"]["multiplier"] == 1.0
+    assert details["AAA"]["risk_ready"] is False
+    assert "outside configured bounds" in details["AAA"]["error"]
 
 
 @pytest.mark.asyncio
@@ -1574,6 +1952,45 @@ async def test_absolute_trend_excludes_incomplete_bar(
     assert details["AAA"]["latest_session"] == str(required_dates[-1])
     assert details["AAA"]["latest_close"] == pytest.approx(90.0)
     assert details["AAA"]["risk_off"] is True
+
+
+@pytest.mark.asyncio
+async def test_regime_history_cache_keys_primary_exchange_overrides(mocker):
+    result = ([date(2024, 1, 2)], {"AAA": [100.0]})
+    fetcher = mocker.AsyncMock(return_value=result)
+    history_cache = RegimeHistoryCache(fetcher)
+
+    assert await history_cache.get(["AAA"], 20, 0) == result
+    assert await history_cache.get(["AAA"], 20, 0) == result
+
+    primary_exchanges = {"AAA": "NYSE"}
+    assert (
+        await history_cache.get(
+            ["AAA"],
+            20,
+            0,
+            primary_exchanges=primary_exchanges,
+        )
+        == result
+    )
+    assert (
+        await history_cache.get(
+            ["AAA"],
+            20,
+            0,
+            primary_exchanges=primary_exchanges,
+        )
+        == result
+    )
+
+    assert fetcher.await_count == 2
+    fetcher.assert_any_await(["AAA"], 20, 0)
+    fetcher.assert_any_await(
+        ["AAA"],
+        20,
+        0,
+        primary_exchanges=primary_exchanges,
+    )
 
 
 @pytest.mark.asyncio
@@ -3990,8 +4407,10 @@ def _configure_tail_harvest(
 ) -> None:
     portfolio_manager.config.strategies.tail_hedge = SimpleNamespace(
         enabled=True,
+        annual_budget=0.005,
         harvest_trigger_weight=0.05,
         harvest_target_weight=0.03,
+        harvest_decision=SimpleNamespace(enabled=False),
         targets=[_tail_target(symbol) for symbol in symbols],
     )
     _enable_tail_hedge_stage(portfolio_manager)
@@ -4029,6 +4448,243 @@ def _set_tail_quotes(portfolio_manager, mocker, prices: dict[int, float]) -> Non
         return _option_ticker(prices[int(contract.conId)])
 
     portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock(side_effect=quote)
+
+
+def _enable_external_tail_harvest(
+    portfolio_manager,
+    provider: _FixedTailHarvestProvider,
+) -> None:
+    portfolio_manager.config.strategies.tail_hedge.harvest_decision = SimpleNamespace(
+        enabled=True,
+        provider="tail-fixture",
+        on_error="baseline",
+        max_signal_age_sessions=0,
+        market_data=SimpleNamespace(
+            lookback_days=3,
+            include_strategy_symbols=True,
+            symbols={},
+        ),
+    )
+    portfolio_manager.config.strategies.tail_hedge.targets = [
+        SimpleNamespace(
+            symbol="BBB",
+            budget_weight=1.0,
+            entries_per_year=6,
+            entry_gate="vix",
+            entry_vix_max=20.0,
+            target_dte=180,
+            min_dte=120,
+            max_dte=240,
+            exit_dte=30,
+            minimum_open_interest=50,
+            minimum_bid=0.01,
+            max_bid_ask_ratio=0.5,
+            max_premium_ratio=0.05,
+            catastrophe_drawdowns=[0.4, 0.5, 0.6],
+        )
+    ]
+    portfolio_manager.external_decisions.replace("tail-fixture", provider)
+
+
+def _mock_tail_harvest_history(portfolio_manager, mocker) -> list[date]:
+    sessions = [date(2026, 8, 31), date(2026, 9, 1), date(2026, 9, 2)]
+    mocker.patch.object(
+        portfolio_manager.regime_engine,
+        "_get_regime_aligned_closes",
+        new=mocker.AsyncMock(return_value=(sessions, {"BBB": [100.0, 92.0, 85.0]})),
+    )
+    return sessions
+
+
+def _tail_harvest_regime_summary() -> list[dict[str, object]]:
+    return [
+        {
+            "symbol": "BBB",
+            "current_shares": 4,
+            "current_value": 340.0,
+            "current_weight": 0.17,
+            "target_weight": 0.50,
+            "target_value": 1_000.0,
+            "target_shares": 11,
+            "volatility_weight": {"effective_weight": 0.50},
+            "target_weight_policy": None,
+            "absolute_trend": {"risk_on": False},
+        }
+    ]
+
+
+def _prepare_external_tail_harvest(
+    portfolio_manager,
+    mocker,
+    *,
+    provider: _FixedTailHarvestProvider,
+    con_id: int,
+    unrealized_pnl: float | None = None,
+) -> tuple[TailHedgeState, list[date]]:
+    _configure_tail_harvest(portfolio_manager, "BBB")
+    _enable_external_tail_harvest(portfolio_manager, provider)
+    sessions = _mock_tail_harvest_history(portfolio_manager, mocker)
+    tail_put = _option_position(
+        "BBB",
+        1,
+        market_value=120.0,
+        right="P",
+        expiry="20261120",
+        con_id=con_id,
+        average_cost=50.0,
+        unrealized_pnl=unrealized_pnl,
+    )
+    tail_put.contract.multiplier = "100"
+    payload = _tail_state(symbol="BBB", puts=[tail_put])
+    _save_tail_state(portfolio_manager, payload)
+    _set_live_tail_positions(portfolio_manager, [tail_put])
+    return payload, sessions
+
+
+@pytest.mark.parametrize(
+    ("on_error", "expected_harvest", "expected_status"),
+    [("baseline", True, "baseline"), ("skip", False, "skipped")],
+)
+def test_external_tail_harvest_nonfatal_failure_policy(
+    portfolio_manager,
+    on_error: str,
+    expected_harvest: bool,
+    expected_status: str,
+) -> None:
+    harvest, detail = portfolio_manager.regime_engine._tail_harvest_decision_fallback(
+        policy=SimpleNamespace(on_error=on_error, provider="tail-fixture"),
+        error="provider unavailable",
+    )
+
+    assert harvest is expected_harvest
+    assert detail["status"] == expected_status
+    assert detail["error"] == "provider unavailable"
+
+
+def test_external_tail_harvest_abort_failure_policy(portfolio_manager) -> None:
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        portfolio_manager.regime_engine._tail_harvest_decision_fallback(
+            policy=SimpleNamespace(on_error="abort", provider="tail-fixture"),
+            error="provider unavailable",
+        )
+
+
+@pytest.mark.asyncio
+async def test_external_tail_harvest_policy_can_veto_eligible_harvest(
+    portfolio_manager_with_db,
+    mocker,
+) -> None:
+    portfolio_manager = portfolio_manager_with_db
+    provider = _FixedTailHarvestProvider(False)
+    payload, sessions = _prepare_external_tail_harvest(
+        portfolio_manager,
+        mocker,
+        provider=provider,
+        con_id=799,
+        unrealized_pnl=70.0,
+    )
+    _set_tail_quotes(portfolio_manager, mocker, {799: 1.20})
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 7)],
+        net_liquidation=2_000.0,
+        market_prices={"BBB": 85.0},
+        regime_summary=_tail_harvest_regime_summary(),
+        hard_underweight_symbols={"BBB"},
+        cohorts=payload.open_cohorts,
+    )
+
+    assert orders == [("BBB", "NYSE", 7)]
+    assert portfolio_manager.orders.records() == []
+    assert len(provider.requests) == 1
+    request = provider.requests[0]
+    assert request.decision_type == "tail_hedge_harvest"
+    assert request.input["market_data"] == {
+        "source": "ibkr",
+        "timeframe": "1 day",
+        "what_to_show": "TRADES",
+        "regular_trading_hours_only": True,
+        "sessions": [session.isoformat() for session in sessions],
+        "closes": {"BBB": [100.0, 92.0, 85.0]},
+        "primary_exchanges": {"BBB": "NYSE"},
+    }
+    underlying = request.input["underlyings"]["BBB"]
+    assert underlying["current_shares"] == pytest.approx(4.0)
+    assert underlying["current_weight"] == pytest.approx(0.17)
+    assert underlying["approved_buy_shares"] == 7
+    assert underlying["broker_position"] == {
+        "shares": 0.0,
+        "market_value": 0,
+        "average_cost_per_share": None,
+        "unrealized_pnl": 0,
+        "realized_pnl": 0,
+    }
+    assert underlying["target_modifiers"]["absolute_trend"] == {"risk_on": False}
+    hedge = request.input["hedge_positions"][0]
+    assert hedge["state_owned_quantity"] == 1
+    assert hedge["live_position_quantity"] == pytest.approx(1.0)
+    assert hedge["state_owned_unrealized_pnl"] == pytest.approx(70.0)
+    assert hedge["quoted_limit_price"] == pytest.approx(1.20)
+    assert hedge["host_candidate"] is True
+    assert hedge["candidate"]["net_proceeds_per_contract"] == pytest.approx(120.0)
+    assert request.input["host_constraints"] == {
+        "baseline_band_triggered": True,
+        "requires_approved_same_symbol_hard_underweight_buy": True,
+        "state_owned_active_profitable_puts_only": True,
+        "host_selects_contracts_quantities_and_limit_prices": True,
+    }
+    assert request.input["opportunity"]["sale_budget"] == pytest.approx(63.6)
+    assert request.input["opportunity"]["planned_sales"] == [
+        {
+            "entry_id": "BBB-tail-799",
+            "symbol": "BBB",
+            "con_id": 799,
+            "expiration": "20261120",
+            "quantity": 1,
+            "limit_price": 1.2,
+            "estimated_gross_proceeds": 120.0,
+            "estimated_fees": 0.0,
+            "estimated_net_proceeds": 120.0,
+        }
+    ]
+    store = portfolio_manager.regime_engine._tail_state_store
+    assert store is not None
+    assert store.load().open_cohorts[0].pending_recovery_quantity is None
+
+
+@pytest.mark.asyncio
+async def test_external_tail_harvest_approval_is_revalidated_before_order(
+    portfolio_manager_with_db,
+    mocker,
+) -> None:
+    portfolio_manager = portfolio_manager_with_db
+    provider = _FixedTailHarvestProvider(True)
+    payload, _ = _prepare_external_tail_harvest(
+        portfolio_manager,
+        mocker,
+        provider=provider,
+        con_id=800,
+    )
+    portfolio_manager.ibkr.get_ticker_for_contract = mocker.AsyncMock(
+        side_effect=[_option_ticker(1.20), _option_ticker(0.40)]
+    )
+
+    orders = await portfolio_manager.regime_engine._apply_tail_harvest(
+        orders=[("BBB", "NYSE", 7)],
+        net_liquidation=2_000.0,
+        market_prices={"BBB": 85.0},
+        regime_summary=_tail_harvest_regime_summary(),
+        hard_underweight_symbols={"BBB"},
+        cohorts=payload.open_cohorts,
+    )
+
+    assert orders == [("BBB", "NYSE", 7)]
+    assert len(provider.requests) == 1
+    assert portfolio_manager.ibkr.get_ticker_for_contract.await_count == 2
+    assert portfolio_manager.orders.records() == []
+    store = portfolio_manager.regime_engine._tail_state_store
+    assert store is not None
+    assert store.load().open_cohorts[0].pending_recovery_quantity is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -93,8 +93,9 @@ class _FixedTargetWeightProvider:
 
 
 class _FixedTailHarvestProvider:
-    def __init__(self, harvest: object) -> None:
+    def __init__(self, harvest: object, expires_at: datetime | None = None) -> None:
         self.harvest = harvest
+        self.expires_at = expires_at
         self.requests: list[ExternalDecisionRequest] = []
 
     async def decide(
@@ -106,6 +107,7 @@ class _FixedTailHarvestProvider:
             request_id=request.request_id,
             decision_type=request.decision_type,
             as_of_session=sessions[-1],
+            expires_at=self.expires_at,
             producer={"name": "fixture-harvest", "version": "policy-1"},
             output={"harvest": self.harvest, "reason": "test-signal"},
         )
@@ -1156,6 +1158,114 @@ async def test_external_target_weight_policy_checks_expiry_after_provider_return
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("on_error", ["baseline", "abort"])
+async def test_cached_target_weight_decision_expires_during_replanning(
+    portfolio_manager: Any, mocker: Any, on_error: str
+) -> None:
+    engine = portfolio_manager.regime_engine
+    policy = _target_weight_policy()
+    policy.on_error = on_error
+    portfolio_manager.config.strategies.regime_rebalance.target_weight_policy = policy
+    now = datetime(2026, 9, 3, 14, 30, tzinfo=UTC)
+    engine._now = mocker.Mock(return_value=now)
+    provider = _FixedTargetWeightProvider(1.07, expires_at=now + timedelta(seconds=5))
+    portfolio_manager.external_decisions.replace("fixture", provider)
+    engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            _required_regime_history_dates(4),
+            {"AAA": [100.0] * 4, "BBB": [100.0] * 4},
+        )
+    )
+    baseline = {"AAA": 0.36, "BBB": 0.45}
+    context = _target_weight_policy_context(portfolio_manager)
+    first, _ = await engine._apply_target_weight_policy(baseline, **context)
+    assert first["AAA"] == pytest.approx(0.3852)
+
+    engine._now.return_value = now + timedelta(seconds=5)
+    if on_error == "abort":
+        with pytest.raises(RuntimeError, match="expired"):
+            await engine._apply_target_weight_policy(baseline, **context)
+    else:
+        second, details = await engine._apply_target_weight_policy(baseline, **context)
+        assert second == baseline
+        assert details["AAA"]["risk_ready"] is False
+        assert "expired" in details["AAA"]["error"]
+    assert len(provider.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_target_weight_policy_preserves_harvest_eligibility(
+    portfolio_manager: Any, mocker: Any
+) -> None:
+    regime = portfolio_manager.config.strategies.regime_rebalance
+    regime.hard_band = 0.4
+    regime.target_weight_policy = _target_weight_policy(symbols=("BBB",))
+    regime.target_weight_policy.enabled = False
+    _mock_regime_tickers(portfolio_manager, mocker)
+    _mock_regime_history(portfolio_manager, mocker, [100.0, 110.0, 100.0, 110.0])
+    portfolio_manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+    apply_harvest = mocker.patch.object(
+        portfolio_manager.regime_engine,
+        "_apply_tail_harvest",
+        new=mocker.AsyncMock(return_value=[]),
+    )
+
+    await portfolio_manager.regime_engine.check_regime_rebalance_positions(
+        _regime_account_summary(),
+        _regime_stock_positions(),
+    )
+
+    assert apply_harvest.call_args.kwargs["hard_underweight_symbols"] == {"BBB"}
+
+
+@pytest.mark.asyncio
+async def test_exchange_override_history_does_not_mix_persisted_listings(
+    portfolio_manager_with_db: PortfolioManager, mocker: Any, monkeypatch: Any
+) -> None:
+    manager = portfolio_manager_with_db
+    _disable_regime_history_retry_delay(monkeypatch)
+    dates = _set_required_regime_history_dates(manager, monkeypatch, required_points=4)
+    _seed_regime_history_cache(manager, [100.0] * 4, symbols=("AAA",))
+    bars = _regime_bars([200.0] * 4)
+    manager.ibkr.ib.reqHistoricalDataAsync = mocker.AsyncMock(return_value=bars)
+
+    _, prices = await manager.regime_engine._get_regime_aligned_closes(
+        ["AAA"],
+        3,
+        0,
+        primary_exchanges={"AAA": "NASDAQ"},
+    )
+    assert prices == {"AAA": [200.0] * 4}
+
+    manager.ibkr.ib.reqHistoricalDataAsync.return_value = []
+    # Exercise the persistent fallback, bypassing the per-plan memory cache.
+    _, default_prices = await manager.regime_engine._get_regime_aligned_closes(
+        ["AAA"],
+        3,
+        0,
+    )
+    (
+        cached_dates,
+        override_prices,
+    ) = await manager.regime_engine._get_regime_aligned_closes(
+        ["AAA"],
+        3,
+        0,
+        primary_exchanges={"AAA": "NASDAQ"},
+    )
+    assert default_prices == {"AAA": [100.0] * 4}
+    assert cached_dates == dates
+    assert override_prices == prices
+    with pytest.raises(ValueError, match="aligned history|fresh historical data"):
+        await manager.regime_engine._get_regime_aligned_closes(
+            ["AAA"],
+            3,
+            0,
+            primary_exchanges={"AAA": "ARCA"},
+        )
+
+
+@pytest.mark.asyncio
 async def test_external_target_weight_policy_clamps_to_volatility_bounds(
     portfolio_manager, mocker
 ):
@@ -1188,6 +1298,42 @@ async def test_external_target_weight_policy_clamps_to_volatility_bounds(
 
     assert details["AAA"]["raw_weight"] == pytest.approx(0.396)
     assert adjusted["AAA"] == pytest.approx(0.38)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("clamp", [True, False])
+async def test_external_target_weight_policy_caps_before_checking_final_weight(
+    portfolio_manager: Any, mocker: Any, clamp: bool
+) -> None:
+    manager = portfolio_manager
+    manager.config.portfolio.symbols["AAA"].volatility_weight = _volatility_weight(
+        max_weight=1.0
+    )
+    manager.config.strategies.regime_rebalance.target_weight_policy = (
+        _target_weight_policy(clamp_to_volatility_bounds=clamp)
+    )
+    manager.external_decisions.replace("fixture", _FixedTargetWeightProvider(1.1))
+    manager.regime_engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            _required_regime_history_dates(4),
+            {"AAA": [100.0] * 4, "BBB": [100.0] * 4},
+        )
+    )
+    baseline = {"AAA": 0.95, "BBB": 0.0}
+
+    weights, details = await manager.regime_engine._apply_target_weight_policy(
+        baseline,
+        **_target_weight_policy_context(manager),
+    )
+
+    if clamp:
+        assert weights == {"AAA": 1.0, "BBB": 0.0}
+        assert details["AAA"]["raw_weight"] == pytest.approx(1.045)
+        assert details["AAA"]["status"] == "applied"
+    else:
+        assert weights == baseline
+        assert details["AAA"]["status"] == "baseline"
+        assert "invalid weight" in details["AAA"]["error"]
 
 
 @pytest.mark.asyncio
@@ -4685,6 +4831,56 @@ async def test_external_tail_harvest_approval_is_revalidated_before_order(
     store = portfolio_manager.regime_engine._tail_state_store
     assert store is not None
     assert store.load().open_cohorts[0].pending_recovery_quantity is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("on_error", ["baseline", "skip", "abort"])
+async def test_tail_harvest_approval_expiring_during_requote_uses_failure_policy(
+    portfolio_manager_with_db: Any, mocker: Any, on_error: str
+) -> None:
+    manager = portfolio_manager_with_db
+    engine = manager.regime_engine
+    now = datetime(2026, 9, 3, 14, 30, tzinfo=UTC)
+    provider = _FixedTailHarvestProvider(True, expires_at=now + timedelta(seconds=5))
+    payload, _ = _prepare_external_tail_harvest(
+        manager,
+        mocker,
+        provider=provider,
+        con_id=802,
+    )
+    manager.config.strategies.tail_hedge.harvest_decision.on_error = on_error
+    engine._now = mocker.Mock(return_value=now)
+    quotes = 0
+
+    async def quote(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        nonlocal quotes
+        quotes += 1
+        if quotes == 2:
+            engine._now.return_value = now + timedelta(seconds=5)
+        return _option_ticker(1.20)
+
+    manager.ibkr.get_ticker_for_contract = mocker.AsyncMock(side_effect=quote)
+    kwargs = {
+        "orders": [("BBB", "NYSE", 7)],
+        "net_liquidation": 2_000.0,
+        "market_prices": {"BBB": 85.0},
+        "regime_summary": _tail_harvest_regime_summary(),
+        "hard_underweight_symbols": {"BBB"},
+        "cohorts": payload.open_cohorts,
+    }
+    if on_error == "abort":
+        with pytest.raises(RuntimeError, match="expired"):
+            await engine._apply_tail_harvest(**kwargs)
+    else:
+        await engine._apply_tail_harvest(**kwargs)
+
+    assert len(provider.requests) == 1
+    assert quotes == 2
+    assert bool(manager.orders.records()) is (on_error == "baseline")
+    state = engine._tail_state_store.load()
+    assert (state.open_cohorts[0].pending_recovery_quantity is not None) is (
+        on_error == "baseline"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -511,6 +511,8 @@ def _target_weight_policy(
     symbols: tuple[str, ...] = ("AAA",),
     min_multiplier: float = 0.8,
     max_multiplier: float = 1.1,
+    min_target_weight: float | None = None,
+    max_target_weight: float | None = None,
     clamp_to_volatility_bounds: bool = False,
     market_symbols: dict[str, SimpleNamespace] | None = None,
 ) -> SimpleNamespace:
@@ -529,6 +531,8 @@ def _target_weight_policy(
             symbol: SimpleNamespace(
                 min_multiplier=min_multiplier,
                 max_multiplier=max_multiplier,
+                min_target_weight=min_target_weight,
+                max_target_weight=max_target_weight,
                 clamp_to_volatility_bounds=clamp_to_volatility_bounds,
             )
             for symbol in symbols
@@ -1038,6 +1042,68 @@ async def test_external_target_weight_policy_can_target_all_cash(
     )
 
     assert orders == [("AAA", "NYSE", -2), ("BBB", "NYSE", -2)]
+
+
+@pytest.mark.asyncio
+async def test_model_target_bounds_preserve_smoothing_capital_base_and_trend(
+    portfolio_manager_with_db: Any, mocker: Any
+) -> None:
+    manager = portfolio_manager_with_db
+    manager.config.runtime.account.margin_usage = 1.25
+    regime = manager.config.strategies.regime_rebalance
+    regime.weight_base = RegimeRebalanceBaseEnum.net_liq_ex_options
+    regime.target_weight_policy = _target_weight_policy(
+        min_multiplier=0.5,
+        max_multiplier=1.2,
+        min_target_weight=0.20,
+        max_target_weight=0.55,
+        clamp_to_volatility_bounds=False,
+    )
+    symbol_config = manager.config.portfolio.symbols["AAA"]
+    symbol_config.volatility_weight = _volatility_weight(
+        target_vol=0.01, min_weight=0.25, max_weight=0.5, smoothing_factor=0.5
+    )
+    symbol_config.absolute_trend = _absolute_trend(
+        lookback_days=3, risk_off_multiplier=0.25
+    )
+    provider = _FixedTargetWeightProvider(0.5)
+    manager.external_decisions.replace("fixture", provider)
+    _mock_regime_tickers(manager, mocker)
+    _mock_regime_histories(
+        manager,
+        mocker,
+        {"AAA": [100.0, 100.0, 100.0, 90.0], "BBB": [100.0] * 4},
+    )
+    manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
+    positions = _regime_stock_positions(aaa=2, bbb=2)
+    positions["AAA"].append(_option_position("AAA", 1, market_value=200.0))
+
+    await manager.regime_engine.check_regime_rebalance_positions(
+        _regime_account_summary("2000"), positions
+    )
+
+    request = provider.requests[0].input
+    assert request["account"]["rebalance_base_value"] == pytest.approx(2250.0)
+    assert request["adjustment_constraints"]["AAA"] == {
+        "min_multiplier": 0.5,
+        "max_multiplier": 1.2,
+        "min_target_weight": 0.20,
+        "max_target_weight": 0.55,
+        "clamp_to_volatility_bounds": False,
+    }
+    # Volatility still smooths 50% toward its 25% floor, producing 37.5%.
+    volatility = manager.data_store.get_last_event_payload("volatility_weight_state")
+    assert volatility["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.375)
+    assert volatility["symbols"]["AAA"]["smoothing_factor"] == 0.5
+    assert request["symbols"]["AAA"]["post_volatility_weight"] == pytest.approx(0.375)
+    policy = manager.data_store.get_last_event_payload(TARGET_WEIGHT_POLICY_STATE_EVENT)
+    assert policy["symbols"]["AAA"]["raw_weight"] == pytest.approx(0.1875)
+    assert policy["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.20)
+    trend = manager.data_store.get_last_event_payload("absolute_trend_state")
+    assert trend["symbols"]["AAA"]["pre_trend_target"] == pytest.approx(0.20)
+    assert trend["symbols"]["AAA"]["final_target"] == pytest.approx(0.05)
+    assert symbol_config.volatility_weight.min_weight == 0.25
+    assert symbol_config.volatility_weight.smoothing_factor == 0.5
 
 
 @pytest.mark.asyncio

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -75,6 +75,7 @@ class _FixedTargetWeightProvider:
         self.requests.append(request)
         sessions = request.input["market_data"]["sessions"]
         return ExternalDecisionResponse(
+            schema_version=1,
             request_id=request.request_id,
             decision_type=request.decision_type,
             as_of_session=sessions[-1],
@@ -104,6 +105,7 @@ class _FixedTailHarvestProvider:
         self.requests.append(request)
         sessions = request.input["market_data"]["sessions"]
         return ExternalDecisionResponse(
+            schema_version=1,
             request_id=request.request_id,
             decision_type=request.decision_type,
             as_of_session=sessions[-1],
@@ -1114,6 +1116,56 @@ def test_external_target_weight_policy_converts_naive_local_time_to_utc(
     assert portfolio_manager.regime_engine._as_utc(local_time) == (
         local_time.astimezone(UTC)
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("on_error", ["baseline", "abort"])
+@pytest.mark.parametrize("initially_accepted", [False, True])
+async def test_rejected_target_weights_stay_rejected_until_next_run(
+    portfolio_manager: Any,
+    mocker: Any,
+    on_error: str,
+    initially_accepted: bool,
+) -> None:
+    engine = portfolio_manager.regime_engine
+    policy = _target_weight_policy()
+    policy.on_error = on_error
+    portfolio_manager.config.strategies.regime_rebalance.target_weight_policy = policy
+    provider = _FixedTargetWeightProvider(1.1)
+    portfolio_manager.external_decisions.replace("fixture", provider)
+    engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            _required_regime_history_dates(4),
+            {"AAA": [100.0] * 4, "BBB": [100.0] * 4},
+        )
+    )
+    context = _target_weight_policy_context(portfolio_manager)
+    baseline = {"AAA": 0.4, "BBB": 0.5}
+    if initially_accepted:
+        weights, _ = await engine._apply_target_weight_policy(baseline, **context)
+        assert weights["AAA"] == pytest.approx(0.44)
+
+    # Reject the cached multiplier when its targets exceed the exposure ceiling.
+    # A later post-fill replan must retain that failure even if the new baseline
+    # would make the same multiplier affordable again.
+    for current_baseline in ({"AAA": 0.5, "BBB": 0.5}, baseline):
+        if on_error == "abort":
+            with pytest.raises(RuntimeError, match="permitted total weight"):
+                await engine._apply_target_weight_policy(current_baseline, **context)
+        else:
+            weights, details = await engine._apply_target_weight_policy(
+                current_baseline, **context
+            )
+            assert weights == current_baseline
+            assert details["AAA"]["status"] == "baseline"
+            assert details["AAA"]["risk_ready"] is False
+    assert len(provider.requests) == 1
+
+    engine.begin_run()
+    weights, details = await engine._apply_target_weight_policy(baseline, **context)
+    assert weights["AAA"] == pytest.approx(0.44)
+    assert details["AAA"]["risk_ready"] is True
+    assert len(provider.requests) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_tail_harvest_decision.py
+++ b/tests/test_tail_harvest_decision.py
@@ -1,0 +1,99 @@
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from thetagang.config_models import TailHarvestDecisionConfig
+from thetagang.external_decisions import (
+    ExternalDecisionError,
+    ExternalDecisionResponse,
+)
+from thetagang.tail_harvest_decision import validate_tail_harvest_response
+
+
+def _policy() -> TailHarvestDecisionConfig:
+    return TailHarvestDecisionConfig(enabled=True, provider="fixture")
+
+
+def _response(
+    *,
+    harvest: object = True,
+    as_of_session: date | None = date(2026, 9, 2),
+) -> ExternalDecisionResponse:
+    return ExternalDecisionResponse(
+        request_id="request-1",
+        decision_type="tail_hedge_harvest",
+        as_of_session=as_of_session,
+        producer={"name": "fixture", "version": "1"},
+        output={"harvest": harvest, "reason": "test"},
+    )
+
+
+@pytest.mark.parametrize("harvest", [True, False])
+def test_tail_harvest_response_accepts_boolean_decision(harvest: bool) -> None:
+    output = validate_tail_harvest_response(
+        _response(harvest=harvest),
+        policy=_policy(),
+        history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+        now=datetime(2026, 9, 3, tzinfo=UTC),
+    )
+
+    assert output.harvest is harvest
+
+
+@pytest.mark.parametrize("harvest", [1, 0, "true", None])
+def test_tail_harvest_response_rejects_non_boolean_decision(
+    harvest: object,
+) -> None:
+    with pytest.raises(ExternalDecisionError, match="invalid harvest"):
+        validate_tail_harvest_response(
+            _response(harvest=harvest),
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+def test_tail_harvest_response_rejects_stale_session() -> None:
+    with pytest.raises(ExternalDecisionError, match="stale"):
+        validate_tail_harvest_response(
+            _response(as_of_session=date(2026, 9, 1)),
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+def test_tail_harvest_response_requires_market_session() -> None:
+    with pytest.raises(ExternalDecisionError, match="requires as_of_session"):
+        validate_tail_harvest_response(
+            _response(as_of_session=None),
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+def test_tail_harvest_response_rejects_expired_decision() -> None:
+    response = _response()
+    response.expires_at = datetime(2026, 9, 3, tzinfo=UTC) - timedelta(seconds=1)
+
+    with pytest.raises(ExternalDecisionError, match="expired"):
+        validate_tail_harvest_response(
+            response,
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+def test_tail_harvest_response_rejects_unknown_output_fields() -> None:
+    response = _response()
+    response.output["quantity"] = 2
+
+    with pytest.raises(ExternalDecisionError, match="invalid output"):
+        validate_tail_harvest_response(
+            response,
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )

--- a/tests/test_tail_harvest_decision.py
+++ b/tests/test_tail_harvest_decision.py
@@ -44,7 +44,7 @@ def test_tail_harvest_response_accepts_boolean_decision(harvest: bool) -> None:
 def test_tail_harvest_response_rejects_non_boolean_decision(
     harvest: object,
 ) -> None:
-    with pytest.raises(ExternalDecisionError, match="invalid harvest"):
+    with pytest.raises(ExternalDecisionError, match="invalid output"):
         validate_tail_harvest_response(
             _response(harvest=harvest),
             policy=_policy(),

--- a/tests/test_tail_harvest_decision.py
+++ b/tests/test_tail_harvest_decision.py
@@ -20,6 +20,7 @@ def _response(
     as_of_session: date | None = date(2026, 9, 2),
 ) -> ExternalDecisionResponse:
     return ExternalDecisionResponse(
+        schema_version=1,
         request_id="request-1",
         decision_type="tail_hedge_harvest",
         as_of_session=as_of_session,

--- a/tests/test_target_weight_policy.py
+++ b/tests/test_target_weight_policy.py
@@ -7,7 +7,11 @@ from thetagang.external_decisions import (
     ExternalDecisionError,
     ExternalDecisionResponse,
 )
-from thetagang.target_weight_policy import validate_target_weight_response
+from thetagang.target_weight_policy import (
+    TargetWeightMultiplier,
+    apply_target_weight_adjustments,
+    validate_target_weight_response,
+)
 
 
 def _policy() -> TargetWeightPolicyConfig:
@@ -109,4 +113,91 @@ def test_target_weight_response_requires_configured_symbol_set() -> None:
             policy=_policy(),
             history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
             now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+@pytest.mark.parametrize(
+    ("symbol", "baseline", "multiplier", "minimum", "maximum", "clamp", "expected"),
+    [
+        ("IBIT", 0.1875, 0.50, 0.10, 0.36, False, 0.10),
+        ("IBIT", 0.30, 1.20, 0.10, 0.36, False, 0.36),
+        ("TQQQ", 0.25, 0.50, 0.15, 0.55, False, 0.15),
+        ("TQQQ", 0.50, 1.20, 0.15, 0.55, False, 0.55),
+        ("IBIT", 0.1875, 0.50, 0.10, None, False, 0.10),
+        ("IBIT", 0.30, 1.20, None, 0.36, False, 0.36),
+        ("IBIT", 0.1875, 0.50, None, None, False, 0.09375),
+        ("IBIT", 0.1875, 0.50, None, None, True, 0.1875),
+        ("IBIT", 0.1875, 0.50, 0.10, 0.36, True, 0.1875),
+        ("IBIT", 0.30, 1.20, 0.10, 0.36, True, 0.30),
+        ("IBIT", 0.1875, 0.50, 0.20, 0.28, True, 0.20),
+        ("IBIT", 0.30, 1.20, 0.20, 0.28, True, 0.28),
+        ("IBIT", 0.30, 1.20, 0.0, 0.0, False, 0.0),
+        ("TQQQ", 0.95, 1.20, None, 0.55, False, 0.55),
+    ],
+)
+def test_target_bounds_apply_after_multiplication(
+    symbol: str,
+    baseline: float,
+    multiplier: float,
+    minimum: float | None,
+    maximum: float | None,
+    clamp: bool,
+    expected: float,
+) -> None:
+    policy = TargetWeightPolicyConfig(
+        symbols={
+            symbol: {
+                "min_multiplier": 0.50,
+                "max_multiplier": 1.20,
+                "min_target_weight": minimum,
+                "max_target_weight": maximum,
+                "clamp_to_volatility_bounds": clamp,
+            }
+        }
+    )
+    original_weights = {symbol: baseline}
+    weights, details = apply_target_weight_adjustments(
+        original_weights,
+        {symbol: TargetWeightMultiplier(multiplier=multiplier)},
+        policy=policy,
+        volatility_bounds={symbol: (0.1875, 0.30)} if clamp else {},
+        eps=1e-8,
+    )
+    assert weights[symbol] == pytest.approx(expected)
+    assert details[symbol]["raw_weight"] == pytest.approx(baseline * multiplier)
+    assert original_weights == {symbol: baseline}
+
+
+@pytest.mark.parametrize(
+    "bounds", [{"min_target_weight": 0.4}, {"max_target_weight": 0.1}]
+)
+def test_target_application_rejects_disjoint_clamps(bounds: dict[str, float]) -> None:
+    policy = TargetWeightPolicyConfig(symbols={"IBIT": bounds})
+    with pytest.raises(ExternalDecisionError, match="do not overlap volatility bounds"):
+        apply_target_weight_adjustments(
+            {"IBIT": 0.25},
+            {"IBIT": TargetWeightMultiplier(multiplier=1.0)},
+            policy=policy,
+            volatility_bounds={"IBIT": (0.1875, 0.30)},
+            eps=1e-8,
+        )
+
+
+def test_target_floors_cannot_bypass_total_exposure_limit() -> None:
+    policy = TargetWeightPolicyConfig(
+        symbols={
+            symbol: {"min_target_weight": 0.6, "clamp_to_volatility_bounds": False}
+            for symbol in ("TQQQ", "IBIT")
+        }
+    )
+    with pytest.raises(ExternalDecisionError, match="permitted total weight"):
+        apply_target_weight_adjustments(
+            {"TQQQ": 0.4, "IBIT": 0.4},
+            {
+                symbol: TargetWeightMultiplier(multiplier=1.0)
+                for symbol in policy.symbols
+            },
+            policy=policy,
+            volatility_bounds={},
+            eps=1e-8,
         )

--- a/tests/test_target_weight_policy.py
+++ b/tests/test_target_weight_policy.py
@@ -31,6 +31,7 @@ def _response(
     symbol: str = "TQQQ",
 ) -> ExternalDecisionResponse:
     return ExternalDecisionResponse(
+        schema_version=1,
         request_id="request-1",
         decision_type="regime_target_weights",
         as_of_session=as_of_session,

--- a/tests/test_target_weight_policy.py
+++ b/tests/test_target_weight_policy.py
@@ -39,15 +39,18 @@ def _response(
     )
 
 
-def test_target_weight_response_accepts_current_bounded_signal() -> None:
+@pytest.mark.parametrize("multiplier", [1, 1.07])
+def test_target_weight_response_accepts_current_bounded_signal(
+    multiplier: float,
+) -> None:
     adjustments = validate_target_weight_response(
-        _response(),
+        _response(multiplier=multiplier),
         policy=_policy(),
         history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
         now=datetime(2026, 9, 3, tzinfo=UTC),
     )
 
-    assert adjustments["TQQQ"].multiplier == pytest.approx(1.07)
+    assert adjustments["TQQQ"].multiplier == pytest.approx(multiplier)
 
 
 @pytest.mark.parametrize("multiplier", [0.79, 1.11, True, "1.0", float("nan")])

--- a/tests/test_target_weight_policy.py
+++ b/tests/test_target_weight_policy.py
@@ -1,0 +1,108 @@
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from thetagang.config_models import TargetWeightPolicyConfig
+from thetagang.external_decisions import (
+    ExternalDecisionError,
+    ExternalDecisionResponse,
+)
+from thetagang.target_weight_policy import validate_target_weight_response
+
+
+def _policy() -> TargetWeightPolicyConfig:
+    return TargetWeightPolicyConfig(
+        enabled=True,
+        provider="fixture",
+        symbols={
+            "TQQQ": {
+                "min_multiplier": 0.8,
+                "max_multiplier": 1.1,
+                "clamp_to_volatility_bounds": True,
+            }
+        },
+    )
+
+
+def _response(
+    *,
+    as_of_session: date = date(2026, 9, 2),
+    multiplier: object = 1.07,
+    symbol: str = "TQQQ",
+) -> ExternalDecisionResponse:
+    return ExternalDecisionResponse(
+        request_id="request-1",
+        decision_type="regime_target_weights",
+        as_of_session=as_of_session,
+        producer={"name": "fixture", "version": "1"},
+        output={"adjustments": {symbol: {"multiplier": multiplier, "reason": "test"}}},
+    )
+
+
+def test_target_weight_response_accepts_current_bounded_signal() -> None:
+    adjustments = validate_target_weight_response(
+        _response(),
+        policy=_policy(),
+        history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+        now=datetime(2026, 9, 3, tzinfo=UTC),
+    )
+
+    assert adjustments["TQQQ"].multiplier == pytest.approx(1.07)
+
+
+@pytest.mark.parametrize("multiplier", [0.79, 1.11, True, "1.0", float("nan")])
+def test_target_weight_response_rejects_invalid_multiplier(
+    multiplier: object,
+) -> None:
+    with pytest.raises(ExternalDecisionError, match="invalid|bounds"):
+        validate_target_weight_response(
+            _response(multiplier=multiplier),
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+def test_target_weight_response_rejects_stale_session() -> None:
+    with pytest.raises(ExternalDecisionError, match="stale"):
+        validate_target_weight_response(
+            _response(as_of_session=date(2026, 9, 1)),
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+def test_target_weight_response_requires_market_session() -> None:
+    response = _response().model_copy(update={"as_of_session": None})
+
+    with pytest.raises(ExternalDecisionError, match="requires as_of_session"):
+        validate_target_weight_response(
+            response,
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+def test_target_weight_response_rejects_expired_signal() -> None:
+    response = _response()
+    response.expires_at = datetime(2026, 9, 3, tzinfo=UTC) - timedelta(seconds=1)
+
+    with pytest.raises(ExternalDecisionError, match="expired"):
+        validate_target_weight_response(
+            response,
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )
+
+
+def test_target_weight_response_requires_configured_symbol_set() -> None:
+    with pytest.raises(ExternalDecisionError, match="symbols do not match"):
+        validate_target_weight_response(
+            _response(symbol="QQQ"),
+            policy=_policy(),
+            history_dates=[date(2026, 9, 1), date(2026, 9, 2)],
+            now=datetime(2026, 9, 3, tzinfo=UTC),
+        )

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -137,6 +137,22 @@ enabled = true
 # Path to the SQLite file, relative to the config file location unless absolute.
 path = "data/thetagang.db"
 
+# External decision providers are named runtime transports that can be reused by
+# narrowly scoped strategy decision points. Commands receive one JSON request on
+# stdin and must emit one JSON response on stdout. They are executed directly,
+# without a shell.
+#
+# [runtime.external_decisions.providers.tqqq_sizing]
+# transport = "command"
+# command = ["/opt/tqqq-policy/.venv/bin/python", "-m", "tqqq_policy"]
+# timeout_seconds = 10
+# max_response_bytes = 1048576
+# working_directory = "/opt/tqqq-policy"
+#
+# [runtime.external_decisions.providers.tail_harvest]
+# command = ["/opt/tail-policy/.venv/bin/python", "-m", "tail_policy"]
+# timeout_seconds = 10
+
 # Optional SQLAlchemy URL override, e.g. "sqlite:////abs/path/thetagang.db".
 # url = "sqlite:////path/to/thetagang.db"
 
@@ -674,6 +690,32 @@ daily_stddev_window = "30 D"
 # deficit_rail_start = 0.06  # deficit that triggers safety rail (fraction of base)
 # deficit_rail_stop = 0.03  # hysteresis stop once within this band (fraction of base)
 # order_history_lookback_days = 30  # look back this many calendar days for fills
+#
+# # Optional external multiplier applied after volatility weighting and before
+# # absolute trend. The provider receives aligned completed-session closes for
+# # this feature universe plus portfolio, account, target, and constraint data.
+# [strategies.regime_rebalance.target_weight_policy]
+# enabled = true
+# provider = "tqqq_sizing"
+# on_error = "baseline" # baseline | abort
+# max_signal_age_sessions = 0
+# # max_total_weight = 1.10 # explicit authorization for policy-created leverage
+#
+# [strategies.regime_rebalance.target_weight_policy.symbols.TQQQ]
+# min_multiplier = 0.80
+# max_multiplier = 1.10
+# clamp_to_volatility_bounds = true
+#
+# [strategies.regime_rebalance.target_weight_policy.market_data]
+# lookback_days = 252
+# include_strategy_symbols = true
+#
+# # Feature-only symbols that are absent from portfolio.symbols need an explicit
+# # primary exchange for IBKR contract resolution.
+# [strategies.regime_rebalance.target_weight_policy.market_data.symbols.QQQ]
+# primary_exchange = "NASDAQ"
+# [strategies.regime_rebalance.target_weight_policy.market_data.symbols.IBIT]
+# primary_exchange = "NASDAQ"
 # Configured portfolio symbol weights must sum to 100%. Effective volatility-
 # adjusted weights are absolute targets and are not renormalized: a total below
 # 100% remains outside the managed targets as cash (or the configured cash fund),
@@ -817,6 +859,22 @@ ignore_dte = 0
 # annual_budget = 0.005  # estimated all-in cost over 365 days / net liquidation
 # harvest_trigger_weight = 0.05  # trim only above 5% of the regime base
 # harvest_target_weight = 0.03  # size sales toward 3% of the regime base
+#
+# # Optional external approval gate for an otherwise eligible harvest. The
+# # provider cannot select contracts, quantities, prices, or create a harvest.
+# [strategies.tail_hedge.harvest_decision]
+# enabled = true
+# provider = "tail_harvest"
+# on_error = "baseline"  # baseline | skip | abort
+# max_signal_age_sessions = 0
+#
+# [strategies.tail_hedge.harvest_decision.market_data]
+# lookback_days = 252
+# include_strategy_symbols = true
+#
+# # Feature-only reference symbols require a primary exchange.
+# [strategies.tail_hedge.harvest_decision.market_data.symbols.SPY]
+# primary_exchange = "ARCA"
 #
 # [[strategies.tail_hedge.targets]]
 # symbol = "QQQ"

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -702,9 +702,18 @@ daily_stddev_window = "30 D"
 # # max_total_weight = 1.10 # explicit authorization for policy-created leverage
 #
 # [strategies.regime_rebalance.target_weight_policy.symbols.TQQQ]
-# min_multiplier = 0.80
-# max_multiplier = 1.10
-# clamp_to_volatility_bounds = true
+# min_multiplier = 0.50
+# max_multiplier = 1.20
+# min_target_weight = 0.15 # optional fraction of the configured regime capital base
+# max_target_weight = 0.55 # applied after multiplication, before absolute trend
+# clamp_to_volatility_bounds = false # true intersects these with volatility bounds
+#
+# [strategies.regime_rebalance.target_weight_policy.symbols.IBIT]
+# min_multiplier = 0.50
+# max_multiplier = 1.20
+# min_target_weight = 0.10
+# max_target_weight = 0.36
+# clamp_to_volatility_bounds = false
 #
 # [strategies.regime_rebalance.target_weight_policy.market_data]
 # lookback_days = 252

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -20,10 +20,12 @@ from thetagang.config_models import (
     DatabaseConfig,
     DisplayMixin,
     ExchangeHoursConfig,
+    ExternalDecisionsConfig,
     IBAsyncConfig,
     IBCConfig,
     OptionChainsConfig,
     OrdersConfig,
+    RegimeRebalanceBaseEnum,
     RegimeRebalanceConfig,
     RollWhenConfig,
     SymbolConfig,
@@ -297,6 +299,9 @@ class RuntimeConfig(BaseModel):
     ib_async: IBAsyncConfig = Field(default_factory=IBAsyncConfig)
     ibc: IBCConfig = Field(default_factory=IBCConfig)
     watchdog: WatchdogConfig = Field(default_factory=WatchdogConfig)
+    external_decisions: ExternalDecisionsConfig = Field(
+        default_factory=ExternalDecisionsConfig
+    )
 
 
 class PortfolioConfig(BaseModel):
@@ -454,6 +459,23 @@ class Config(BaseModel, DisplayMixin):
     portfolio: PortfolioConfig
     strategies: StrategiesConfig
 
+    def _validate_external_market_decision(self, policy: Any) -> None:
+        decision_name = policy.decision_name
+        if policy.provider not in self.runtime.external_decisions.providers:
+            raise ValueError(
+                f"{decision_name} provider must exist in "
+                "runtime.external_decisions.providers"
+            )
+        for symbol, market_symbol in policy.market_data.symbols.items():
+            if (
+                symbol not in self.portfolio.symbols
+                and not market_symbol.primary_exchange.strip()
+            ):
+                raise ValueError(
+                    f"{decision_name} market data symbol {symbol} requires "
+                    "primary_exchange when it is not in portfolio.symbols"
+                )
+
     @model_validator(mode="after")
     def apply_strategy_overrides(self) -> Config:
         symbols = self.portfolio.symbols
@@ -520,6 +542,86 @@ class Config(BaseModel, DisplayMixin):
             raise ValueError(
                 "tail_hedge target symbols must be in portfolio.symbols: "
                 + ", ".join(missing_symbols)
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_target_weight_policy(self) -> Config:
+        policy = self.strategies.regime_rebalance.target_weight_policy
+        if not policy.enabled:
+            return self
+        self._validate_external_market_decision(policy)
+        regime = self.strategies.regime_rebalance
+        if regime.weight_base == RegimeRebalanceBaseEnum.managed_stocks:
+            raise ValueError(
+                "target weight policy does not support weight_base=managed_stocks"
+            )
+        unknown_targets = [
+            symbol for symbol in policy.symbols if symbol not in regime.symbols
+        ]
+        if unknown_targets:
+            raise ValueError(
+                "target weight policy symbols must be regime_rebalance symbols: "
+                + ", ".join(unknown_targets)
+            )
+        missing_targets = [
+            symbol for symbol in policy.symbols if symbol not in self.portfolio.symbols
+        ]
+        if missing_targets:
+            raise ValueError(
+                "target weight policy symbols must be in portfolio.symbols: "
+                + ", ".join(missing_targets)
+            )
+        zero_weight_targets = [
+            symbol
+            for symbol in policy.symbols
+            if self.portfolio.symbols[symbol].weight <= 0
+        ]
+        if zero_weight_targets:
+            raise ValueError(
+                "target weight policy symbols must have positive configured weights: "
+                + ", ".join(zero_weight_targets)
+            )
+        for symbol, symbol_policy in policy.symbols.items():
+            symbol_config = self.portfolio.symbols[symbol]
+            if symbol_policy.clamp_to_volatility_bounds and (
+                symbol_config.volatility_weight is None
+                or not symbol_config.volatility_weight.enabled
+            ):
+                raise ValueError(
+                    f"target weight policy for {symbol} requires enabled "
+                    "volatility_weight when clamp_to_volatility_bounds=true"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_tail_harvest_decision(self) -> Config:
+        tail_hedge = self.strategies.tail_hedge
+        policy = tail_hedge.harvest_decision
+        if not policy.enabled:
+            return self
+        self._validate_external_market_decision(policy)
+        if not tail_hedge.enabled:
+            raise ValueError(
+                "tail harvest decision requires strategies.tail_hedge.enabled = true"
+            )
+        regime = self.strategies.regime_rebalance
+        if not regime.enabled:
+            raise ValueError(
+                "tail harvest decision requires "
+                "strategies.regime_rebalance.enabled = true"
+            )
+        eligible_underlyings = {
+            target.symbol
+            for target in tail_hedge.targets
+            if target.symbol in regime.symbols
+            and target.symbol in self.portfolio.symbols
+            and self.portfolio.symbols[target.symbol].weight > 0
+        }
+        if not eligible_underlyings:
+            raise ValueError(
+                "tail harvest decision requires a positive-weight tail target in "
+                "regime_rebalance.symbols"
             )
         return self
 

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -585,13 +585,24 @@ class Config(BaseModel, DisplayMixin):
             )
         for symbol, symbol_policy in policy.symbols.items():
             symbol_config = self.portfolio.symbols[symbol]
-            if symbol_policy.clamp_to_volatility_bounds and (
-                symbol_config.volatility_weight is None
-                or not symbol_config.volatility_weight.enabled
-            ):
+            if not symbol_policy.clamp_to_volatility_bounds:
+                continue
+            volatility = symbol_config.volatility_weight
+            if volatility is None or not volatility.enabled:
                 raise ValueError(
                     f"target weight policy for {symbol} requires enabled "
                     "volatility_weight when clamp_to_volatility_bounds=true"
+                )
+            if (
+                symbol_policy.min_target_weight is not None
+                and symbol_policy.min_target_weight > volatility.max_weight
+            ) or (
+                symbol_policy.max_target_weight is not None
+                and symbol_policy.max_target_weight < volatility.min_weight
+            ):
+                raise ValueError(
+                    f"target weight policy for {symbol} has target bounds that "
+                    "do not overlap volatility bounds"
                 )
         return self
 

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -23,6 +23,7 @@ from thetagang.config_models import (
     ExternalDecisionsConfig,
     IBAsyncConfig,
     IBCConfig,
+    MarketDecisionConfig,
     OptionChainsConfig,
     OrdersConfig,
     RegimeRebalanceBaseEnum,
@@ -459,7 +460,7 @@ class Config(BaseModel, DisplayMixin):
     portfolio: PortfolioConfig
     strategies: StrategiesConfig
 
-    def _validate_external_market_decision(self, policy: Any) -> None:
+    def _validate_external_market_decision(self, policy: MarketDecisionConfig) -> None:
         decision_name = policy.decision_name
         if policy.provider not in self.runtime.external_decisions.providers:
             raise ValueError(

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -1,7 +1,7 @@
 import math
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, Optional, Self
+from typing import Any, ClassVar, Literal, Optional, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from rich.console import Console
@@ -305,6 +305,62 @@ class VIXCallHedgeConfig(BaseModel, DisplayMixin):
                     )
 
 
+class DecisionMarketDataSymbolConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    primary_exchange: str = ""
+
+
+class DecisionMarketDataConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lookback_days: int = Field(default=252, ge=2)
+    include_strategy_symbols: bool = True
+    symbols: dict[str, DecisionMarketDataSymbolConfig] = Field(default_factory=dict)
+
+
+class MarketDecisionConfig(BaseModel):
+    """Shared configuration for decisions based on completed market sessions."""
+
+    decision_name: ClassVar[str] = "external market decision"
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    provider: str = ""
+    max_signal_age_sessions: int = Field(default=0, ge=0)
+    market_data: DecisionMarketDataConfig = Field(
+        default_factory=DecisionMarketDataConfig
+    )
+
+    @model_validator(mode="after")
+    def validate_enabled_policy(self) -> Self:
+        if not self.enabled:
+            return self
+        if not self.provider:
+            raise ValueError(f"{self.decision_name} provider is required when enabled")
+        if (
+            not self.market_data.include_strategy_symbols
+            and not self.market_data.symbols
+        ):
+            raise ValueError(
+                f"{self.decision_name} market data universe cannot be empty"
+            )
+        if self.max_signal_age_sessions > self.market_data.lookback_days:
+            raise ValueError(
+                f"{self.decision_name} max_signal_age_sessions cannot exceed "
+                "market_data.lookback_days"
+            )
+        return self
+
+
+class TailHarvestDecisionConfig(MarketDecisionConfig):
+    """External approval gate for an otherwise eligible tail harvest."""
+
+    decision_name: ClassVar[str] = "tail harvest decision"
+
+    on_error: Literal["baseline", "skip", "abort"] = "baseline"
+
+
 class TailHedgeTargetConfig(BaseModel, DisplayMixin):
     model_config = ConfigDict(extra="forbid")
 
@@ -389,6 +445,9 @@ class TailHedgeConfig(BaseModel, DisplayMixin):
     annual_budget: float = Field(default=0.005, gt=0.0, le=1.0)
     harvest_trigger_weight: float = Field(default=0.05, gt=0.0, le=1.0)
     harvest_target_weight: float = Field(default=0.03, ge=0.0, le=1.0)
+    harvest_decision: TailHarvestDecisionConfig = Field(
+        default_factory=TailHarvestDecisionConfig
+    )
     targets: list[TailHedgeTargetConfig] = Field(default_factory=list)
 
     @model_validator(mode="after")
@@ -430,6 +489,16 @@ class TailHedgeConfig(BaseModel, DisplayMixin):
             "Harvest target (% regime base)",
             "=",
             pfmt(self.harvest_target_weight),
+        )
+        table.add_row(
+            "",
+            "External harvest decision",
+            "=",
+            (
+                self.harvest_decision.provider
+                if self.harvest_decision.enabled
+                else "disabled"
+            ),
         )
         if not self.targets:
             table.add_row("", "Targets", "=", "-")
@@ -759,6 +828,71 @@ class RatioGateConfig(BaseModel, DisplayMixin):
         )
 
 
+class ExternalDecisionProviderConfig(BaseModel):
+    """Runtime transport for an out-of-process decision provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transport: Literal["command"] = "command"
+    command: list[str] = Field(..., min_length=1)
+    timeout_seconds: float = Field(default=10.0, gt=0.0, le=300.0)
+    max_response_bytes: int = Field(default=1_048_576, ge=1_024, le=16_777_216)
+    working_directory: str | None = None
+
+    @model_validator(mode="after")
+    def validate_command(self) -> Self:
+        if any(not part.strip() for part in self.command):
+            raise ValueError(
+                "external decision provider command entries cannot be empty"
+            )
+        return self
+
+
+class ExternalDecisionsConfig(BaseModel):
+    """Named providers reusable by strategy-specific decision points."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    providers: dict[str, ExternalDecisionProviderConfig] = Field(default_factory=dict)
+
+
+class TargetWeightPolicySymbolConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+    min_multiplier: float = Field(default=0.0, ge=0.0)
+    max_multiplier: float = Field(default=1.0, ge=0.0)
+    clamp_to_volatility_bounds: bool = True
+
+    @model_validator(mode="after")
+    def validate_multiplier_bounds(self) -> Self:
+        if self.max_multiplier < self.min_multiplier:
+            raise ValueError(
+                "target weight policy max_multiplier must be >= min_multiplier"
+            )
+        return self
+
+
+class TargetWeightPolicyConfig(MarketDecisionConfig):
+    """A bounded external overlay on regime-rebalance target weights."""
+
+    decision_name: ClassVar[str] = "target weight policy"
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+    on_error: Literal["baseline", "abort"] = "baseline"
+    max_total_weight: float | None = Field(default=None, ge=1.0)
+    symbols: dict[str, TargetWeightPolicySymbolConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_symbols(self) -> Self:
+        if not self.enabled:
+            return self
+        if not self.symbols:
+            raise ValueError(
+                "target weight policy requires at least one configured symbol"
+            )
+        return self
+
+
 class RegimeRebalanceBaseEnum(str, Enum):
     net_liq = "net_liq"
     managed_stocks = "managed_stocks"
@@ -788,6 +922,9 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
         default=RegimeRebalanceBaseEnum.net_liq_ex_options
     )
     ratio_gate: RatioGateConfig | None = None
+    target_weight_policy: TargetWeightPolicyConfig = Field(
+        default_factory=TargetWeightPolicyConfig
+    )
 
     @model_validator(mode="after")
     def validate_bands(self) -> Self:
@@ -853,6 +990,16 @@ class RegimeRebalanceConfig(BaseModel, DisplayMixin):
         table.add_row("", "Deficit rail start", "=", f"{pfmt(self.deficit_rail_start)}")
         table.add_row("", "Deficit rail stop", "=", f"{pfmt(self.deficit_rail_stop)}")
         table.add_row("", "Weight base", "=", f"{self.weight_base.value}")
+        table.add_row(
+            "",
+            "External target weight policy",
+            "=",
+            (
+                self.target_weight_policy.provider
+                if self.target_weight_policy.enabled
+                else "disabled"
+            ),
+        )
         if self.ratio_gate is not None:
             self.ratio_gate.add_to_table(table, section)
 

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -861,13 +861,23 @@ class TargetWeightPolicySymbolConfig(BaseModel):
 
     min_multiplier: float = Field(default=0.0, ge=0.0)
     max_multiplier: float = Field(default=1.0, ge=0.0)
+    min_target_weight: float | None = Field(default=None, ge=0.0, le=1.0)
+    max_target_weight: float | None = Field(default=None, ge=0.0, le=1.0)
     clamp_to_volatility_bounds: bool = True
 
     @model_validator(mode="after")
-    def validate_multiplier_bounds(self) -> Self:
+    def validate_bounds(self) -> Self:
         if self.max_multiplier < self.min_multiplier:
             raise ValueError(
                 "target weight policy max_multiplier must be >= min_multiplier"
+            )
+        if (
+            self.min_target_weight is not None
+            and self.max_target_weight is not None
+            and self.max_target_weight < self.min_target_weight
+        ):
+            raise ValueError(
+                "target weight policy max_target_weight must be >= min_target_weight"
             )
         return self
 

--- a/thetagang/decision_check.py
+++ b/thetagang/decision_check.py
@@ -1,0 +1,250 @@
+"""Offline provider conformance checks: python -m thetagang.decision_check."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import click
+from pydantic import AwareDatetime, BaseModel, TypeAdapter
+
+from thetagang.config_models import (
+    ExternalDecisionProviderConfig,
+    TailHarvestDecisionConfig,
+    TargetWeightPolicyConfig,
+)
+from thetagang.external_decisions import (
+    ExternalDecisionError,
+    ExternalDecisionProviders,
+    ExternalDecisionRequest,
+    ExternalDecisionResponse,
+    parse_external_decision_response,
+    validate_response_identity,
+)
+from thetagang.tail_harvest_decision import (
+    TAIL_HARVEST_DECISION_TYPE,
+    TailHarvestDecisionRequest,
+    TailHarvestDecisionResponse,
+    validate_tail_harvest_response,
+)
+from thetagang.target_weight_policy import (
+    TARGET_WEIGHT_DECISION_TYPE,
+    TargetWeightDecisionRequest,
+    TargetWeightDecisionResponse,
+    apply_target_weight_adjustments,
+    validate_target_weight_response,
+)
+
+Request = TargetWeightDecisionRequest | TailHarvestDecisionRequest
+CONTRACT_MODELS: dict[str, type[BaseModel]] = {
+    "regime_target_weights.request": TargetWeightDecisionRequest,
+    "regime_target_weights.response": TargetWeightDecisionResponse,
+    "tail_hedge_harvest.request": TailHarvestDecisionRequest,
+    "tail_hedge_harvest.response": TailHarvestDecisionResponse,
+}
+
+
+def published_schemas() -> dict[str, dict[str, Any]]:
+    return {
+        f"{name}.v1.schema.json": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            **model.model_json_schema(),
+        }
+        for name, model in CONTRACT_MODELS.items()
+    }
+
+
+def read_request(path: Path) -> Request:
+    raw = path.read_bytes()
+    envelope = ExternalDecisionRequest.model_validate_json(raw)
+    if envelope.decision_type == TARGET_WEIGHT_DECISION_TYPE:
+        return TargetWeightDecisionRequest.model_validate_json(raw)
+    if envelope.decision_type == TAIL_HARVEST_DECISION_TYPE:
+        return TailHarvestDecisionRequest.model_validate_json(raw)
+    raise ExternalDecisionError(f"Unsupported decision type: {envelope.decision_type}")
+
+
+def check_response(
+    request: Request,
+    response: ExternalDecisionResponse,
+    *,
+    at: datetime,
+    max_signal_age_sessions: int,
+    weight_epsilon: float,
+) -> dict[str, Any]:
+    """Use production validators and target allocation math against saved context."""
+
+    validate_response_identity(
+        response,
+        ExternalDecisionRequest.model_validate(request.model_dump(mode="json")),
+    )
+    result: dict[str, Any] = {
+        "valid": True,
+        "decision_type": request.decision_type,
+        "validated_at": at.isoformat(),
+        "producer": response.producer.model_dump(),
+        "output": response.output,
+    }
+    if isinstance(request, TargetWeightDecisionRequest):
+        context = request.input
+        policy = TargetWeightPolicyConfig.model_validate(
+            {
+                "symbols": {
+                    symbol: limits.model_dump()
+                    for symbol, limits in context.adjustment_constraints.items()
+                },
+                "max_total_weight": context.total_weight_constraint.max_total_weight,
+                "max_signal_age_sessions": max_signal_age_sessions,
+            }
+        )
+        adjustments = validate_target_weight_response(
+            response,
+            policy=policy,
+            history_dates=context.market_data.sessions,
+            now=at,
+        )
+        bounds: dict[str, tuple[float, float]] = {}
+        for symbol, limits in policy.symbols.items():
+            if symbol not in context.symbols:
+                raise ExternalDecisionError(f"Missing target symbol context: {symbol}")
+            if limits.clamp_to_volatility_bounds:
+                volatility = context.symbols[symbol].volatility_weight.config
+                if volatility is None or not volatility.enabled:
+                    raise ExternalDecisionError(f"Missing volatility bounds: {symbol}")
+                bounds[symbol] = (volatility.min_weight, volatility.max_weight)
+        weights, _ = apply_target_weight_adjustments(
+            {
+                symbol: item.post_volatility_weight
+                for symbol, item in context.symbols.items()
+            },
+            adjustments,
+            policy=policy,
+            volatility_bounds=bounds,
+            eps=weight_epsilon,
+        )
+        result["post_policy_weights"] = weights
+    else:
+        validate_tail_harvest_response(
+            response,
+            policy=TailHarvestDecisionConfig(
+                max_signal_age_sessions=max_signal_age_sessions
+            ),
+            history_dates=request.input.market_data.sessions,
+            now=at,
+        )
+    return result
+
+
+@click.group()
+def cli() -> None:
+    """Check external decision providers without starting ThetaGang or IBKR."""
+
+
+@cli.command()
+@click.option(
+    "--output-dir", required=True, type=click.Path(file_okay=False, path_type=Path)
+)
+def schemas(output_dir: Path) -> None:
+    """Export versioned request and response JSON schemas."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for filename, schema in published_schemas().items():
+        (output_dir / filename).write_text(
+            json.dumps(schema, indent=2, sort_keys=True) + "\n"
+        )
+    click.echo(f"Wrote {len(CONTRACT_MODELS)} schemas to {output_dir}")
+
+
+@cli.command(context_settings={"ignore_unknown_options": True})
+@click.option(
+    "--request",
+    "request_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--response",
+    "response_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--at",
+    help="Replay validation time (ISO 8601 with offset); defaults to generated_at.",
+)
+@click.option(
+    "--max-signal-age-sessions",
+    default=0,
+    type=click.IntRange(min=0),
+    show_default=True,
+)
+@click.option("--weight-epsilon", default=1e-8, type=float, show_default=True)
+@click.option("--timeout-seconds", default=10.0, type=float, show_default=True)
+@click.option("--max-response-bytes", default=1_048_576, type=int, show_default=True)
+@click.option(
+    "--working-directory", type=click.Path(exists=True, file_okay=False, path_type=Path)
+)
+@click.argument("command", nargs=-1, type=click.UNPROCESSED)
+def check(
+    request_path: Path,
+    response_path: Path | None,
+    at: str | None,
+    max_signal_age_sessions: int,
+    weight_epsilon: float,
+    timeout_seconds: float,
+    max_response_bytes: int,
+    working_directory: Path | None,
+    command: tuple[str, ...],
+) -> None:
+    """Replay REQUEST against COMMAND (after --), or validate a saved RESPONSE."""
+    if bool(command) == (response_path is not None):
+        raise click.UsageError("Supply either a command after -- or --response.")
+    if not math.isfinite(weight_epsilon) or weight_epsilon <= 0:
+        raise click.BadParameter(
+            "must be finite and positive", param_hint="--weight-epsilon"
+        )
+    try:
+        request = read_request(request_path)
+        validation_time = (
+            TypeAdapter(AwareDatetime).validate_python(at)
+            if at
+            else request.generated_at
+        )
+        transport = ExternalDecisionProviderConfig(
+            command=list(command) or ["saved-response"],
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            working_directory=str(working_directory) if working_directory else None,
+        )
+        if response_path is None:
+            providers = ExternalDecisionProviders({"offline": transport})
+            response = asyncio.run(
+                providers.decide(
+                    "offline",
+                    ExternalDecisionRequest.model_validate(
+                        request.model_dump(mode="json")
+                    ),
+                )
+            )
+        else:
+            with response_path.open("rb") as stream:
+                raw = stream.read(transport.max_response_bytes + 1)
+            if len(raw) > transport.max_response_bytes:
+                raise ExternalDecisionError("external decision response is too large")
+            response = parse_external_decision_response(raw)
+        result = check_response(
+            request,
+            response,
+            at=validation_time,
+            max_signal_age_sessions=max_signal_age_sessions,
+            weight_epsilon=weight_epsilon,
+        )
+    except (OSError, ValueError, ExternalDecisionError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(json.dumps(result, indent=2, allow_nan=False))
+
+
+if __name__ == "__main__":
+    cli()

--- a/thetagang/decision_check.py
+++ b/thetagang/decision_check.py
@@ -78,10 +78,7 @@ def check_response(
 ) -> dict[str, Any]:
     """Use production validators and target allocation math against saved context."""
 
-    validate_response_identity(
-        response,
-        ExternalDecisionRequest.model_validate(request.model_dump(mode="json")),
-    )
+    validate_response_identity(response, request)
     result: dict[str, Any] = {
         "valid": True,
         "decision_type": request.decision_type,

--- a/thetagang/external_decisions.py
+++ b/thetagang/external_decisions.py
@@ -25,12 +25,17 @@ class _ResponseTooLargeError(RuntimeError):
     pass
 
 
-class ExternalDecisionRequestEnvelope(BaseModel):
+class ExternalDecisionEnvelope(BaseModel):
+    """Protocol identity shared by requests and responses."""
+
     model_config = ConfigDict(extra="forbid")
 
     schema_version: Literal[1] = EXTERNAL_DECISION_SCHEMA_VERSION
     request_id: str = Field(..., min_length=1)
     decision_type: str = Field(..., min_length=1)
+
+
+class ExternalDecisionRequestEnvelope(ExternalDecisionEnvelope):
     generated_at: datetime
     dry_run: bool
 
@@ -52,10 +57,8 @@ class DecisionInput(BaseModel):
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
 
-class ExternalDecisionMarketData(BaseModel):
+class ExternalDecisionMarketData(DecisionInput):
     """Aligned completed-session data shared by market-based decisions."""
-
-    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     source: str = "ibkr"
     timeframe: str
@@ -85,12 +88,7 @@ class ExternalDecisionProducer(BaseModel):
     version: str = Field(..., min_length=1)
 
 
-class ExternalDecisionResponseEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: Literal[1] = EXTERNAL_DECISION_SCHEMA_VERSION
-    request_id: str = Field(..., min_length=1)
-    decision_type: str = Field(..., min_length=1)
+class ExternalDecisionResponseEnvelope(ExternalDecisionEnvelope):
     # Decision-specific validators may require a completed market session, but
     # the generic transport also supports decisions that are not market-based.
     as_of_session: date | None = None
@@ -353,7 +351,7 @@ class ExternalDecisionProviders:
 
 
 def validate_response_identity(
-    response: ExternalDecisionResponse, request: ExternalDecisionRequest
+    response: ExternalDecisionResponseEnvelope, request: ExternalDecisionRequestEnvelope
 ) -> None:
     if response.request_id != request.request_id:
         raise ExternalDecisionError("external decision response request_id mismatch")

--- a/thetagang/external_decisions.py
+++ b/thetagang/external_decisions.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import signal
 from collections.abc import Mapping
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -179,13 +181,30 @@ class CommandExternalDecisionProvider:
         return bytes(captured)
 
     @staticmethod
-    async def _kill_and_wait(process: asyncio.subprocess.Process) -> None:
-        if process.returncode is None:
-            try:
+    async def _discard_output(stream: asyncio.StreamReader) -> None:
+        while await stream.read(65_536):
+            pass
+
+    @classmethod
+    async def _kill_and_wait(cls, process: asyncio.subprocess.Process) -> None:
+        try:
+            if os.name == "posix":
+                # Descendants can inherit the pipes even after the command exits.
+                os.killpg(process.pid, signal.SIGKILL)
+            elif process.returncode is None:
                 process.kill()
-            except ProcessLookupError:
-                pass
-        await process.wait()
+        except ProcessLookupError:
+            pass
+        # wait() alone can deadlock when a pipe's reader paused its transport
+        # after hitting the buffer limit. Drain without retaining more output.
+        await asyncio.gather(
+            *(
+                cls._discard_output(stream)
+                for stream in (process.stdout, process.stderr)
+                if stream is not None
+            ),
+            process.wait(),
+        )
 
     async def decide(
         self, request: ExternalDecisionRequest
@@ -212,6 +231,7 @@ class CommandExternalDecisionProvider:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
+                start_new_session=os.name == "posix",
             )
         except OSError as exc:
             raise ExternalDecisionError(
@@ -242,23 +262,17 @@ class CommandExternalDecisionProvider:
                 timeout=self._config.timeout_seconds,
             )
         except TimeoutError as exc:
-            await self._kill_and_wait(process)
-            await asyncio.gather(*tasks, return_exceptions=True)
             raise ExternalDecisionError("external decision provider timed out") from exc
         except _ResponseTooLargeError as exc:
-            await self._kill_and_wait(process)
-            await asyncio.gather(*tasks, return_exceptions=True)
             raise ExternalDecisionError(
                 "external decision response is too large"
             ) from exc
-        except asyncio.CancelledError:
-            await self._kill_and_wait(process)
+        finally:
+            # Stop all readers before cleanup takes ownership of the pipes.
+            for task in tasks:
+                task.cancel()
             await asyncio.gather(*tasks, return_exceptions=True)
-            raise
-        except Exception:
             await self._kill_and_wait(process)
-            await asyncio.gather(*tasks, return_exceptions=True)
-            raise
 
         if process.returncode != 0:
             error_text = stderr.decode("utf-8", errors="replace").strip()
@@ -357,12 +371,17 @@ def validate_market_decision_response(
     if signal_age_sessions > max_signal_age_sessions:
         raise ExternalDecisionError(f"{decision_name} signal is stale")
 
-    if response.expires_at is not None:
-        expires_at = response.expires_at
+    validate_decision_expiry(response.expires_at, now=now, decision_name=decision_name)
+    return signal_session
+
+
+def validate_decision_expiry(
+    expires_at: datetime | None, *, now: datetime, decision_name: str
+) -> None:
+    if expires_at is not None:
         if expires_at.utcoffset() is None:
             raise ExternalDecisionError(
                 f"{decision_name} expires_at must include a timezone"
             )
         if expires_at.astimezone(UTC) <= now.astimezone(UTC):
             raise ExternalDecisionError(f"{decision_name} signal has expired")
-    return signal_session

--- a/thetagang/external_decisions.py
+++ b/thetagang/external_decisions.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Literal, Protocol
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from thetagang.config_models import ExternalDecisionProviderConfig
+
+EXTERNAL_DECISION_SCHEMA_VERSION = 1
+
+
+class ExternalDecisionError(RuntimeError):
+    """Raised when an external provider cannot return a valid decision."""
+
+
+class _ResponseTooLargeError(RuntimeError):
+    pass
+
+
+class ExternalDecisionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = EXTERNAL_DECISION_SCHEMA_VERSION
+    request_id: str = Field(..., min_length=1)
+    decision_type: str = Field(..., min_length=1)
+    generated_at: datetime
+    dry_run: bool
+    input: dict[str, Any]
+
+    @field_validator("generated_at")
+    @classmethod
+    def require_generated_at_timezone(cls, value: datetime) -> datetime:
+        if value.utcoffset() is None:
+            raise ValueError("generated_at must include a timezone")
+        return value
+
+
+class ExternalDecisionMarketData(BaseModel):
+    """Aligned completed-session data shared by market-based decisions."""
+
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+    source: str = "ibkr"
+    timeframe: str
+    what_to_show: str = "TRADES"
+    regular_trading_hours_only: bool = True
+    sessions: list[date] = Field(..., min_length=1)
+    closes: dict[str, list[float]] = Field(..., min_length=1)
+    primary_exchanges: dict[str, str] = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def validate_alignment(self) -> ExternalDecisionMarketData:
+        symbols = set(self.closes)
+        if symbols != set(self.primary_exchanges):
+            raise ValueError("market data symbols and exchanges must match")
+        if any(len(values) != len(self.sessions) for values in self.closes.values()):
+            raise ValueError("market data close arrays must align with sessions")
+        return self
+
+    def request_input(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+
+class ExternalDecisionProducer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1)
+    version: str = Field(..., min_length=1)
+
+
+class ExternalDecisionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = EXTERNAL_DECISION_SCHEMA_VERSION
+    request_id: str = Field(..., min_length=1)
+    decision_type: str = Field(..., min_length=1)
+    # Decision-specific validators may require a completed market session, but
+    # the generic transport also supports decisions that are not market-based.
+    as_of_session: date | None = None
+    expires_at: datetime | None = None
+    producer: ExternalDecisionProducer
+    output: dict[str, Any]
+
+    @field_validator("expires_at")
+    @classmethod
+    def require_expires_at_timezone(cls, value: datetime | None) -> datetime | None:
+        if value is not None and value.utcoffset() is None:
+            raise ValueError("expires_at must include a timezone")
+        return value
+
+
+def build_external_decision_request(
+    *,
+    decision_type: str,
+    generated_at: datetime,
+    dry_run: bool,
+    input_data: dict[str, Any],
+) -> ExternalDecisionRequest:
+    return ExternalDecisionRequest(
+        request_id=str(uuid4()),
+        decision_type=decision_type,
+        generated_at=generated_at,
+        dry_run=dry_run,
+        input=input_data,
+    )
+
+
+def external_decision_response_metadata(
+    response: ExternalDecisionResponse,
+    *,
+    provider: str,
+) -> dict[str, Any]:
+    return {
+        "request_id": response.request_id,
+        "provider": provider,
+        "producer": response.producer.name,
+        "producer_version": response.producer.version,
+        "as_of_session": (
+            response.as_of_session.isoformat() if response.as_of_session else None
+        ),
+        "expires_at": (
+            response.expires_at.isoformat() if response.expires_at else None
+        ),
+    }
+
+
+class ExternalDecisionProvider(Protocol):
+    async def decide(
+        self, request: ExternalDecisionRequest
+    ) -> ExternalDecisionResponse: ...
+
+
+class CommandExternalDecisionProvider:
+    """Invoke a provider command with JSON on stdin and stdout."""
+
+    def __init__(self, config: ExternalDecisionProviderConfig) -> None:
+        self._config = config
+
+    @staticmethod
+    async def _write_request(
+        stream: asyncio.StreamWriter, request_bytes: bytes
+    ) -> None:
+        try:
+            stream.write(request_bytes)
+            await stream.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            # Match communicate(): an early provider exit is reported through
+            # its return code or invalid response instead of the stdin pipe.
+            pass
+        finally:
+            stream.close()
+
+    @staticmethod
+    async def _read_response(
+        stream: asyncio.StreamReader, max_response_bytes: int
+    ) -> bytes:
+        chunks: list[bytes] = []
+        response_bytes = 0
+        while chunk := await stream.read(65_536):
+            response_bytes += len(chunk)
+            if response_bytes > max_response_bytes:
+                raise _ResponseTooLargeError
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+    @staticmethod
+    async def _read_stderr(stream: asyncio.StreamReader) -> bytes:
+        captured = bytearray()
+        while chunk := await stream.read(65_536):
+            if len(captured) < 512:
+                remaining = 512 - len(captured)
+                captured.extend(chunk[:remaining])
+        return bytes(captured)
+
+    @staticmethod
+    async def _kill_and_wait(process: asyncio.subprocess.Process) -> None:
+        if process.returncode is None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+        await process.wait()
+
+    async def decide(
+        self, request: ExternalDecisionRequest
+    ) -> ExternalDecisionResponse:
+        try:
+            request_bytes = json.dumps(
+                request.model_dump(mode="json"),
+                allow_nan=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise ExternalDecisionError(
+                "external decision request is not valid JSON"
+            ) from exc
+
+        cwd = None
+        if self._config.working_directory is not None:
+            cwd = str(Path(self._config.working_directory).expanduser())
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *self._config.command,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+            )
+        except OSError as exc:
+            raise ExternalDecisionError(
+                "external decision provider could not be started"
+            ) from exc
+
+        if process.stdin is None or process.stdout is None or process.stderr is None:
+            await self._kill_and_wait(process)
+            raise ExternalDecisionError(
+                "external decision provider pipes could not be created"
+            )
+
+        tasks = [
+            asyncio.create_task(self._write_request(process.stdin, request_bytes)),
+            asyncio.create_task(
+                self._read_response(
+                    process.stdout,
+                    self._config.max_response_bytes,
+                )
+            ),
+            asyncio.create_task(self._read_stderr(process.stderr)),
+            asyncio.create_task(process.wait()),
+        ]
+        communication = asyncio.gather(*tasks)
+        try:
+            _, stdout, stderr, _ = await asyncio.wait_for(
+                communication,
+                timeout=self._config.timeout_seconds,
+            )
+        except TimeoutError as exc:
+            await self._kill_and_wait(process)
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise ExternalDecisionError("external decision provider timed out") from exc
+        except _ResponseTooLargeError as exc:
+            await self._kill_and_wait(process)
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise ExternalDecisionError(
+                "external decision response is too large"
+            ) from exc
+        except asyncio.CancelledError:
+            await self._kill_and_wait(process)
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+        except Exception:
+            await self._kill_and_wait(process)
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+
+        if process.returncode != 0:
+            error_text = stderr.decode("utf-8", errors="replace").strip()
+            error_suffix = f": {error_text[:512]}" if error_text else ""
+            raise ExternalDecisionError(
+                f"external decision provider exited with status "
+                f"{process.returncode}{error_suffix}"
+            )
+        try:
+            decoded = json.loads(
+                stdout.decode("utf-8"),
+                parse_constant=lambda value: _raise_invalid_constant(value),
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise ExternalDecisionError(
+                "external decision provider returned invalid JSON"
+            ) from exc
+        if not isinstance(decoded, dict):
+            raise ExternalDecisionError(
+                "external decision provider response must be a JSON object"
+            )
+        try:
+            return ExternalDecisionResponse.model_validate(decoded)
+        except ValueError as exc:
+            raise ExternalDecisionError(
+                "external decision provider returned an invalid response envelope"
+            ) from exc
+
+
+def _raise_invalid_constant(value: str) -> Any:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
+class ExternalDecisionProviders:
+    """Named provider registry shared by decision points across the application."""
+
+    def __init__(
+        self, providers: Mapping[str, ExternalDecisionProviderConfig] | None = None
+    ) -> None:
+        self._providers: dict[str, ExternalDecisionProvider] = {}
+        configured_providers = providers if isinstance(providers, Mapping) else {}
+        for name, config in configured_providers.items():
+            if config.transport == "command":
+                self._providers[name] = CommandExternalDecisionProvider(config)
+
+    def replace(self, name: str, provider: ExternalDecisionProvider) -> None:
+        """Replace a provider, primarily for embedding and deterministic tests."""
+
+        self._providers[name] = provider
+
+    async def decide(
+        self, provider_name: str, request: ExternalDecisionRequest
+    ) -> ExternalDecisionResponse:
+        provider = self._providers.get(provider_name)
+        if provider is None:
+            raise ExternalDecisionError(
+                f"external decision provider is not configured: {provider_name}"
+            )
+        response = await provider.decide(request)
+        if response.request_id != request.request_id:
+            raise ExternalDecisionError(
+                "external decision response request_id mismatch"
+            )
+        if response.decision_type != request.decision_type:
+            raise ExternalDecisionError("external decision response type mismatch")
+        return response
+
+
+def validate_market_decision_response(
+    response: ExternalDecisionResponse,
+    *,
+    history_dates: list[date],
+    max_signal_age_sessions: int,
+    now: datetime,
+    decision_name: str,
+) -> date:
+    """Validate freshness shared by completed-session market decisions."""
+
+    if not history_dates:
+        raise ExternalDecisionError(
+            f"{decision_name} requires completed-session market data"
+        )
+    latest_session = history_dates[-1]
+    signal_session = response.as_of_session
+    if signal_session is None:
+        raise ExternalDecisionError(f"{decision_name} response requires as_of_session")
+    if signal_session > latest_session:
+        raise ExternalDecisionError(f"{decision_name} signal is from the future")
+    try:
+        signal_index = history_dates.index(signal_session)
+    except ValueError as exc:
+        raise ExternalDecisionError(
+            f"{decision_name} signal is not aligned to a supplied session"
+        ) from exc
+    signal_age_sessions = len(history_dates) - signal_index - 1
+    if signal_age_sessions > max_signal_age_sessions:
+        raise ExternalDecisionError(f"{decision_name} signal is stale")
+
+    if response.expires_at is not None:
+        expires_at = response.expires_at
+        if expires_at.utcoffset() is None:
+            raise ExternalDecisionError(
+                f"{decision_name} expires_at must include a timezone"
+            )
+        if expires_at.astimezone(UTC) <= now.astimezone(UTC):
+            raise ExternalDecisionError(f"{decision_name} signal has expired")
+    return signal_session

--- a/thetagang/external_decisions.py
+++ b/thetagang/external_decisions.py
@@ -7,7 +7,7 @@ import signal
 from collections.abc import Mapping
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import Any, Literal, Protocol
+from typing import Annotated, Any, Literal, Protocol
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -30,9 +30,16 @@ class ExternalDecisionEnvelope(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal[1] = EXTERNAL_DECISION_SCHEMA_VERSION
+    schema_version: Literal[1]
     request_id: str = Field(..., min_length=1)
     decision_type: str = Field(..., min_length=1)
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def require_integer_schema_version(cls, value: Any) -> int:
+        if type(value) is not int:
+            raise ValueError("schema_version must be an integer")
+        return value
 
 
 class ExternalDecisionRequestEnvelope(ExternalDecisionEnvelope):
@@ -64,12 +71,20 @@ class ExternalDecisionMarketData(DecisionInput):
     timeframe: str
     what_to_show: str = "TRADES"
     regular_trading_hours_only: bool = True
-    sessions: list[date] = Field(..., min_length=1)
-    closes: dict[str, list[float]] = Field(..., min_length=1)
+    sessions: list[date] = Field(
+        ..., min_length=1, description="Unique sessions ordered oldest to newest."
+    )
+    closes: dict[str, list[Annotated[float, Field(gt=0, strict=True)]]] = Field(
+        ..., min_length=1
+    )
     primary_exchanges: dict[str, str] = Field(..., min_length=1)
 
     @model_validator(mode="after")
     def validate_alignment(self) -> ExternalDecisionMarketData:
+        if any(
+            earlier >= later for earlier, later in zip(self.sessions, self.sessions[1:])
+        ):
+            raise ValueError("market data sessions must be strictly increasing")
         symbols = set(self.closes)
         if symbols != set(self.primary_exchanges):
             raise ValueError("market data symbols and exchanges must match")
@@ -115,6 +130,7 @@ def build_external_decision_request(
     input_data: dict[str, Any],
 ) -> ExternalDecisionRequest:
     return ExternalDecisionRequest(
+        schema_version=EXTERNAL_DECISION_SCHEMA_VERSION,
         request_id=str(uuid4()),
         decision_type=decision_type,
         generated_at=generated_at,

--- a/thetagang/external_decisions.py
+++ b/thetagang/external_decisions.py
@@ -25,7 +25,7 @@ class _ResponseTooLargeError(RuntimeError):
     pass
 
 
-class ExternalDecisionRequest(BaseModel):
+class ExternalDecisionRequestEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: Literal[1] = EXTERNAL_DECISION_SCHEMA_VERSION
@@ -33,7 +33,6 @@ class ExternalDecisionRequest(BaseModel):
     decision_type: str = Field(..., min_length=1)
     generated_at: datetime
     dry_run: bool
-    input: dict[str, Any]
 
     @field_validator("generated_at")
     @classmethod
@@ -41,6 +40,16 @@ class ExternalDecisionRequest(BaseModel):
         if value.utcoffset() is None:
             raise ValueError("generated_at must include a timezone")
         return value
+
+
+class ExternalDecisionRequest(ExternalDecisionRequestEnvelope):
+    input: dict[str, Any]
+
+
+class DecisionInput(BaseModel):
+    """JSON contract fields shared by the published decision-specific requests."""
+
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
 
 class ExternalDecisionMarketData(BaseModel):
@@ -76,7 +85,7 @@ class ExternalDecisionProducer(BaseModel):
     version: str = Field(..., min_length=1)
 
 
-class ExternalDecisionResponse(BaseModel):
+class ExternalDecisionResponseEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: Literal[1] = EXTERNAL_DECISION_SCHEMA_VERSION
@@ -87,7 +96,6 @@ class ExternalDecisionResponse(BaseModel):
     as_of_session: date | None = None
     expires_at: datetime | None = None
     producer: ExternalDecisionProducer
-    output: dict[str, Any]
 
     @field_validator("expires_at")
     @classmethod
@@ -95,6 +103,10 @@ class ExternalDecisionResponse(BaseModel):
         if value is not None and value.utcoffset() is None:
             raise ValueError("expires_at must include a timezone")
         return value
+
+
+class ExternalDecisionResponse(ExternalDecisionResponseEnvelope):
+    output: dict[str, Any]
 
 
 def build_external_decision_request(
@@ -281,25 +293,29 @@ class CommandExternalDecisionProvider:
                 f"external decision provider exited with status "
                 f"{process.returncode}{error_suffix}"
             )
-        try:
-            decoded = json.loads(
-                stdout.decode("utf-8"),
-                parse_constant=lambda value: _raise_invalid_constant(value),
-            )
-        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
-            raise ExternalDecisionError(
-                "external decision provider returned invalid JSON"
-            ) from exc
-        if not isinstance(decoded, dict):
-            raise ExternalDecisionError(
-                "external decision provider response must be a JSON object"
-            )
-        try:
-            return ExternalDecisionResponse.model_validate(decoded)
-        except ValueError as exc:
-            raise ExternalDecisionError(
-                "external decision provider returned an invalid response envelope"
-            ) from exc
+        return parse_external_decision_response(stdout)
+
+
+def parse_external_decision_response(stdout: bytes) -> ExternalDecisionResponse:
+    try:
+        decoded = json.loads(
+            stdout.decode("utf-8"),
+            parse_constant=lambda value: _raise_invalid_constant(value),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ExternalDecisionError(
+            "external decision provider returned invalid JSON"
+        ) from exc
+    if not isinstance(decoded, dict):
+        raise ExternalDecisionError(
+            "external decision provider response must be a JSON object"
+        )
+    try:
+        return ExternalDecisionResponse.model_validate(decoded)
+    except ValueError as exc:
+        raise ExternalDecisionError(
+            "external decision provider returned an invalid response envelope"
+        ) from exc
 
 
 def _raise_invalid_constant(value: str) -> Any:
@@ -332,13 +348,17 @@ class ExternalDecisionProviders:
                 f"external decision provider is not configured: {provider_name}"
             )
         response = await provider.decide(request)
-        if response.request_id != request.request_id:
-            raise ExternalDecisionError(
-                "external decision response request_id mismatch"
-            )
-        if response.decision_type != request.decision_type:
-            raise ExternalDecisionError("external decision response type mismatch")
+        validate_response_identity(response, request)
         return response
+
+
+def validate_response_identity(
+    response: ExternalDecisionResponse, request: ExternalDecisionRequest
+) -> None:
+    if response.request_id != request.request_id:
+        raise ExternalDecisionError("external decision response request_id mismatch")
+    if response.decision_type != request.decision_type:
+        raise ExternalDecisionError("external decision response type mismatch")
 
 
 def validate_market_decision_response(

--- a/thetagang/ibkr.py
+++ b/thetagang/ibkr.py
@@ -104,6 +104,8 @@ class IBKR:
         self,
         contract: Contract,
         duration: str,
+        *,
+        cache_symbol: str | None = None,
     ) -> BarDataList:
         bars = await self.ib.reqHistoricalDataAsync(
             contract,
@@ -114,7 +116,9 @@ class IBKR:
             True,
         )
         if self.data_store:
-            self.data_store.record_historical_bars(contract.symbol, "1 day", bars)
+            self.data_store.record_historical_bars(
+                cache_symbol or contract.symbol, "1 day", bars
+            )
         return bars
 
     async def request_executions(

--- a/thetagang/portfolio_manager.py
+++ b/thetagang/portfolio_manager.py
@@ -39,6 +39,7 @@ from thetagang.config import (
     stage_enabled_map_from_run,
 )
 from thetagang.db import DataStore
+from thetagang.external_decisions import ExternalDecisionProviders
 from thetagang.fmt import dfmt, ffmt, ifmt, pfmt
 from thetagang.ibkr import IBKR
 from thetagang.order_execution import OrderExecutionManager
@@ -73,6 +74,7 @@ from thetagang.strategies.tail_hedge_state import (
     is_tail_order_ref,
     is_tail_reduction_ref,
 )
+from thetagang.target_weight_policy import TARGET_WEIGHT_POLICY_STATE_EVENT
 from thetagang.trades import Trades
 from thetagang.trading_operations import (
     OptionChainScanner,
@@ -95,6 +97,7 @@ logging.getLogger("ib_async.wrapper").setLevel(logging.CRITICAL)
 TAIL_HARVEST_FILL_TIMEOUT_SECONDS = 5 * 60
 REGIME_PLANNING_STATE_EVENTS = {
     ABSOLUTE_TREND_STATE_EVENT,
+    TARGET_WEIGHT_POLICY_STATE_EVENT,
     "regime_rebalance_state",
     "volatility_weight_state",
 }
@@ -122,6 +125,12 @@ class PortfolioManager:
         self.account_number = config.runtime.account.number
         self.config = config
         self.data_store = data_store
+        external_decision_config = getattr(
+            self.config.runtime, "external_decisions", None
+        )
+        self.external_decisions = ExternalDecisionProviders(
+            getattr(external_decision_config, "providers", {})
+        )
         self.ibkr = IBKR(
             ib,
             config.runtime.ib_async.api_response_wait_time,
@@ -197,6 +206,8 @@ class PortfolioManager:
             ibkr=self.ibkr,
             order_ops=self.order_ops,
             data_store=self.data_store,
+            external_decisions=self.external_decisions,
+            dry_run=self.dry_run,
             get_primary_exchange=self.get_primary_exchange,
             now_provider=lambda: datetime.now(),  # noqa: DTZ005
             tail_hedge_stage_enabled=lambda: self.stage_enabled("post_tail_hedge"),
@@ -780,6 +791,7 @@ class PortfolioManager:
     async def manage(self) -> None:
         had_error = False
         try:
+            self.regime_engine.begin_run()
             self.set_reserved_cash_for_post_management(0.0)
             if self.data_store:
                 self.data_store.record_event("run_start", {"dry_run": self.dry_run})

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -26,6 +26,11 @@ from thetagang.accounting import (
     state_owned_option_values,
 )
 from thetagang.config import Config
+from thetagang.config_models import (
+    DecisionMarketDataConfig,
+    TailHarvestDecisionConfig,
+    TargetWeightPolicyConfig,
+)
 from thetagang.db import DataStore
 from thetagang.external_decisions import (
     ExternalDecisionError,
@@ -53,6 +58,8 @@ from thetagang.strategies.tail_hedge_state import (
     parse_state_datetime,
 )
 from thetagang.tail_harvest_decision import (
+    HarvestCandidateInput,
+    TailProgramInput,
     build_tail_harvest_request,
     validate_tail_harvest_response,
 )
@@ -1036,22 +1043,9 @@ class RegimeRebalanceEngine:
                     "unrecovered_cost": cohort.net_charge,
                     "host_candidate": candidate is not None,
                     "candidate": (
-                        {
-                            "quantity": candidate.quantity,
-                            "gross_proceeds_per_contract": (
-                                candidate.gross_proceeds_per_contract
-                            ),
-                            "estimated_fee_per_contract": (
-                                candidate.estimated_fee_per_contract
-                            ),
-                            "net_proceeds_per_contract": (
-                                candidate.net_proceeds_per_contract
-                            ),
-                            "cost_basis_per_contract": (
-                                candidate.cost_basis_per_contract
-                            ),
-                            "profit_multiple": candidate.profit_multiple,
-                        }
+                        HarvestCandidateInput.model_validate(
+                            candidate, from_attributes=True
+                        ).model_dump(mode="json")
                         if candidate is not None
                         else None
                     ),
@@ -1110,14 +1104,12 @@ class RegimeRebalanceEngine:
             market_price = market_prices.get(symbol)
             current_value = self._finite_float_or_none(summary.get("current_value"))
             if current_value is None:
-                current_value = sum(
-                    self._finite_float_or_none(position.marketValue) or 0.0
-                    for position in stock_positions
-                )
+                current_value = reported_market_value
             current_shares = self._finite_float_or_none(summary.get("current_shares"))
             if current_shares is None:
                 current_shares = live_shares
             symbol_config = self.config.portfolio.symbols[symbol]
+            approved_buy_shares = rebalance_shares.get(symbol, 0)
             result[symbol] = {
                 "configured_weight": float(symbol_config.weight),
                 "primary_exchange": str(symbol_config.primary_exchange),
@@ -1143,27 +1135,15 @@ class RegimeRebalanceEngine:
                 "target_shares": self._finite_float_or_none(
                     summary.get("target_shares")
                 ),
-                "approved_buy_shares": rebalance_shares.get(symbol, 0),
+                "approved_buy_shares": approved_buy_shares,
                 "approved_buy_value": (
-                    rebalance_shares.get(symbol, 0) * market_price
+                    approved_buy_shares * market_price
                     if market_price is not None
                     else None
                 ),
-                "tail_program": {
-                    "budget_weight": target.budget_weight,
-                    "entries_per_year": target.entries_per_year,
-                    "entry_gate": target.entry_gate,
-                    "entry_vix_max": target.entry_vix_max,
-                    "target_dte": target.target_dte,
-                    "min_dte": target.min_dte,
-                    "max_dte": target.max_dte,
-                    "exit_dte": target.exit_dte,
-                    "minimum_open_interest": target.minimum_open_interest,
-                    "minimum_bid": target.minimum_bid,
-                    "max_bid_ask_ratio": target.max_bid_ask_ratio,
-                    "max_premium_ratio": target.max_premium_ratio,
-                    "catastrophe_drawdowns": target.catastrophe_drawdowns,
-                },
+                "tail_program": TailProgramInput.model_validate(
+                    target, from_attributes=True
+                ).model_dump(mode="json"),
                 "target_modifiers": {
                     "volatility_weight": summary.get("volatility_weight"),
                     "target_weight_policy": summary.get("target_weight_policy"),
@@ -1175,7 +1155,7 @@ class RegimeRebalanceEngine:
     def _tail_harvest_decision_fallback(
         self,
         *,
-        policy: Any,
+        policy: TailHarvestDecisionConfig,
         error: str,
     ) -> tuple[bool, dict[str, Any]]:
         if policy.on_error == "abort":
@@ -2305,7 +2285,7 @@ class RegimeRebalanceEngine:
     async def _load_external_market_data(
         self,
         *,
-        market_data_config: Any,
+        market_data_config: DecisionMarketDataConfig,
         strategy_symbols: Iterable[str],
         symbol_configs: dict[str, Any],
         decision_name: str,
@@ -2345,20 +2325,17 @@ class RegimeRebalanceEngine:
                 history_exchange_overrides[symbol] = configured_exchange
 
         lookback_days = int(market_data_config.lookback_days)
-        if history_cache is None:
-            history_dates, aligned_closes = await self._get_regime_aligned_closes(
-                history_symbols,
-                lookback_days,
-                0,
-                primary_exchanges=history_exchange_overrides or None,
-            )
-        else:
-            history_dates, aligned_closes = await history_cache.get(
-                history_symbols,
-                lookback_days,
-                0,
-                primary_exchanges=history_exchange_overrides or None,
-            )
+        fetch_history: AlignedClosesFetcher = (
+            self._get_regime_aligned_closes
+            if history_cache is None
+            else history_cache.get
+        )
+        history_dates, aligned_closes = await fetch_history(
+            history_symbols,
+            lookback_days,
+            0,
+            primary_exchanges=history_exchange_overrides or None,
+        )
         return ExternalDecisionMarketData(
             timeframe=REGIME_HISTORY_TIMEFRAME,
             sessions=history_dates,
@@ -2370,7 +2347,7 @@ class RegimeRebalanceEngine:
         self,
         effective_weights: dict[str, float],
         *,
-        policy: Any,
+        policy: TargetWeightPolicyConfig,
         error: str,
     ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
         if policy.on_error == "abort":
@@ -2510,16 +2487,16 @@ class RegimeRebalanceEngine:
                 },
                 eps=regime_rebalance.eps,
             )
+            response_metadata = external_decision_response_metadata(
+                outcome.response, provider=policy.provider
+            )
             details: dict[str, dict[str, Any]] = {
                 symbol: {
                     "status": "applied",
                     **weight_details[symbol],
                     "multiplier": adjustment.multiplier,
                     "reason": adjustment.reason,
-                    **external_decision_response_metadata(
-                        outcome.response,
-                        provider=policy.provider,
-                    ),
+                    **response_metadata,
                     "risk_ready": True,
                 }
                 for symbol, adjustment in outcome.adjustments.items()

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -36,6 +36,7 @@ from thetagang.external_decisions import (
     ExternalDecisionResponse,
     build_external_decision_request,
     external_decision_response_metadata,
+    validate_decision_expiry,
 )
 from thetagang.fmt import dfmt, ffmt, ifmt, pfmt
 from thetagang.ibkr import IBKR, TickerField
@@ -1365,6 +1366,35 @@ class RegimeRebalanceEngine:
             regime_summary=regime_summary,
             history_cache=history_cache,
         )
+        if should_harvest and policy.enabled:
+            # The provider and market-history requests yield. Re-quote and
+            # rebuild the snapshot before any state or order mutation.
+            quoted_limit_prices = await self._quote_tail_puts(
+                symbols=set(rebalance_shares),
+                cohorts=snapshot.cohorts,
+                portfolio_positions=snapshot.portfolio_positions,
+            )
+            snapshot = self._build_tail_harvest_snapshot(
+                net_liquidation=net_liquidation,
+                rebalance_shares=rebalance_shares,
+                market_prices=market_prices,
+                quoted_limit_prices=quoted_limit_prices,
+                record_unprofitable=True,
+            )
+            if snapshot is None:
+                return set()
+            expires_at = external_decision.get("expires_at")
+            try:
+                validate_decision_expiry(
+                    datetime.fromisoformat(expires_at) if expires_at else None,
+                    now=self._as_utc(self._now()),
+                    decision_name="tail harvest decision",
+                )
+            except ExternalDecisionError as exc:
+                should_harvest, external_decision = (
+                    self._tail_harvest_decision_fallback(policy=policy, error=str(exc))
+                )
+
         if external_decision:
             band_payload = self._tail_harvest_band_payload(
                 snapshot,
@@ -1386,26 +1416,6 @@ class RegimeRebalanceEngine:
                 "harvest opportunity."
             )
             return set()
-
-        if policy.enabled:
-            # The provider and market-history requests yield. Re-quote and
-            # rebuild the complete snapshot before any state or order mutation;
-            # the external result cannot bypass changed ownership, conflicts,
-            # profitability, or the allocation band.
-            quoted_limit_prices = await self._quote_tail_puts(
-                symbols=set(rebalance_shares),
-                cohorts=snapshot.cohorts,
-                portfolio_positions=snapshot.portfolio_positions,
-            )
-            snapshot = self._build_tail_harvest_snapshot(
-                net_liquidation=net_liquidation,
-                rebalance_shares=rebalance_shares,
-                market_prices=market_prices,
-                quoted_limit_prices=quoted_limit_prices,
-                record_unprofitable=True,
-            )
-            if snapshot is None:
-                return set()
 
         candidates = snapshot.candidates
         state = snapshot.state
@@ -1969,7 +1979,18 @@ class RegimeRebalanceEngine:
             primaryExchange=primary_exchange or self.get_primary_exchange(symbol),
         )
         for attempt in range(1, REGIME_HISTORY_MAX_ATTEMPTS + 1):
-            bars = list(await self.ibkr.request_historical_data(contract, duration))
+            if primary_exchange:
+                bars = list(
+                    await self.ibkr.request_historical_data(
+                        contract,
+                        duration,
+                        cache_symbol=self._history_cache_symbol(
+                            symbol, primary_exchange
+                        ),
+                    )
+                )
+            else:
+                bars = list(await self.ibkr.request_historical_data(contract, duration))
             if bars:
                 if attempt > 1:
                     log.warning(
@@ -2008,11 +2029,18 @@ class RegimeRebalanceEngine:
         )
         return {symbol: self._bars_to_closes(bars) for symbol, bars in histories}
 
+    @staticmethod
+    def _history_cache_symbol(symbol: str, primary_exchange: str | None) -> str:
+        # The legacy cache is keyed by ticker alone. Explicit listing overrides
+        # must neither consume nor overwrite that ticker's default history.
+        return f"{symbol}@{primary_exchange}" if primary_exchange else symbol
+
     def _merge_cached_regime_closes(
         self,
         symbols: list[str],
         api_closes_by_symbol: ClosesBySymbol,
         required_dates: list[date],
+        primary_exchanges: dict[str, str] | None = None,
     ) -> ClosesBySymbol:
         if self.data_store is None:
             raise RegimeHistoryValidationError(
@@ -2025,7 +2053,12 @@ class RegimeRebalanceEngine:
         for symbol in symbols:
             try:
                 cached_bars = self.data_store.get_historical_bars(
-                    symbol, REGIME_HISTORY_TIMEFRAME, start_time, end_time
+                    self._history_cache_symbol(
+                        symbol, (primary_exchanges or {}).get(symbol)
+                    ),
+                    REGIME_HISTORY_TIMEFRAME,
+                    start_time,
+                    end_time,
                 )
             except Exception as exc:
                 log.error(f"{symbol}: failed to read cached regime history.")
@@ -2051,11 +2084,13 @@ class RegimeRebalanceEngine:
         api_closes_by_symbol: ClosesBySymbol,
         required_points: int,
         required_dates: list[date],
+        primary_exchanges: dict[str, str] | None = None,
     ) -> AlignedClosesResult:
         merged_closes_by_symbol = self._merge_cached_regime_closes(
             symbols,
             api_closes_by_symbol,
             required_dates,
+            primary_exchanges,
         )
         dates, aligned_closes = self._align_regime_closes(
             symbols=symbols,
@@ -2117,6 +2152,7 @@ class RegimeRebalanceEngine:
                 api_closes_by_symbol=api_closes_by_symbol,
                 required_points=required_points,
                 required_dates=required_dates,
+                primary_exchanges=primary_exchanges,
             )
 
     async def _resolve_effective_weights(
@@ -2504,6 +2540,21 @@ class RegimeRebalanceEngine:
             return dict(effective_weights), {}
         ratio_gate = getattr(regime_rebalance, "ratio_gate", None)
 
+        if (
+            self._target_weight_policy_outcome is not None
+            and self._target_weight_policy_outcome.response is not None
+        ):
+            try:
+                validate_decision_expiry(
+                    self._target_weight_policy_outcome.response.expires_at,
+                    now=self._as_utc(self._now()),
+                    decision_name="target weight policy",
+                )
+            except ExternalDecisionError as exc:
+                self._target_weight_policy_outcome = _TargetWeightPolicyOutcome(
+                    adjustments=None, response=None, error=str(exc)
+                )
+
         if self._target_weight_policy_outcome is None:
             try:
                 market_data = await self._load_external_market_data(
@@ -2660,7 +2711,7 @@ class RegimeRebalanceEngine:
             for symbol, adjustment in outcome.adjustments.items():
                 baseline_weight = effective_weights[symbol]
                 raw_weight = baseline_weight * adjustment.multiplier
-                if not math.isfinite(raw_weight) or raw_weight < 0 or raw_weight > 1:
+                if not math.isfinite(raw_weight) or raw_weight < 0:
                     raise ExternalDecisionError(
                         f"target weight policy produced an invalid weight for {symbol}"
                     )
@@ -2672,6 +2723,10 @@ class RegimeRebalanceEngine:
                     effective_weight = max(
                         float(volatility_weight.min_weight),
                         min(effective_weight, float(volatility_weight.max_weight)),
+                    )
+                if effective_weight > 1:
+                    raise ExternalDecisionError(
+                        f"target weight policy produced an invalid weight for {symbol}"
                     )
                 adjusted_weights[symbol] = effective_weight
                 details[symbol] = {
@@ -3139,6 +3194,7 @@ class RegimeRebalanceEngine:
             ("volatility_weight", volatility_details),
             ("absolute_trend", trend_details),
         )
+        target_policy = getattr(regime_rebalance, "target_weight_policy", None)
         harvest_risk_ready_symbols = {
             symbol
             for symbol in symbols
@@ -3154,12 +3210,9 @@ class RegimeRebalanceEngine:
                 for config_name, modifier_details in target_modifier_details
             )
             and (
-                symbol
-                not in getattr(
-                    getattr(regime_rebalance, "target_weight_policy", None),
-                    "symbols",
-                    {},
-                )
+                target_policy is None
+                or not target_policy.enabled
+                or symbol not in target_policy.symbols
                 or bool(
                     target_weight_policy_details.get(symbol, {}).get(
                         "risk_ready", False

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -2350,6 +2350,11 @@ class RegimeRebalanceEngine:
         policy: TargetWeightPolicyConfig,
         error: str,
     ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
+        # A failed application invalidates the signal for the rest of this run,
+        # just like a failed response. Replanning must not revive rejected risk.
+        self._target_weight_policy_outcome = _TargetWeightPolicyOutcome(
+            adjustments=None, response=None, error=error
+        )
         if policy.on_error == "abort":
             raise RuntimeError(
                 f"External target weight policy failed: {error}"

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -4,8 +4,8 @@ import asyncio
 import math
 from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
-from typing import Any
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, Protocol
 
 import exchange_calendars as xcals
 import numpy as np
@@ -16,7 +16,9 @@ from rich.table import Table
 
 from thetagang import log
 from thetagang.accounting import (
+    AccountingError,
     AccountingPolicy,
+    AccountMetric,
     AccountSummary,
     BrokerAccountSnapshot,
     CapitalBaseKind,
@@ -27,10 +29,19 @@ from thetagang.accounting import (
 )
 from thetagang.config import Config
 from thetagang.db import DataStore
+from thetagang.external_decisions import (
+    ExternalDecisionError,
+    ExternalDecisionMarketData,
+    ExternalDecisionProviders,
+    ExternalDecisionResponse,
+    build_external_decision_request,
+    external_decision_response_metadata,
+)
 from thetagang.fmt import dfmt, ffmt, ifmt, pfmt
 from thetagang.ibkr import IBKR, TickerField
 from thetagang.strategies.runtime_services import resolve_symbol_configs
 from thetagang.strategies.tail_harvest_policy import (
+    HarvestBandDecision,
     evaluate_harvest_band,
     minimum_harvest_limit_price,
 )
@@ -38,17 +49,38 @@ from thetagang.strategies.tail_hedge_state import (
     TAIL_HEDGE_HARVEST_ORDER_REF_PREFIX,
     TAIL_HEDGE_MIN_LIMIT_PRICE_ATTR,
     TailHedgeCohort,
+    TailHedgeState,
     TailHedgeStateStore,
     build_tail_reduction_order_ref,
     parse_state_datetime,
+)
+from thetagang.tail_harvest_decision import (
+    TAIL_HARVEST_DECISION_TYPE,
+    validate_tail_harvest_response,
+)
+from thetagang.target_weight_policy import (
+    TARGET_WEIGHT_DECISION_TYPE,
+    TARGET_WEIGHT_POLICY_STATE_EVENT,
+    TargetWeightMultiplier,
+    validate_target_weight_response,
 )
 from thetagang.trading_operations import OrderOperations
 from thetagang.util import midpoint_or_market_price, portfolio_positions_to_dict
 
 AlignedClosesResult = tuple[list[date], dict[str, list[float]]]
-AlignedClosesFetcher = Callable[
-    [list[str], int, int], Coroutine[Any, Any, AlignedClosesResult]
-]
+
+
+class AlignedClosesFetcher(Protocol):
+    def __call__(
+        self,
+        symbols: list[str],
+        lookback_days: int,
+        cooldown_days: int,
+        *,
+        primary_exchanges: dict[str, str] | None = None,
+    ) -> Coroutine[Any, Any, AlignedClosesResult]: ...
+
+
 ClosesBySymbol = dict[str, dict[date, float]]
 TRADING_DAYS_PER_YEAR = 252
 REGIME_HISTORY_TIMEFRAME = "1 day"
@@ -63,6 +95,26 @@ class RegimeHistoryValidationError(ValueError):
     def __init__(self, message: str, *, cache_recoverable: bool) -> None:
         super().__init__(message)
         self.cache_recoverable = cache_recoverable
+
+
+@dataclass(frozen=True)
+class _TargetWeightPolicyOutcome:
+    adjustments: dict[str, TargetWeightMultiplier] | None
+    response: ExternalDecisionResponse | None
+    error: str | None
+
+
+@dataclass(frozen=True)
+class _TailHarvestSnapshot:
+    portfolio_positions: dict[str, list[PortfolioItem]]
+    state: TailHedgeState
+    cohorts: list[TailHedgeCohort]
+    candidates: list[HarvestPut]
+    live_quotes: dict[tuple[str, int], float]
+    net_liquidation: float
+    regime_base: float
+    excluded_option_value: float
+    band: HarvestBandDecision
 
 
 @dataclass(frozen=True)
@@ -287,19 +339,33 @@ def _pfmt_or_dash(value: float | None) -> str:
 class RegimeHistoryCache:
     def __init__(self, fetcher: AlignedClosesFetcher) -> None:
         self._fetcher = fetcher
-        self._cache: dict[tuple[tuple[str, ...], int, int], AlignedClosesResult] = {}
+        self._cache: dict[
+            tuple[tuple[str, ...], int, int, tuple[tuple[str, str], ...]],
+            AlignedClosesResult,
+        ] = {}
 
     async def get(
         self,
         symbols: list[str],
         lookback_days: int,
         cooldown_days: int,
+        *,
+        primary_exchanges: dict[str, str] | None = None,
     ) -> AlignedClosesResult:
-        key = (tuple(symbols), lookback_days, cooldown_days)
+        exchange_key = tuple(sorted((primary_exchanges or {}).items()))
+        key = (tuple(symbols), lookback_days, cooldown_days, exchange_key)
         cached = self._cache.get(key)
         if cached is not None:
             return cached
-        result = await self._fetcher(symbols, lookback_days, cooldown_days)
+        if primary_exchanges:
+            result = await self._fetcher(
+                symbols,
+                lookback_days,
+                cooldown_days,
+                primary_exchanges=primary_exchanges,
+            )
+        else:
+            result = await self._fetcher(symbols, lookback_days, cooldown_days)
         self._cache[key] = result
         return result
 
@@ -312,6 +378,8 @@ class RegimeRebalanceEngine:
         ibkr: IBKR,
         order_ops: OrderOperations,
         data_store: DataStore | None,
+        external_decisions: ExternalDecisionProviders | None = None,
+        dry_run: bool = False,
         get_primary_exchange: Callable[[str], str],
         now_provider: Callable[[], datetime],
         tail_hedge_stage_enabled: Callable[[], bool] | None = None,
@@ -321,6 +389,9 @@ class RegimeRebalanceEngine:
         self.ibkr = ibkr
         self.order_ops = order_ops
         self.data_store = data_store
+        self.external_decisions = external_decisions or ExternalDecisionProviders()
+        self.dry_run = dry_run
+        self._target_weight_policy_outcome: _TargetWeightPolicyOutcome | None = None
         self._get_primary_exchange = get_primary_exchange
         self._now = now_provider
         self._tail_hedge_stage_enabled = tail_hedge_stage_enabled or (lambda: False)
@@ -336,6 +407,11 @@ class RegimeRebalanceEngine:
             else None
         )
         self.regime_rebalance_order_ref_prefix = "tg:regime-rebalance"
+
+    def begin_run(self) -> None:
+        """Clear decisions that may only be reused within one manager run."""
+
+        self._target_weight_policy_outcome = None
 
     def _reserve_cash_for_post_management(self, amount: float) -> None:
         if self._set_reserved_cash_for_post_management is None:
@@ -584,6 +660,7 @@ class RegimeRebalanceEngine:
         cohort: TailHedgeCohort,
         position: PortfolioItem,
         limit_price: float,
+        record_unprofitable: bool = True,
     ) -> HarvestPut | None:
         symbol = cohort.symbol
         contract = position.contract
@@ -621,20 +698,21 @@ class RegimeRebalanceEngine:
             or average_cost <= 0
             or net_proceeds <= average_cost
         ):
-            self._record_tail_harvest(
-                "candidate_not_net_profitable",
-                symbol=symbol,
-                entry_id=cohort.entry_id,
-                con_id=cohort.con_id,
-                gross_proceeds_per_contract=gross_proceeds,
-                estimated_fee_per_contract=estimated_fee,
-                net_proceeds_per_contract=net_proceeds,
-                cost_basis_per_contract=average_cost,
-            )
-            log.info(
-                f"{symbol}: Tail put conId={cohort.con_id} is not profitable "
-                "after its estimated sell fee."
-            )
+            if record_unprofitable:
+                self._record_tail_harvest(
+                    "candidate_not_net_profitable",
+                    symbol=symbol,
+                    entry_id=cohort.entry_id,
+                    con_id=cohort.con_id,
+                    gross_proceeds_per_contract=gross_proceeds,
+                    estimated_fee_per_contract=estimated_fee,
+                    net_proceeds_per_contract=net_proceeds,
+                    cost_basis_per_contract=average_cost,
+                )
+                log.info(
+                    f"{symbol}: Tail put conId={cohort.con_id} is not profitable "
+                    "after its estimated sell fee."
+                )
             return None
 
         contract.exchange = self.order_ops.get_order_exchange()
@@ -690,34 +768,26 @@ class RegimeRebalanceEngine:
                 quoted[(cohort.entry_id, con_id)] = limit_price
         return quoted
 
-    async def _enqueue_tail_harvest(
+    def _build_tail_harvest_snapshot(
         self,
         *,
         net_liquidation: float,
         rebalance_shares: dict[str, int],
         market_prices: dict[str, float],
-        cohorts: list[TailHedgeCohort],
-        portfolio_positions: dict[str, list[PortfolioItem]],
-    ) -> set[str]:
+        quoted_limit_prices: dict[tuple[str, int], float],
+        record_unprofitable: bool,
+    ) -> _TailHarvestSnapshot | None:
         if self._tail_state_store is None:
-            return set()
+            return None
 
-        quoted_limit_prices = await self._quote_tail_puts(
-            symbols=set(rebalance_shares),
-            cohorts=cohorts,
-            portfolio_positions=portfolio_positions,
-        )
-
-        # Quote requests yield to ib_async. Re-evaluate the portfolio-level
-        # band from its current cache before persisting or queuing a sale.
         account_number = self.config.runtime.account.number
-        refreshed_positions = portfolio_positions_to_dict(
+        portfolio_positions = portfolio_positions_to_dict(
             self.ibkr.portfolio(account=account_number)
         )
         state = self._tail_state_store.load()
-        live_cohorts = state.open_cohorts
+        cohorts = state.open_cohorts
         unavailable_con_ids, blocked_symbols, blocked_reason = (
-            self._tail_harvest_conflicts(live_cohorts)
+            self._tail_harvest_conflicts(cohorts)
         )
         if blocked_reason is not None:
             self._record_tail_harvest_blocked(
@@ -725,17 +795,18 @@ class RegimeRebalanceEngine:
                 blocked_symbols=blocked_symbols,
                 reason=blocked_reason,
             )
-            return set()
-        refreshed_puts = self._long_puts_by_con_id(refreshed_positions)
+            return None
+
+        positions_by_con_id = self._long_puts_by_con_id(portfolio_positions)
         cohorts_by_key = {
-            (cohort.entry_id, cohort.con_id): cohort for cohort in live_cohorts
+            (cohort.entry_id, cohort.con_id): cohort for cohort in cohorts
         }
         candidates: list[HarvestPut] = []
         live_quotes: dict[tuple[str, int], float] = {}
         for key, limit_price in quoted_limit_prices.items():
             cohort = cohorts_by_key.get(key)
             con_id = key[1]
-            position = refreshed_puts.get(con_id)
+            position = positions_by_con_id.get(con_id)
             if (
                 cohort is None
                 or cohort.status != "active"
@@ -751,6 +822,7 @@ class RegimeRebalanceEngine:
                 cohort=cohort,
                 position=position,
                 limit_price=limit_price,
+                record_unprofitable=record_unprofitable,
             )
             if candidate is not None:
                 candidates.append(candidate)
@@ -763,51 +835,72 @@ class RegimeRebalanceEngine:
             ),
         )
         sleeve_value = self._tail_hedge_market_value_at_quotes(
-            refreshed_positions,
-            live_cohorts,
+            portfolio_positions,
+            cohorts,
             live_quotes,
         )
-        refreshed_net_liquidation = self._latest_net_liquidation(net_liquidation)
-        refreshed_regime_base, excluded_option_value = (
-            self._regime_rebalance_base_value(
-                net_liquidation=refreshed_net_liquidation,
-                portfolio_positions=refreshed_positions,
-                market_prices=market_prices,
-                cohorts=live_cohorts,
-                # Use the conservative quote-aware tail mark on both sides of
-                # the ratio. This keeps the shared option-exclusion formula
-                # coherent even when IBKR's portfolio mark lags the quote.
-                tail_hedge_value_override=sleeve_value,
-            )
+        current_net_liquidation = self._latest_net_liquidation(net_liquidation)
+        regime_base, excluded_option_value = self._regime_rebalance_base_value(
+            net_liquidation=current_net_liquidation,
+            portfolio_positions=portfolio_positions,
+            market_prices=market_prices,
+            cohorts=cohorts,
+            # Use the conservative quote-aware tail mark on both sides of the
+            # ratio. This keeps the shared option-exclusion formula coherent.
+            tail_hedge_value_override=sleeve_value,
         )
         tail_hedge = self.config.strategies.tail_hedge
-        decision = evaluate_harvest_band(
-            portfolio_base_value=refreshed_regime_base,
+        band = evaluate_harvest_band(
+            portfolio_base_value=regime_base,
             sleeve_value=sleeve_value,
             trigger_weight=tail_hedge.harvest_trigger_weight,
             target_weight=tail_hedge.harvest_target_weight,
         )
-        if decision is None:
-            return set()
-        sale_budget = decision.sale_budget
-        band_payload = {
-            "net_liquidation": refreshed_net_liquidation,
-            "regime_rebalance_base": refreshed_regime_base,
+        if band is None:
+            return None
+        return _TailHarvestSnapshot(
+            portfolio_positions=portfolio_positions,
+            state=state,
+            cohorts=cohorts,
+            candidates=candidates,
+            live_quotes=live_quotes,
+            net_liquidation=current_net_liquidation,
+            regime_base=regime_base,
+            excluded_option_value=excluded_option_value,
+            band=band,
+        )
+
+    def _tail_harvest_band_payload(
+        self,
+        snapshot: _TailHarvestSnapshot,
+        *,
+        rebalance_shares: dict[str, int],
+        market_prices: dict[str, float],
+    ) -> dict[str, Any]:
+        tail_hedge = self.config.strategies.tail_hedge
+        return {
+            "net_liquidation": snapshot.net_liquidation,
+            "regime_rebalance_base": snapshot.regime_base,
             "regime_weight_base": (
                 self.config.strategies.regime_rebalance.weight_base.value
             ),
-            "excluded_option_value": excluded_option_value,
-            "sleeve_value": decision.sleeve_value,
-            "sleeve_weight": decision.sleeve_weight,
+            "excluded_option_value": snapshot.excluded_option_value,
+            "sleeve_value": snapshot.band.sleeve_value,
+            "sleeve_weight": snapshot.band.sleeve_weight,
             "harvest_trigger_weight": tail_hedge.harvest_trigger_weight,
             "harvest_target_weight": tail_hedge.harvest_target_weight,
-            "target_sleeve_value": decision.target_value,
+            "target_sleeve_value": snapshot.band.target_value,
             "approved_rebalance_value": sum(
                 shares * market_prices[symbol]
                 for symbol, shares in rebalance_shares.items()
             ),
         }
 
+    @staticmethod
+    def _select_tail_harvest_candidates(
+        candidates: list[HarvestPut],
+        sale_budget: float,
+    ) -> list[tuple[HarvestPut, int]]:
         selected: list[tuple[HarvestPut, int]] = []
         selected_con_ids: set[int] = set()
         remaining = sale_budget
@@ -826,6 +919,507 @@ class RegimeRebalanceEngine:
             selected.append((candidate, quantity))
             selected_con_ids.add(con_id)
             remaining -= quantity * candidate.gross_proceeds_per_contract
+        return selected
+
+    def _tail_harvest_planned_sales(
+        self,
+        snapshot: _TailHarvestSnapshot,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "entry_id": candidate.entry_id,
+                "symbol": candidate.contract.symbol,
+                "con_id": candidate.contract.conId,
+                "expiration": candidate.expiration,
+                "quantity": quantity,
+                "limit_price": candidate.limit_price,
+                "estimated_gross_proceeds": (
+                    quantity * candidate.gross_proceeds_per_contract
+                ),
+                "estimated_fees": quantity * candidate.estimated_fee_per_contract,
+                "estimated_net_proceeds": (
+                    quantity * candidate.net_proceeds_per_contract
+                ),
+            }
+            for candidate, quantity in self._select_tail_harvest_candidates(
+                snapshot.candidates,
+                snapshot.band.sale_budget,
+            )
+        ]
+
+    @staticmethod
+    def _finite_float_or_none(value: Any) -> float | None:
+        if isinstance(value, bool):
+            return None
+        try:
+            number = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        return number if math.isfinite(number) else None
+
+    def _tail_harvest_hedge_inputs(
+        self, snapshot: _TailHarvestSnapshot
+    ) -> list[dict[str, Any]]:
+        positions_by_con_id = self._long_puts_by_con_id(snapshot.portfolio_positions)
+        candidates_by_key = {
+            (candidate.entry_id, candidate.contract.conId): candidate
+            for candidate in snapshot.candidates
+        }
+        inputs: list[dict[str, Any]] = []
+        for cohort in snapshot.cohorts:
+            key = (cohort.entry_id, cohort.con_id)
+            position = positions_by_con_id.get(cohort.con_id)
+            owned_position = (
+                self._owned_tail_position_value(position, cohort)
+                if position is not None
+                else None
+            )
+            owned_quantity = owned_position[0] if owned_position is not None else 0
+            reported_owned_value = (
+                owned_position[1] if owned_position is not None else None
+            )
+            live_quantity = self._finite_float_or_none(
+                getattr(position, "position", None)
+            )
+            live_market_value = self._finite_float_or_none(
+                getattr(position, "marketValue", None)
+            )
+            live_unrealized_pnl = self._finite_float_or_none(
+                getattr(position, "unrealizedPNL", None)
+            )
+            live_realized_pnl = self._finite_float_or_none(
+                getattr(position, "realizedPNL", None)
+            )
+            live_average_cost = self._finite_float_or_none(
+                getattr(position, "averageCost", None)
+            )
+            ownership_ratio = (
+                owned_quantity / live_quantity
+                if live_quantity is not None and live_quantity > 0
+                else None
+            )
+            candidate = candidates_by_key.get(key)
+            inputs.append(
+                {
+                    "entry_id": cohort.entry_id,
+                    "symbol": cohort.symbol,
+                    "status": cohort.status,
+                    "contract": {
+                        "con_id": cohort.con_id,
+                        "expiration": cohort.expiration,
+                        "strike": cohort.strike,
+                        "right": "P",
+                        "multiplier": self._finite_float_or_none(
+                            getattr(
+                                getattr(position, "contract", None),
+                                "multiplier",
+                                None,
+                            )
+                        ),
+                    },
+                    "state_owned_quantity": owned_quantity,
+                    "live_position_quantity": live_quantity,
+                    "reported_owned_market_value": reported_owned_value,
+                    "live_position_market_value": live_market_value,
+                    "live_average_cost_per_contract": live_average_cost,
+                    "live_realized_pnl": live_realized_pnl,
+                    "state_owned_unrealized_pnl": (
+                        live_unrealized_pnl * ownership_ratio
+                        if live_unrealized_pnl is not None
+                        and ownership_ratio is not None
+                        else None
+                    ),
+                    "quoted_limit_price": snapshot.live_quotes.get(key),
+                    "entered_at": self._as_utc(cohort.entered_at).isoformat(),
+                    "entry_limit_price": cohort.entry_limit_price,
+                    "estimated_cost": cohort.estimated_cost,
+                    "recovered_cost": cohort.recovered_cost,
+                    "unrecovered_cost": cohort.net_charge,
+                    "host_candidate": candidate is not None,
+                    "candidate": (
+                        {
+                            "quantity": candidate.quantity,
+                            "gross_proceeds_per_contract": (
+                                candidate.gross_proceeds_per_contract
+                            ),
+                            "estimated_fee_per_contract": (
+                                candidate.estimated_fee_per_contract
+                            ),
+                            "net_proceeds_per_contract": (
+                                candidate.net_proceeds_per_contract
+                            ),
+                            "cost_basis_per_contract": (
+                                candidate.cost_basis_per_contract
+                            ),
+                            "profit_multiple": candidate.profit_multiple,
+                        }
+                        if candidate is not None
+                        else None
+                    ),
+                }
+            )
+        return inputs
+
+    def _tail_harvest_underlying_inputs(
+        self,
+        snapshot: _TailHarvestSnapshot,
+        *,
+        rebalance_shares: dict[str, int],
+        market_prices: dict[str, float],
+        regime_summary: list[dict[str, Any]],
+    ) -> dict[str, dict[str, Any]]:
+        summaries = {str(item["symbol"]): item for item in regime_summary}
+        result: dict[str, dict[str, Any]] = {}
+        for target in self.config.strategies.tail_hedge.targets:
+            symbol = target.symbol
+            summary = summaries.get(symbol, {})
+            stock_positions = [
+                position
+                for position in snapshot.portfolio_positions.get(symbol, [])
+                if isinstance(position.contract, Stock)
+            ]
+            live_shares = sum(
+                self._finite_float_or_none(position.position) or 0.0
+                for position in stock_positions
+            )
+            reported_market_value = sum(
+                self._finite_float_or_none(position.marketValue) or 0.0
+                for position in stock_positions
+            )
+            reported_unrealized_pnl = sum(
+                self._finite_float_or_none(getattr(position, "unrealizedPNL", None))
+                or 0.0
+                for position in stock_positions
+            )
+            reported_realized_pnl = sum(
+                self._finite_float_or_none(getattr(position, "realizedPNL", None))
+                or 0.0
+                for position in stock_positions
+            )
+            gross_shares = sum(
+                abs(self._finite_float_or_none(position.position) or 0.0)
+                for position in stock_positions
+            )
+            weighted_cost = sum(
+                abs(self._finite_float_or_none(position.position) or 0.0)
+                * (
+                    self._finite_float_or_none(getattr(position, "averageCost", None))
+                    or 0.0
+                )
+                for position in stock_positions
+            )
+            market_price = market_prices.get(symbol)
+            current_value = self._finite_float_or_none(summary.get("current_value"))
+            if current_value is None:
+                current_value = sum(
+                    self._finite_float_or_none(position.marketValue) or 0.0
+                    for position in stock_positions
+                )
+            current_shares = self._finite_float_or_none(summary.get("current_shares"))
+            if current_shares is None:
+                current_shares = live_shares
+            symbol_config = self.config.portfolio.symbols[symbol]
+            result[symbol] = {
+                "configured_weight": float(symbol_config.weight),
+                "primary_exchange": str(symbol_config.primary_exchange),
+                "market_price": market_price,
+                "current_shares": current_shares,
+                "current_value": current_value,
+                "broker_position": {
+                    "shares": live_shares,
+                    "market_value": reported_market_value,
+                    "average_cost_per_share": (
+                        weighted_cost / gross_shares if gross_shares > 0 else None
+                    ),
+                    "unrealized_pnl": reported_unrealized_pnl,
+                    "realized_pnl": reported_realized_pnl,
+                },
+                "current_weight": self._finite_float_or_none(
+                    summary.get("current_weight")
+                ),
+                "target_weight": self._finite_float_or_none(
+                    summary.get("target_weight")
+                ),
+                "target_value": self._finite_float_or_none(summary.get("target_value")),
+                "target_shares": self._finite_float_or_none(
+                    summary.get("target_shares")
+                ),
+                "approved_buy_shares": rebalance_shares.get(symbol, 0),
+                "approved_buy_value": (
+                    rebalance_shares.get(symbol, 0) * market_price
+                    if market_price is not None
+                    else None
+                ),
+                "tail_program": {
+                    "budget_weight": target.budget_weight,
+                    "entries_per_year": target.entries_per_year,
+                    "entry_gate": target.entry_gate,
+                    "entry_vix_max": target.entry_vix_max,
+                    "target_dte": target.target_dte,
+                    "min_dte": target.min_dte,
+                    "max_dte": target.max_dte,
+                    "exit_dte": target.exit_dte,
+                    "minimum_open_interest": target.minimum_open_interest,
+                    "minimum_bid": target.minimum_bid,
+                    "max_bid_ask_ratio": target.max_bid_ask_ratio,
+                    "max_premium_ratio": target.max_premium_ratio,
+                    "catastrophe_drawdowns": target.catastrophe_drawdowns,
+                },
+                "target_modifiers": {
+                    "volatility_weight": summary.get("volatility_weight"),
+                    "target_weight_policy": summary.get("target_weight_policy"),
+                    "absolute_trend": summary.get("absolute_trend"),
+                },
+            }
+        return result
+
+    def _tail_harvest_decision_fallback(
+        self,
+        *,
+        policy: Any,
+        error: str,
+    ) -> tuple[bool, dict[str, Any]]:
+        if policy.on_error == "abort":
+            raise RuntimeError(f"External tail harvest decision failed: {error}")
+        harvest = policy.on_error == "baseline"
+        status = "baseline" if harvest else "skipped"
+        log.warning(
+            f"External tail harvest decision failed; using {status} behavior ({error})."
+        )
+        return harvest, {
+            "status": status,
+            "harvest": harvest,
+            "reason": None,
+            "error": error,
+            "provider": policy.provider,
+        }
+
+    async def _evaluate_tail_harvest_decision(
+        self,
+        snapshot: _TailHarvestSnapshot,
+        *,
+        rebalance_shares: dict[str, int],
+        market_prices: dict[str, float],
+        regime_summary: list[dict[str, Any]],
+        history_cache: RegimeHistoryCache | None = None,
+    ) -> tuple[bool, dict[str, Any]]:
+        tail_hedge = self.config.strategies.tail_hedge
+        policy = getattr(tail_hedge, "harvest_decision", None)
+        if policy is None or not getattr(policy, "enabled", False):
+            return True, {}
+
+        try:
+            market_data_config = policy.market_data
+            market_data = await self._load_external_market_data(
+                market_data_config=market_data_config,
+                strategy_symbols=(target.symbol for target in tail_hedge.targets),
+                symbol_configs=self.config.portfolio.symbols,
+                decision_name="tail harvest decision",
+                history_cache=history_cache,
+            )
+            band_payload = self._tail_harvest_band_payload(
+                snapshot,
+                rebalance_shares=rebalance_shares,
+                market_prices=market_prices,
+            )
+            request = build_external_decision_request(
+                decision_type=TAIL_HARVEST_DECISION_TYPE,
+                generated_at=self._as_utc(self._now()),
+                dry_run=self.dry_run,
+                input_data={
+                    "strategy": {
+                        "name": "tail_hedge",
+                        "annual_budget": float(tail_hedge.annual_budget),
+                        "regime_weight_base": (
+                            self.config.strategies.regime_rebalance.weight_base.value
+                        ),
+                        "regime_margin_usage": (
+                            AccountingPolicy.from_config(
+                                self.config
+                            ).regime_margin_usage
+                        ),
+                    },
+                    "host_constraints": {
+                        "baseline_band_triggered": True,
+                        "requires_approved_same_symbol_hard_underweight_buy": True,
+                        "state_owned_active_profitable_puts_only": True,
+                        "host_selects_contracts_quantities_and_limit_prices": True,
+                    },
+                    "account": {
+                        "net_liquidation": snapshot.net_liquidation,
+                        "regime_rebalance_base": snapshot.regime_base,
+                        "excluded_option_value": snapshot.excluded_option_value,
+                    },
+                    "opportunity": {
+                        "sleeve_value": snapshot.band.sleeve_value,
+                        "sleeve_weight": snapshot.band.sleeve_weight,
+                        "harvest_trigger_weight": tail_hedge.harvest_trigger_weight,
+                        "harvest_target_weight": tail_hedge.harvest_target_weight,
+                        "target_sleeve_value": snapshot.band.target_value,
+                        "sale_budget": snapshot.band.sale_budget,
+                        "approved_rebalance_value": band_payload[
+                            "approved_rebalance_value"
+                        ],
+                        "planned_sales": self._tail_harvest_planned_sales(snapshot),
+                    },
+                    "underlyings": self._tail_harvest_underlying_inputs(
+                        snapshot,
+                        rebalance_shares=rebalance_shares,
+                        market_prices=market_prices,
+                        regime_summary=regime_summary,
+                    ),
+                    "hedge_positions": self._tail_harvest_hedge_inputs(snapshot),
+                    "market_data": market_data.request_input(),
+                },
+            )
+            response = await self.external_decisions.decide(policy.provider, request)
+            output = validate_tail_harvest_response(
+                response,
+                policy=policy,
+                history_dates=market_data.sessions,
+                now=self._as_utc(self._now()),
+            )
+            return output.harvest, {
+                "status": "applied",
+                "harvest": output.harvest,
+                "reason": output.reason,
+                "error": None,
+                **external_decision_response_metadata(
+                    response,
+                    provider=policy.provider,
+                ),
+            }
+        except Exception as exc:  # noqa: BLE001
+            return self._tail_harvest_decision_fallback(
+                policy=policy,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    async def _enqueue_tail_harvest(
+        self,
+        *,
+        net_liquidation: float,
+        rebalance_shares: dict[str, int],
+        market_prices: dict[str, float],
+        regime_summary: list[dict[str, Any]],
+        cohorts: list[TailHedgeCohort],
+        portfolio_positions: dict[str, list[PortfolioItem]],
+        history_cache: RegimeHistoryCache | None = None,
+    ) -> set[str]:
+        if self._tail_state_store is None:
+            return set()
+
+        quoted_limit_prices = await self._quote_tail_puts(
+            symbols=set(rebalance_shares),
+            cohorts=cohorts,
+            portfolio_positions=portfolio_positions,
+        )
+
+        # Quote requests yield to ib_async. Re-evaluate all host-owned safety
+        # constraints from the current cache before consulting an external
+        # decision provider.
+        policy = self.config.strategies.tail_hedge.harvest_decision
+        snapshot = self._build_tail_harvest_snapshot(
+            net_liquidation=net_liquidation,
+            rebalance_shares=rebalance_shares,
+            market_prices=market_prices,
+            quoted_limit_prices=quoted_limit_prices,
+            record_unprofitable=not policy.enabled,
+        )
+        if snapshot is None:
+            return set()
+
+        if not snapshot.candidates:
+            # The first snapshot suppresses this per-cohort telemetry while an
+            # external policy is enabled so an approved result will not record
+            # it twice. Restore the baseline event when there is nothing to ask.
+            if policy.enabled:
+                snapshot = self._build_tail_harvest_snapshot(
+                    net_liquidation=net_liquidation,
+                    rebalance_shares=rebalance_shares,
+                    market_prices=market_prices,
+                    quoted_limit_prices=quoted_limit_prices,
+                    record_unprofitable=True,
+                )
+                if snapshot is None:
+                    return set()
+            band_payload = self._tail_harvest_band_payload(
+                snapshot,
+                rebalance_shares=rebalance_shares,
+                market_prices=market_prices,
+            )
+            for symbol, shares in rebalance_shares.items():
+                self._record_tail_harvest(
+                    "no_eligible_cohort",
+                    symbol=symbol,
+                    rebalance_shares=shares,
+                    sale_budget=snapshot.band.sale_budget,
+                    **band_payload,
+                )
+            return set()
+
+        should_harvest, external_decision = await self._evaluate_tail_harvest_decision(
+            snapshot,
+            rebalance_shares=rebalance_shares,
+            market_prices=market_prices,
+            regime_summary=regime_summary,
+            history_cache=history_cache,
+        )
+        if external_decision:
+            band_payload = self._tail_harvest_band_payload(
+                snapshot,
+                rebalance_shares=rebalance_shares,
+                market_prices=market_prices,
+            )
+            for symbol, shares in rebalance_shares.items():
+                self._record_tail_harvest(
+                    "external_policy_decision",
+                    symbol=symbol,
+                    rebalance_shares=shares,
+                    sale_budget=snapshot.band.sale_budget,
+                    external_decision=external_decision,
+                    **band_payload,
+                )
+        if not should_harvest:
+            log.notice(
+                "External tail-harvest policy declined the eligible baseline "
+                "harvest opportunity."
+            )
+            return set()
+
+        if policy.enabled:
+            # The provider and market-history requests yield. Re-quote and
+            # rebuild the complete snapshot before any state or order mutation;
+            # the external result cannot bypass changed ownership, conflicts,
+            # profitability, or the allocation band.
+            quoted_limit_prices = await self._quote_tail_puts(
+                symbols=set(rebalance_shares),
+                cohorts=snapshot.cohorts,
+                portfolio_positions=snapshot.portfolio_positions,
+            )
+            snapshot = self._build_tail_harvest_snapshot(
+                net_liquidation=net_liquidation,
+                rebalance_shares=rebalance_shares,
+                market_prices=market_prices,
+                quoted_limit_prices=quoted_limit_prices,
+                record_unprofitable=True,
+            )
+            if snapshot is None:
+                return set()
+
+        candidates = snapshot.candidates
+        state = snapshot.state
+        decision = snapshot.band
+        sale_budget = decision.sale_budget
+        band_payload = self._tail_harvest_band_payload(
+            snapshot,
+            rebalance_shares=rebalance_shares,
+            market_prices=market_prices,
+        )
+        if external_decision:
+            band_payload["external_decision"] = external_decision
+
+        selected = self._select_tail_harvest_candidates(candidates, sale_budget)
 
         if not selected:
             for symbol, shares in rebalance_shares.items():
@@ -959,6 +1553,7 @@ class RegimeRebalanceEngine:
         regime_summary: list[dict[str, Any]],
         hard_underweight_symbols: set[str],
         cohorts: list[TailHedgeCohort],
+        history_cache: RegimeHistoryCache | None = None,
     ) -> list[tuple[str, str, int]]:
         targets = self._configured_tail_harvest_targets()
         if not targets or not cohorts or not hard_underweight_symbols:
@@ -1024,8 +1619,10 @@ class RegimeRebalanceEngine:
             net_liquidation=current_net_liquidation,
             rebalance_shares=rebalance_shares,
             market_prices=market_prices,
+            regime_summary=regime_summary,
             cohorts=cohorts,
             portfolio_positions=portfolio_positions,
+            history_cache=history_cache,
         )
         summaries = {str(item["symbol"]): item for item in regime_summary}
         for symbol in enqueued_symbols:
@@ -1360,13 +1957,16 @@ class RegimeRebalanceEngine:
             return None
 
     async def _fetch_regime_history_bars(
-        self, symbol: str, duration: str
+        self,
+        symbol: str,
+        duration: str,
+        primary_exchange: str | None = None,
     ) -> tuple[str, list[Any]]:
         contract = Stock(
             symbol,
             self.order_ops.get_order_exchange(),
             currency="USD",
-            primaryExchange=self.get_primary_exchange(symbol),
+            primaryExchange=primary_exchange or self.get_primary_exchange(symbol),
         )
         for attempt in range(1, REGIME_HISTORY_MAX_ATTEMPTS + 1):
             bars = list(await self.ibkr.request_historical_data(contract, duration))
@@ -1390,10 +1990,18 @@ class RegimeRebalanceEngine:
         return symbol, []
 
     async def _fetch_regime_history_closes(
-        self, symbols: list[str], duration: str
+        self,
+        symbols: list[str],
+        duration: str,
+        primary_exchanges: dict[str, str] | None = None,
     ) -> ClosesBySymbol:
         tasks: list[Coroutine[Any, Any, tuple[str, list[Any]]]] = [
-            self._fetch_regime_history_bars(symbol, duration) for symbol in symbols
+            self._fetch_regime_history_bars(
+                symbol,
+                duration,
+                (primary_exchanges or {}).get(symbol),
+            )
+            for symbol in symbols
         ]
         histories = await log.track_async(
             tasks, description="Fetching regime rebalancing history..."
@@ -1467,6 +2075,8 @@ class RegimeRebalanceEngine:
         symbols: list[str],
         lookback_days: int,
         cooldown_days: int,
+        *,
+        primary_exchanges: dict[str, str] | None = None,
     ) -> tuple[list[date], dict[str, list[float]]]:
         if not symbols:
             log.error("Regime-aware rebalancing has no symbols to build a proxy.")
@@ -1486,7 +2096,9 @@ class RegimeRebalanceEngine:
             )
         duration = f"{calendar_days} D"
         api_closes_by_symbol = await self._fetch_regime_history_closes(
-            symbols, duration
+            symbols,
+            duration,
+            primary_exchanges,
         )
 
         try:
@@ -1664,6 +2276,443 @@ class RegimeRebalanceEngine:
                     )
 
         return effective_weights, volatility_details
+
+    @staticmethod
+    def _as_utc(value: datetime) -> datetime:
+        # datetime.astimezone() correctly interprets a naive value in the
+        # process-local timezone. Replacing tzinfo would merely relabel local
+        # wall time as UTC and could make expiry checks several hours late.
+        return value.astimezone(UTC)
+
+    async def _load_external_market_data(
+        self,
+        *,
+        market_data_config: Any,
+        strategy_symbols: Iterable[str],
+        symbol_configs: dict[str, Any],
+        decision_name: str,
+        history_cache: RegimeHistoryCache | None = None,
+    ) -> ExternalDecisionMarketData:
+        history_symbols: list[str] = []
+        if market_data_config.include_strategy_symbols:
+            history_symbols.extend(strategy_symbols)
+        history_symbols.extend(market_data_config.symbols)
+        history_symbols = list(dict.fromkeys(history_symbols))
+        if not history_symbols:
+            raise ExternalDecisionError(
+                f"{decision_name} market data universe is empty"
+            )
+
+        primary_exchanges: dict[str, str] = {}
+        history_exchange_overrides: dict[str, str] = {}
+        for symbol in history_symbols:
+            market_symbol = market_data_config.symbols.get(symbol)
+            explicit_exchange = (
+                market_symbol.primary_exchange.strip()
+                if market_symbol is not None
+                else ""
+            )
+            configured_exchange = explicit_exchange
+            if not configured_exchange and symbol in symbol_configs:
+                configured_exchange = str(
+                    symbol_configs[symbol].primary_exchange
+                ).strip()
+            if not configured_exchange:
+                raise ExternalDecisionError(
+                    f"{decision_name} market data symbol {symbol} does not have "
+                    "a primary exchange"
+                )
+            primary_exchanges[symbol] = configured_exchange
+            if explicit_exchange:
+                history_exchange_overrides[symbol] = configured_exchange
+
+        lookback_days = int(market_data_config.lookback_days)
+        if history_cache is None:
+            history_dates, aligned_closes = await self._get_regime_aligned_closes(
+                history_symbols,
+                lookback_days,
+                0,
+                primary_exchanges=history_exchange_overrides or None,
+            )
+        else:
+            history_dates, aligned_closes = await history_cache.get(
+                history_symbols,
+                lookback_days,
+                0,
+                primary_exchanges=history_exchange_overrides or None,
+            )
+        return ExternalDecisionMarketData(
+            timeframe=REGIME_HISTORY_TIMEFRAME,
+            sessions=history_dates,
+            closes=aligned_closes,
+            primary_exchanges=primary_exchanges,
+        )
+
+    def _target_weight_policy_fallback(
+        self,
+        effective_weights: dict[str, float],
+        *,
+        policy: Any,
+        error: str,
+    ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
+        if policy.on_error == "abort":
+            raise RuntimeError(
+                f"External target weight policy failed: {error}"
+            ) from None
+        log.warning(
+            "External target weight policy failed; using post-volatility "
+            f"baseline targets ({error})."
+        )
+        return (
+            dict(effective_weights),
+            {
+                symbol: {
+                    "status": "baseline",
+                    "baseline_weight": effective_weights[symbol],
+                    "multiplier": 1.0,
+                    "raw_weight": effective_weights[symbol],
+                    "effective_weight": effective_weights[symbol],
+                    "reason": None,
+                    "error": error,
+                    "risk_ready": False,
+                }
+                for symbol in policy.symbols
+            },
+        )
+
+    @staticmethod
+    def _target_weight_policy_total_limit(
+        effective_weights: dict[str, float], policy: Any
+    ) -> float:
+        return max(sum(effective_weights.values()), policy.max_total_weight or 1.0)
+
+    def _target_weight_symbol_input(
+        self,
+        symbol: str,
+        *,
+        symbol_config: Any,
+        volatility_detail: dict[str, float] | None,
+        effective_weight: float,
+        total_value: float,
+        current_position: int,
+        current_value: float,
+        market_price: float,
+    ) -> dict[str, Any]:
+        volatility_weight = getattr(symbol_config, "volatility_weight", None)
+        volatility_config = None
+        if volatility_weight is not None:
+            volatility_config = {
+                "enabled": bool(volatility_weight.enabled),
+                "target_vol": float(volatility_weight.target_vol),
+                "lookback_days": int(volatility_weight.lookback_days),
+                "min_weight": float(volatility_weight.min_weight),
+                "max_weight": float(volatility_weight.max_weight),
+                "rebalance_band": float(volatility_weight.rebalance_band),
+                "smoothing_factor": float(volatility_weight.smoothing_factor),
+                "increase_smoothing_factor": (
+                    float(volatility_weight.increase_smoothing_factor)
+                    if volatility_weight.increase_smoothing_factor is not None
+                    else None
+                ),
+                "decrease_smoothing_factor": (
+                    float(volatility_weight.decrease_smoothing_factor)
+                    if volatility_weight.decrease_smoothing_factor is not None
+                    else None
+                ),
+            }
+
+        absolute_trend = getattr(symbol_config, "absolute_trend", None)
+        absolute_trend_config = None
+        if absolute_trend is not None:
+            absolute_trend_config = {
+                "enabled": bool(absolute_trend.enabled),
+                "lookback_days": int(absolute_trend.lookback_days),
+                "risk_off_multiplier": float(absolute_trend.risk_off_multiplier),
+            }
+
+        rebalance_policy_fn = getattr(self.config, "regime_rebalance_policy", None)
+        rebalance_policy = (
+            rebalance_policy_fn(symbol) if callable(rebalance_policy_fn) else None
+        )
+
+        def resolved_threshold(name: str) -> Any:
+            policy_value = getattr(rebalance_policy, name, None)
+            if policy_value is not None:
+                return policy_value
+            suffix = name.removeprefix("min_threshold_")
+            buy_value = getattr(
+                symbol_config,
+                f"buy_only_min_threshold_{suffix}",
+                None,
+            )
+            if buy_value is not None:
+                return buy_value
+            return getattr(
+                symbol_config,
+                f"sell_only_min_threshold_{suffix}",
+                None,
+            )
+
+        return {
+            "configured_weight": float(symbol_config.weight),
+            "post_volatility_weight": effective_weight,
+            "current_weight": current_value / total_value,
+            "current_value": current_value,
+            "current_shares": current_position,
+            "market_price": market_price,
+            "volatility_weight": {
+                "config": volatility_config,
+                "calculation": volatility_detail,
+            },
+            "absolute_trend": absolute_trend_config,
+            "execution_constraints": {
+                "trading_allowed": bool(self.config.trading_is_allowed(symbol)),
+                "rebalance_mode": (
+                    rebalance_policy.mode.value
+                    if rebalance_policy is not None
+                    else "both"
+                ),
+                "min_threshold_shares": resolved_threshold("min_threshold_shares"),
+                "min_threshold_amount": resolved_threshold("min_threshold_amount"),
+                "min_threshold_percent": resolved_threshold("min_threshold_percent"),
+                "min_threshold_percent_relative": resolved_threshold(
+                    "min_threshold_percent_relative"
+                ),
+            },
+        }
+
+    async def _apply_target_weight_policy(
+        self,
+        effective_weights: dict[str, float],
+        *,
+        symbols: list[str],
+        symbol_configs: dict[str, Any],
+        volatility_details: dict[str, dict[str, float]],
+        account: BrokerAccountSnapshot,
+        regime_margin_usage: float,
+        total_value: float,
+        excluded_value: float,
+        last_rebalance: datetime | None,
+        current_positions: dict[str, int],
+        current_values: dict[str, float],
+        market_prices: dict[str, float],
+        history_cache: RegimeHistoryCache | None = None,
+    ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
+        regime_rebalance = self.config.strategies.regime_rebalance
+        policy = getattr(regime_rebalance, "target_weight_policy", None)
+        if policy is None or not getattr(policy, "enabled", False):
+            return dict(effective_weights), {}
+        ratio_gate = getattr(regime_rebalance, "ratio_gate", None)
+
+        if self._target_weight_policy_outcome is None:
+            try:
+                market_data = await self._load_external_market_data(
+                    market_data_config=policy.market_data,
+                    strategy_symbols=symbols,
+                    symbol_configs=symbol_configs,
+                    decision_name="target weight policy",
+                    history_cache=history_cache,
+                )
+                account_metrics: dict[str, float] = {}
+                for metric in AccountMetric:
+                    try:
+                        account_metrics[metric.value] = account.value(metric)
+                    except AccountingError:
+                        continue
+
+                allowed_total_weight = self._target_weight_policy_total_limit(
+                    effective_weights,
+                    policy,
+                )
+                request = build_external_decision_request(
+                    decision_type=TARGET_WEIGHT_DECISION_TYPE,
+                    generated_at=self._as_utc(self._now()),
+                    dry_run=self.dry_run,
+                    input_data={
+                        "strategy": {
+                            "name": "regime_rebalance",
+                            "weight_base": regime_rebalance.weight_base.value,
+                            "margin_usage": regime_margin_usage,
+                            "lookback_days": int(regime_rebalance.lookback_days),
+                            "soft_band": float(regime_rebalance.soft_band),
+                            "hard_band": float(regime_rebalance.hard_band),
+                            "hard_band_rebalance_fraction": float(
+                                regime_rebalance.hard_band_rebalance_fraction
+                            ),
+                            "cooldown_days": int(regime_rebalance.cooldown_days),
+                            "last_rebalance_at": (
+                                self._as_utc(last_rebalance).isoformat()
+                                if last_rebalance is not None
+                                else None
+                            ),
+                            "choppiness_min": float(regime_rebalance.choppiness_min),
+                            "efficiency_max": float(regime_rebalance.efficiency_max),
+                            "flow_trade_min": float(regime_rebalance.flow_trade_min),
+                            "flow_trade_stop": float(regime_rebalance.flow_trade_stop),
+                            "flow_imbalance_tau": float(
+                                regime_rebalance.flow_imbalance_tau
+                            ),
+                            "deficit_rail_start": float(
+                                regime_rebalance.deficit_rail_start
+                            ),
+                            "deficit_rail_stop": float(
+                                regime_rebalance.deficit_rail_stop
+                            ),
+                            "ratio_gate": (
+                                {
+                                    "enabled": bool(ratio_gate.enabled),
+                                    "anchor": str(ratio_gate.anchor),
+                                    "drift_max": float(ratio_gate.drift_max),
+                                    "vol_min": (
+                                        float(ratio_gate.vol_min)
+                                        if ratio_gate.vol_min is not None
+                                        else None
+                                    ),
+                                }
+                                if ratio_gate is not None
+                                else None
+                            ),
+                        },
+                        "account": {
+                            "metrics": account_metrics,
+                            "rebalance_base_value": total_value,
+                            "excluded_option_value": excluded_value,
+                        },
+                        "portfolio": {
+                            "configured_total_weight": sum(
+                                float(symbol_configs[symbol].weight)
+                                for symbol in symbols
+                            ),
+                            "post_volatility_total_weight": sum(
+                                effective_weights.values()
+                            ),
+                        },
+                        "symbols": {
+                            symbol: self._target_weight_symbol_input(
+                                symbol,
+                                symbol_config=symbol_configs[symbol],
+                                volatility_detail=volatility_details.get(symbol),
+                                effective_weight=effective_weights[symbol],
+                                total_value=total_value,
+                                current_position=current_positions[symbol],
+                                current_value=current_values[symbol],
+                                market_price=market_prices[symbol],
+                            )
+                            for symbol in symbols
+                        },
+                        "adjustment_constraints": {
+                            symbol: {
+                                "min_multiplier": limits.min_multiplier,
+                                "max_multiplier": limits.max_multiplier,
+                                "clamp_to_volatility_bounds": (
+                                    limits.clamp_to_volatility_bounds
+                                ),
+                            }
+                            for symbol, limits in policy.symbols.items()
+                        },
+                        "total_weight_constraint": {
+                            "max_total_weight": policy.max_total_weight,
+                            "effective_max_total_weight": allowed_total_weight,
+                            "default_prevents_additional_leverage": (
+                                policy.max_total_weight is None
+                            ),
+                        },
+                        "market_data": market_data.request_input(),
+                    },
+                )
+                response = await self.external_decisions.decide(
+                    policy.provider,
+                    request,
+                )
+                adjustments = validate_target_weight_response(
+                    response,
+                    policy=policy,
+                    history_dates=market_data.sessions,
+                    now=self._as_utc(self._now()),
+                )
+                self._target_weight_policy_outcome = _TargetWeightPolicyOutcome(
+                    adjustments=adjustments,
+                    response=response,
+                    error=None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                self._target_weight_policy_outcome = _TargetWeightPolicyOutcome(
+                    adjustments=None,
+                    response=None,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+
+        outcome = self._target_weight_policy_outcome
+        if (
+            outcome.error is not None
+            or outcome.adjustments is None
+            or outcome.response is None
+        ):
+            return self._target_weight_policy_fallback(
+                effective_weights,
+                policy=policy,
+                error=outcome.error or "provider returned no adjustments",
+            )
+
+        adjusted_weights = dict(effective_weights)
+        details: dict[str, dict[str, Any]] = {}
+        try:
+            for symbol, adjustment in outcome.adjustments.items():
+                baseline_weight = effective_weights[symbol]
+                raw_weight = baseline_weight * adjustment.multiplier
+                if not math.isfinite(raw_weight) or raw_weight < 0 or raw_weight > 1:
+                    raise ExternalDecisionError(
+                        f"target weight policy produced an invalid weight for {symbol}"
+                    )
+
+                effective_weight = raw_weight
+                limits = policy.symbols[symbol]
+                if limits.clamp_to_volatility_bounds:
+                    volatility_weight = symbol_configs[symbol].volatility_weight
+                    effective_weight = max(
+                        float(volatility_weight.min_weight),
+                        min(effective_weight, float(volatility_weight.max_weight)),
+                    )
+                adjusted_weights[symbol] = effective_weight
+                details[symbol] = {
+                    "status": "applied",
+                    "baseline_weight": baseline_weight,
+                    "multiplier": adjustment.multiplier,
+                    "raw_weight": raw_weight,
+                    "effective_weight": effective_weight,
+                    "reason": adjustment.reason,
+                    **external_decision_response_metadata(
+                        outcome.response,
+                        provider=policy.provider,
+                    ),
+                    "risk_ready": True,
+                }
+
+            adjusted_total = sum(adjusted_weights.values())
+            allowed_total = self._target_weight_policy_total_limit(
+                effective_weights,
+                policy,
+            )
+            if adjusted_total > allowed_total + regime_rebalance.eps:
+                raise ExternalDecisionError(
+                    "target weight policy exceeds the permitted total weight"
+                )
+        except (AttributeError, KeyError, TypeError, ExternalDecisionError) as exc:
+            return self._target_weight_policy_fallback(
+                effective_weights,
+                policy=policy,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        for symbol, detail in details.items():
+            log.notice(
+                f"{symbol}: external target policy provider={policy.provider} "
+                f"producer={detail['producer']}@{detail['producer_version']} "
+                f"multiplier={ffmt(detail['multiplier'])} "
+                f"target={pfmt(detail['baseline_weight'])}->"
+                f"{pfmt(detail['effective_weight'])}"
+            )
+        return adjusted_weights, details
 
     async def _apply_absolute_trend(
         self,
@@ -2056,6 +3105,28 @@ class RegimeRebalanceEngine:
             history_cache,
             exclude_current_run_state=exclude_current_run_state,
         )
+        post_volatility_effective_weights = dict(effective_weights)
+        post_volatility_total_effective_weight = sum(
+            post_volatility_effective_weights.values()
+        )
+        (
+            effective_weights,
+            target_weight_policy_details,
+        ) = await self._apply_target_weight_policy(
+            effective_weights,
+            symbols=symbols,
+            symbol_configs=symbol_configs,
+            volatility_details=volatility_details,
+            account=account,
+            regime_margin_usage=regime_margin_usage,
+            total_value=total_value,
+            excluded_value=excluded_value,
+            last_rebalance=last_rebalance,
+            current_positions=current_positions,
+            current_values=current_values,
+            market_prices=market_prices,
+            history_cache=history_cache,
+        )
         pre_trend_effective_weights = dict(effective_weights)
         pre_trend_total_effective_weight = sum(pre_trend_effective_weights.values())
         effective_weights, trend_details = await self._apply_absolute_trend(
@@ -2081,6 +3152,19 @@ class RegimeRebalanceEngine:
                 )
                 or symbol in modifier_details
                 for config_name, modifier_details in target_modifier_details
+            )
+            and (
+                symbol
+                not in getattr(
+                    getattr(regime_rebalance, "target_weight_policy", None),
+                    "symbols",
+                    {},
+                )
+                or bool(
+                    target_weight_policy_details.get(symbol, {}).get(
+                        "risk_ready", False
+                    )
+                )
             )
         }
         total_effective_weight = sum(effective_weights.values())
@@ -2119,15 +3203,26 @@ class RegimeRebalanceEngine:
                 )
                 for details in volatility_details.values()
             )
+            target_policy_increase_weight = sum(
+                max(
+                    0.0,
+                    details["effective_weight"] - details["baseline_weight"],
+                )
+                for details in target_weight_policy_details.values()
+                if details.get("status") == "applied"
+            )
             if stacked_target_weight > (
-                volatility_increase_weight + regime_rebalance.eps
+                volatility_increase_weight
+                + target_policy_increase_weight
+                + regime_rebalance.eps
             ):
                 log.error(
                     "Regime-aware rebalancing effective weights exceed 100% "
-                    "without a sufficient volatility-weight increase."
+                    "without a sufficient bounded dynamic-weight increase."
                 )
                 raise ValueError(
-                    "Only volatility-adjusted weights may stack above 100%."
+                    "Only volatility-adjusted weights or explicitly bounded external "
+                    "weights may stack above 100%."
                 )
             log.notice(
                 "Regime-aware rebalancing stacking "
@@ -2183,7 +3278,7 @@ class RegimeRebalanceEngine:
             proxy_weights = (
                 effective_weights
                 if total_effective_weight > 0
-                else pre_trend_effective_weights
+                else post_volatility_effective_weights
             )
 
         dates, values = await self._get_regime_proxy_series(
@@ -2225,7 +3320,7 @@ class RegimeRebalanceEngine:
             ):
                 # Preserve a usable relative-market signal when zero trend
                 # multipliers intentionally move the entire rest basket to cash.
-                ratio_effective_weights = pre_trend_effective_weights
+                ratio_effective_weights = post_volatility_effective_weights
             _, ratio_aligned_closes = await history_cache.get(
                 symbols,
                 regime_rebalance.lookback_days,
@@ -2797,6 +3892,7 @@ class RegimeRebalanceEngine:
             )
 
             volatility_detail = volatility_details.get(symbol)
+            target_weight_policy_detail = target_weight_policy_details.get(symbol)
             trend_detail = trend_details.get(symbol)
             target_weight_display = pfmt(target_weight)
             if volatility_detail is not None:
@@ -2804,6 +3900,12 @@ class RegimeRebalanceEngine:
                     f"{pfmt(target_weight)} "
                     f"(base {pfmt(volatility_detail['base_weight'])}, "
                     f"vol {pfmt(volatility_detail['realized_vol'])})"
+                )
+            if target_weight_policy_detail is not None:
+                target_weight_display += (
+                    " (external "
+                    f"{target_weight_policy_detail['status']} "
+                    f"x{ffmt(target_weight_policy_detail['multiplier'])})"
                 )
             if trend_detail is not None:
                 target_weight_display += (
@@ -2833,6 +3935,8 @@ class RegimeRebalanceEngine:
                 "gate_status": gate_status,
                 "volatility_weight": volatility_detail,
             }
+            if target_weight_policy_detail is not None:
+                summary_details["target_weight_policy"] = target_weight_policy_detail
             if trend_detail is not None:
                 summary_details["absolute_trend"] = trend_detail
             regime_summary.append(summary_details)
@@ -2846,6 +3950,7 @@ class RegimeRebalanceEngine:
                 hard_underweight_symbols & harvest_risk_ready_symbols
             ),
             cohorts=tail_cohorts,
+            history_cache=history_cache,
         )
         for details in regime_summary:
             symbol = str(details["symbol"])
@@ -3100,6 +4205,19 @@ class RegimeRebalanceEngine:
                     "deficit_active": deficit_active_next,
                 },
             )
+            if target_weight_policy_details:
+                self.data_store.record_event(
+                    TARGET_WEIGHT_POLICY_STATE_EVENT,
+                    {
+                        "post_volatility_total_effective_weight": (
+                            post_volatility_total_effective_weight
+                        ),
+                        "post_policy_total_effective_weight": (
+                            pre_trend_total_effective_weight
+                        ),
+                        "symbols": target_weight_policy_details,
+                    },
+                )
             if trend_details and not self.data_store.record_event(
                 ABSOLUTE_TREND_STATE_EVENT,
                 {
@@ -3113,15 +4231,17 @@ class RegimeRebalanceEngine:
                 raise RuntimeError("Failed to persist absolute trend state.")
             if volatility_details:
                 volatility_unallocated_target_weight = max(
-                    0.0, 1.0 - pre_trend_total_effective_weight
+                    0.0, 1.0 - post_volatility_total_effective_weight
                 )
                 volatility_stacked_target_weight = max(
-                    0.0, pre_trend_total_effective_weight - 1.0
+                    0.0, post_volatility_total_effective_weight - 1.0
                 )
                 self.data_store.record_event(
                     "volatility_weight_state",
                     {
-                        "total_effective_weight": pre_trend_total_effective_weight,
+                        "total_effective_weight": (
+                            post_volatility_total_effective_weight
+                        ),
                         "unallocated_target_weight": (
                             volatility_unallocated_target_weight
                         ),

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -16,9 +16,7 @@ from rich.table import Table
 
 from thetagang import log
 from thetagang.accounting import (
-    AccountingError,
     AccountingPolicy,
-    AccountMetric,
     AccountSummary,
     BrokerAccountSnapshot,
     CapitalBaseKind,
@@ -34,7 +32,6 @@ from thetagang.external_decisions import (
     ExternalDecisionMarketData,
     ExternalDecisionProviders,
     ExternalDecisionResponse,
-    build_external_decision_request,
     external_decision_response_metadata,
     validate_decision_expiry,
 )
@@ -56,13 +53,14 @@ from thetagang.strategies.tail_hedge_state import (
     parse_state_datetime,
 )
 from thetagang.tail_harvest_decision import (
-    TAIL_HARVEST_DECISION_TYPE,
+    build_tail_harvest_request,
     validate_tail_harvest_response,
 )
 from thetagang.target_weight_policy import (
-    TARGET_WEIGHT_DECISION_TYPE,
     TARGET_WEIGHT_POLICY_STATE_EVENT,
     TargetWeightMultiplier,
+    apply_target_weight_adjustments,
+    build_target_weight_request,
     validate_target_weight_response,
 )
 from thetagang.trading_operations import OrderOperations
@@ -1223,55 +1221,39 @@ class RegimeRebalanceEngine:
                 rebalance_shares=rebalance_shares,
                 market_prices=market_prices,
             )
-            request = build_external_decision_request(
-                decision_type=TAIL_HARVEST_DECISION_TYPE,
+            request = build_tail_harvest_request(
                 generated_at=self._as_utc(self._now()),
                 dry_run=self.dry_run,
-                input_data={
-                    "strategy": {
-                        "name": "tail_hedge",
-                        "annual_budget": float(tail_hedge.annual_budget),
-                        "regime_weight_base": (
-                            self.config.strategies.regime_rebalance.weight_base.value
-                        ),
-                        "regime_margin_usage": (
-                            AccountingPolicy.from_config(
-                                self.config
-                            ).regime_margin_usage
-                        ),
-                    },
-                    "host_constraints": {
-                        "baseline_band_triggered": True,
-                        "requires_approved_same_symbol_hard_underweight_buy": True,
-                        "state_owned_active_profitable_puts_only": True,
-                        "host_selects_contracts_quantities_and_limit_prices": True,
-                    },
-                    "account": {
-                        "net_liquidation": snapshot.net_liquidation,
-                        "regime_rebalance_base": snapshot.regime_base,
-                        "excluded_option_value": snapshot.excluded_option_value,
-                    },
-                    "opportunity": {
-                        "sleeve_value": snapshot.band.sleeve_value,
-                        "sleeve_weight": snapshot.band.sleeve_weight,
-                        "harvest_trigger_weight": tail_hedge.harvest_trigger_weight,
-                        "harvest_target_weight": tail_hedge.harvest_target_weight,
-                        "target_sleeve_value": snapshot.band.target_value,
-                        "sale_budget": snapshot.band.sale_budget,
-                        "approved_rebalance_value": band_payload[
-                            "approved_rebalance_value"
-                        ],
-                        "planned_sales": self._tail_harvest_planned_sales(snapshot),
-                    },
-                    "underlyings": self._tail_harvest_underlying_inputs(
-                        snapshot,
-                        rebalance_shares=rebalance_shares,
-                        market_prices=market_prices,
-                        regime_summary=regime_summary,
-                    ),
-                    "hedge_positions": self._tail_harvest_hedge_inputs(snapshot),
-                    "market_data": market_data.request_input(),
+                tail_hedge=tail_hedge,
+                regime_weight_base=self.config.strategies.regime_rebalance.weight_base.value,
+                regime_margin_usage=AccountingPolicy.from_config(
+                    self.config
+                ).regime_margin_usage,
+                account={
+                    "net_liquidation": snapshot.net_liquidation,
+                    "regime_rebalance_base": snapshot.regime_base,
+                    "excluded_option_value": snapshot.excluded_option_value,
                 },
+                opportunity={
+                    "sleeve_value": snapshot.band.sleeve_value,
+                    "sleeve_weight": snapshot.band.sleeve_weight,
+                    "harvest_trigger_weight": tail_hedge.harvest_trigger_weight,
+                    "harvest_target_weight": tail_hedge.harvest_target_weight,
+                    "target_sleeve_value": snapshot.band.target_value,
+                    "sale_budget": snapshot.band.sale_budget,
+                    "approved_rebalance_value": band_payload[
+                        "approved_rebalance_value"
+                    ],
+                    "planned_sales": self._tail_harvest_planned_sales(snapshot),
+                },
+                underlyings=self._tail_harvest_underlying_inputs(
+                    snapshot,
+                    rebalance_shares=rebalance_shares,
+                    market_prices=market_prices,
+                    regime_summary=regime_summary,
+                ),
+                hedge_positions=self._tail_harvest_hedge_inputs(snapshot),
+                market_data=market_data,
             )
             response = await self.external_decisions.decide(policy.provider, request)
             output = validate_tail_harvest_response(
@@ -2416,107 +2398,6 @@ class RegimeRebalanceEngine:
             },
         )
 
-    @staticmethod
-    def _target_weight_policy_total_limit(
-        effective_weights: dict[str, float], policy: Any
-    ) -> float:
-        return max(sum(effective_weights.values()), policy.max_total_weight or 1.0)
-
-    def _target_weight_symbol_input(
-        self,
-        symbol: str,
-        *,
-        symbol_config: Any,
-        volatility_detail: dict[str, float] | None,
-        effective_weight: float,
-        total_value: float,
-        current_position: int,
-        current_value: float,
-        market_price: float,
-    ) -> dict[str, Any]:
-        volatility_weight = getattr(symbol_config, "volatility_weight", None)
-        volatility_config = None
-        if volatility_weight is not None:
-            volatility_config = {
-                "enabled": bool(volatility_weight.enabled),
-                "target_vol": float(volatility_weight.target_vol),
-                "lookback_days": int(volatility_weight.lookback_days),
-                "min_weight": float(volatility_weight.min_weight),
-                "max_weight": float(volatility_weight.max_weight),
-                "rebalance_band": float(volatility_weight.rebalance_band),
-                "smoothing_factor": float(volatility_weight.smoothing_factor),
-                "increase_smoothing_factor": (
-                    float(volatility_weight.increase_smoothing_factor)
-                    if volatility_weight.increase_smoothing_factor is not None
-                    else None
-                ),
-                "decrease_smoothing_factor": (
-                    float(volatility_weight.decrease_smoothing_factor)
-                    if volatility_weight.decrease_smoothing_factor is not None
-                    else None
-                ),
-            }
-
-        absolute_trend = getattr(symbol_config, "absolute_trend", None)
-        absolute_trend_config = None
-        if absolute_trend is not None:
-            absolute_trend_config = {
-                "enabled": bool(absolute_trend.enabled),
-                "lookback_days": int(absolute_trend.lookback_days),
-                "risk_off_multiplier": float(absolute_trend.risk_off_multiplier),
-            }
-
-        rebalance_policy_fn = getattr(self.config, "regime_rebalance_policy", None)
-        rebalance_policy = (
-            rebalance_policy_fn(symbol) if callable(rebalance_policy_fn) else None
-        )
-
-        def resolved_threshold(name: str) -> Any:
-            policy_value = getattr(rebalance_policy, name, None)
-            if policy_value is not None:
-                return policy_value
-            suffix = name.removeprefix("min_threshold_")
-            buy_value = getattr(
-                symbol_config,
-                f"buy_only_min_threshold_{suffix}",
-                None,
-            )
-            if buy_value is not None:
-                return buy_value
-            return getattr(
-                symbol_config,
-                f"sell_only_min_threshold_{suffix}",
-                None,
-            )
-
-        return {
-            "configured_weight": float(symbol_config.weight),
-            "post_volatility_weight": effective_weight,
-            "current_weight": current_value / total_value,
-            "current_value": current_value,
-            "current_shares": current_position,
-            "market_price": market_price,
-            "volatility_weight": {
-                "config": volatility_config,
-                "calculation": volatility_detail,
-            },
-            "absolute_trend": absolute_trend_config,
-            "execution_constraints": {
-                "trading_allowed": bool(self.config.trading_is_allowed(symbol)),
-                "rebalance_mode": (
-                    rebalance_policy.mode.value
-                    if rebalance_policy is not None
-                    else "both"
-                ),
-                "min_threshold_shares": resolved_threshold("min_threshold_shares"),
-                "min_threshold_amount": resolved_threshold("min_threshold_amount"),
-                "min_threshold_percent": resolved_threshold("min_threshold_percent"),
-                "min_threshold_percent_relative": resolved_threshold(
-                    "min_threshold_percent_relative"
-                ),
-            },
-        }
-
     async def _apply_target_weight_policy(
         self,
         effective_weights: dict[str, float],
@@ -2538,8 +2419,6 @@ class RegimeRebalanceEngine:
         policy = getattr(regime_rebalance, "target_weight_policy", None)
         if policy is None or not getattr(policy, "enabled", False):
             return dict(effective_weights), {}
-        ratio_gate = getattr(regime_rebalance, "ratio_gate", None)
-
         if (
             self._target_weight_policy_outcome is not None
             and self._target_weight_policy_outcome.response is not None
@@ -2564,112 +2443,23 @@ class RegimeRebalanceEngine:
                     decision_name="target weight policy",
                     history_cache=history_cache,
                 )
-                account_metrics: dict[str, float] = {}
-                for metric in AccountMetric:
-                    try:
-                        account_metrics[metric.value] = account.value(metric)
-                    except AccountingError:
-                        continue
-
-                allowed_total_weight = self._target_weight_policy_total_limit(
-                    effective_weights,
-                    policy,
-                )
-                request = build_external_decision_request(
-                    decision_type=TARGET_WEIGHT_DECISION_TYPE,
+                request = build_target_weight_request(
                     generated_at=self._as_utc(self._now()),
                     dry_run=self.dry_run,
-                    input_data={
-                        "strategy": {
-                            "name": "regime_rebalance",
-                            "weight_base": regime_rebalance.weight_base.value,
-                            "margin_usage": regime_margin_usage,
-                            "lookback_days": int(regime_rebalance.lookback_days),
-                            "soft_band": float(regime_rebalance.soft_band),
-                            "hard_band": float(regime_rebalance.hard_band),
-                            "hard_band_rebalance_fraction": float(
-                                regime_rebalance.hard_band_rebalance_fraction
-                            ),
-                            "cooldown_days": int(regime_rebalance.cooldown_days),
-                            "last_rebalance_at": (
-                                self._as_utc(last_rebalance).isoformat()
-                                if last_rebalance is not None
-                                else None
-                            ),
-                            "choppiness_min": float(regime_rebalance.choppiness_min),
-                            "efficiency_max": float(regime_rebalance.efficiency_max),
-                            "flow_trade_min": float(regime_rebalance.flow_trade_min),
-                            "flow_trade_stop": float(regime_rebalance.flow_trade_stop),
-                            "flow_imbalance_tau": float(
-                                regime_rebalance.flow_imbalance_tau
-                            ),
-                            "deficit_rail_start": float(
-                                regime_rebalance.deficit_rail_start
-                            ),
-                            "deficit_rail_stop": float(
-                                regime_rebalance.deficit_rail_stop
-                            ),
-                            "ratio_gate": (
-                                {
-                                    "enabled": bool(ratio_gate.enabled),
-                                    "anchor": str(ratio_gate.anchor),
-                                    "drift_max": float(ratio_gate.drift_max),
-                                    "vol_min": (
-                                        float(ratio_gate.vol_min)
-                                        if ratio_gate.vol_min is not None
-                                        else None
-                                    ),
-                                }
-                                if ratio_gate is not None
-                                else None
-                            ),
-                        },
-                        "account": {
-                            "metrics": account_metrics,
-                            "rebalance_base_value": total_value,
-                            "excluded_option_value": excluded_value,
-                        },
-                        "portfolio": {
-                            "configured_total_weight": sum(
-                                float(symbol_configs[symbol].weight)
-                                for symbol in symbols
-                            ),
-                            "post_volatility_total_weight": sum(
-                                effective_weights.values()
-                            ),
-                        },
-                        "symbols": {
-                            symbol: self._target_weight_symbol_input(
-                                symbol,
-                                symbol_config=symbol_configs[symbol],
-                                volatility_detail=volatility_details.get(symbol),
-                                effective_weight=effective_weights[symbol],
-                                total_value=total_value,
-                                current_position=current_positions[symbol],
-                                current_value=current_values[symbol],
-                                market_price=market_prices[symbol],
-                            )
-                            for symbol in symbols
-                        },
-                        "adjustment_constraints": {
-                            symbol: {
-                                "min_multiplier": limits.min_multiplier,
-                                "max_multiplier": limits.max_multiplier,
-                                "clamp_to_volatility_bounds": (
-                                    limits.clamp_to_volatility_bounds
-                                ),
-                            }
-                            for symbol, limits in policy.symbols.items()
-                        },
-                        "total_weight_constraint": {
-                            "max_total_weight": policy.max_total_weight,
-                            "effective_max_total_weight": allowed_total_weight,
-                            "default_prevents_additional_leverage": (
-                                policy.max_total_weight is None
-                            ),
-                        },
-                        "market_data": market_data.request_input(),
-                    },
+                    config=self.config,
+                    effective_weights=effective_weights,
+                    symbols=symbols,
+                    symbol_configs=symbol_configs,
+                    volatility_details=volatility_details,
+                    account=account,
+                    regime_margin_usage=regime_margin_usage,
+                    total_value=total_value,
+                    excluded_value=excluded_value,
+                    last_rebalance=last_rebalance,
+                    current_positions=current_positions,
+                    current_values=current_values,
+                    market_prices=market_prices,
+                    market_data=market_data,
                 )
                 response = await self.external_decisions.decide(
                     policy.provider,
@@ -2705,36 +2495,26 @@ class RegimeRebalanceEngine:
                 error=outcome.error or "provider returned no adjustments",
             )
 
-        adjusted_weights = dict(effective_weights)
-        details: dict[str, dict[str, Any]] = {}
         try:
-            for symbol, adjustment in outcome.adjustments.items():
-                baseline_weight = effective_weights[symbol]
-                raw_weight = baseline_weight * adjustment.multiplier
-                if not math.isfinite(raw_weight) or raw_weight < 0:
-                    raise ExternalDecisionError(
-                        f"target weight policy produced an invalid weight for {symbol}"
+            adjusted_weights, weight_details = apply_target_weight_adjustments(
+                effective_weights,
+                outcome.adjustments,
+                policy=policy,
+                volatility_bounds={
+                    symbol: (
+                        float(symbol_configs[symbol].volatility_weight.min_weight),
+                        float(symbol_configs[symbol].volatility_weight.max_weight),
                     )
-
-                effective_weight = raw_weight
-                limits = policy.symbols[symbol]
-                if limits.clamp_to_volatility_bounds:
-                    volatility_weight = symbol_configs[symbol].volatility_weight
-                    effective_weight = max(
-                        float(volatility_weight.min_weight),
-                        min(effective_weight, float(volatility_weight.max_weight)),
-                    )
-                if effective_weight > 1:
-                    raise ExternalDecisionError(
-                        f"target weight policy produced an invalid weight for {symbol}"
-                    )
-                adjusted_weights[symbol] = effective_weight
-                details[symbol] = {
+                    for symbol in outcome.adjustments
+                    if policy.symbols[symbol].clamp_to_volatility_bounds
+                },
+                eps=regime_rebalance.eps,
+            )
+            details: dict[str, dict[str, Any]] = {
+                symbol: {
                     "status": "applied",
-                    "baseline_weight": baseline_weight,
+                    **weight_details[symbol],
                     "multiplier": adjustment.multiplier,
-                    "raw_weight": raw_weight,
-                    "effective_weight": effective_weight,
                     "reason": adjustment.reason,
                     **external_decision_response_metadata(
                         outcome.response,
@@ -2742,16 +2522,8 @@ class RegimeRebalanceEngine:
                     ),
                     "risk_ready": True,
                 }
-
-            adjusted_total = sum(adjusted_weights.values())
-            allowed_total = self._target_weight_policy_total_limit(
-                effective_weights,
-                policy,
-            )
-            if adjusted_total > allowed_total + regime_rebalance.eps:
-                raise ExternalDecisionError(
-                    "target weight policy exceeds the permitted total weight"
-                )
+                for symbol, adjustment in outcome.adjustments.items()
+            }
         except (AttributeError, KeyError, TypeError, ExternalDecisionError) as exc:
             return self._target_weight_policy_fallback(
                 effective_weights,

--- a/thetagang/tail_harvest_decision.py
+++ b/thetagang/tail_harvest_decision.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 from thetagang.config_models import TailHarvestDecisionConfig, TailHedgeConfig
 from thetagang.external_decisions import (
@@ -175,7 +175,7 @@ class TailHarvestDecisionRequest(ExternalDecisionRequestEnvelope):
 class TailHarvestDecisionOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    harvest: bool
+    harvest: bool = Field(strict=True)
     reason: str | None = None
 
 
@@ -240,10 +240,6 @@ def validate_tail_harvest_response(
         now=now,
         decision_name="tail harvest decision",
     )
-    if type(response.output.get("harvest")) is not bool:
-        raise ExternalDecisionError(
-            "tail harvest decision returned an invalid harvest value"
-        )
     try:
         return TailHarvestDecisionOutput.model_validate(response.output)
     except ValueError as exc:

--- a/thetagang/tail_harvest_decision.py
+++ b/thetagang/tail_harvest_decision.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from thetagang.config_models import TailHarvestDecisionConfig
+from thetagang.external_decisions import (
+    ExternalDecisionError,
+    ExternalDecisionResponse,
+    validate_market_decision_response,
+)
+
+TAIL_HARVEST_DECISION_TYPE = "tail_hedge_harvest"
+
+
+class TailHarvestDecisionOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    harvest: bool
+    reason: str | None = None
+
+
+def validate_tail_harvest_response(
+    response: ExternalDecisionResponse,
+    *,
+    policy: TailHarvestDecisionConfig,
+    history_dates: list[date],
+    now: datetime,
+) -> TailHarvestDecisionOutput:
+    validate_market_decision_response(
+        response,
+        history_dates=history_dates,
+        max_signal_age_sessions=policy.max_signal_age_sessions,
+        now=now,
+        decision_name="tail harvest decision",
+    )
+    if type(response.output.get("harvest")) is not bool:
+        raise ExternalDecisionError(
+            "tail harvest decision returned an invalid harvest value"
+        )
+    try:
+        return TailHarvestDecisionOutput.model_validate(response.output)
+    except ValueError as exc:
+        raise ExternalDecisionError(
+            "tail harvest decision returned an invalid output"
+        ) from exc

--- a/thetagang/tail_harvest_decision.py
+++ b/thetagang/tail_harvest_decision.py
@@ -1,17 +1,175 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import AwareDatetime, BaseModel, ConfigDict
 
-from thetagang.config_models import TailHarvestDecisionConfig
+from thetagang.config_models import TailHarvestDecisionConfig, TailHedgeConfig
 from thetagang.external_decisions import (
+    DecisionInput,
     ExternalDecisionError,
+    ExternalDecisionMarketData,
+    ExternalDecisionRequest,
+    ExternalDecisionRequestEnvelope,
     ExternalDecisionResponse,
+    ExternalDecisionResponseEnvelope,
+    build_external_decision_request,
     validate_market_decision_response,
 )
 
 TAIL_HARVEST_DECISION_TYPE = "tail_hedge_harvest"
+
+
+class TailHarvestStrategyInput(DecisionInput):
+    name: Literal["tail_hedge"]
+    annual_budget: float
+    regime_weight_base: Literal["net_liq", "net_liq_ex_options", "managed_stocks"]
+    regime_margin_usage: float
+
+
+class TailHarvestHostConstraints(DecisionInput):
+    baseline_band_triggered: Literal[True]
+    requires_approved_same_symbol_hard_underweight_buy: Literal[True]
+    state_owned_active_profitable_puts_only: Literal[True]
+    host_selects_contracts_quantities_and_limit_prices: Literal[True]
+
+
+class TailHarvestAccountInput(DecisionInput):
+    net_liquidation: float
+    regime_rebalance_base: float
+    excluded_option_value: float
+
+
+class PlannedHarvestSale(DecisionInput):
+    entry_id: str
+    symbol: str
+    con_id: int
+    expiration: str
+    quantity: int
+    limit_price: float
+    estimated_gross_proceeds: float
+    estimated_fees: float
+    estimated_net_proceeds: float
+
+
+class HarvestOpportunityInput(DecisionInput):
+    sleeve_value: float
+    sleeve_weight: float
+    harvest_trigger_weight: float
+    harvest_target_weight: float
+    target_sleeve_value: float
+    sale_budget: float
+    approved_rebalance_value: float
+    planned_sales: list[PlannedHarvestSale]
+
+
+class UnderlyingBrokerPosition(DecisionInput):
+    shares: float
+    market_value: float
+    average_cost_per_share: float | None
+    unrealized_pnl: float
+    realized_pnl: float
+
+
+class TailProgramInput(DecisionInput):
+    budget_weight: float
+    entries_per_year: int
+    entry_gate: Literal["vix", "none"]
+    entry_vix_max: float
+    target_dte: int
+    min_dte: int
+    max_dte: int
+    exit_dte: int
+    minimum_open_interest: int
+    minimum_bid: float
+    max_bid_ask_ratio: float
+    max_premium_ratio: float
+    catastrophe_drawdowns: list[float]
+
+
+# Diagnostics describe preceding host calculations, not provider instructions.
+# Keys can vary by calculation availability and status; consumers tolerate new keys.
+ModifierDiagnostics = dict[str, str | bool | int | float | date | None]
+
+
+class TargetModifierInputs(DecisionInput):
+    volatility_weight: ModifierDiagnostics | None
+    target_weight_policy: ModifierDiagnostics | None
+    absolute_trend: ModifierDiagnostics | None
+
+
+class ProtectedUnderlyingInput(DecisionInput):
+    configured_weight: float
+    primary_exchange: str
+    market_price: float | None
+    current_shares: float | None
+    current_value: float | None
+    broker_position: UnderlyingBrokerPosition
+    current_weight: float | None
+    target_weight: float | None
+    target_value: float | None
+    target_shares: float | None
+    approved_buy_shares: int
+    approved_buy_value: float | None
+    tail_program: TailProgramInput
+    target_modifiers: TargetModifierInputs
+
+
+class HedgeContractInput(DecisionInput):
+    con_id: int
+    expiration: str
+    strike: float
+    right: Literal["P"]
+    multiplier: float | None
+
+
+class HarvestCandidateInput(DecisionInput):
+    quantity: int
+    gross_proceeds_per_contract: float
+    estimated_fee_per_contract: float
+    net_proceeds_per_contract: float
+    cost_basis_per_contract: float
+    profit_multiple: float
+
+
+class HedgePositionInput(DecisionInput):
+    entry_id: str
+    symbol: str
+    status: str
+    contract: HedgeContractInput
+    state_owned_quantity: int
+    live_position_quantity: float | None
+    reported_owned_market_value: float | None
+    live_position_market_value: float | None
+    live_average_cost_per_contract: float | None
+    live_realized_pnl: float | None
+    state_owned_unrealized_pnl: float | None
+    quoted_limit_price: float | None
+    entered_at: AwareDatetime
+    entry_limit_price: float
+    estimated_cost: float
+    recovered_cost: float
+    unrecovered_cost: float
+    host_candidate: bool
+    candidate: HarvestCandidateInput | None
+
+
+class TailHarvestDecisionInput(DecisionInput):
+    """USD values, fractional weights, and whole option contract quantities."""
+
+    strategy: TailHarvestStrategyInput
+    host_constraints: TailHarvestHostConstraints
+    account: TailHarvestAccountInput
+    opportunity: HarvestOpportunityInput
+    underlyings: dict[str, ProtectedUnderlyingInput]
+    hedge_positions: list[HedgePositionInput]
+    market_data: ExternalDecisionMarketData
+
+
+class TailHarvestDecisionRequest(ExternalDecisionRequestEnvelope):
+    decision_type: Literal["tail_hedge_harvest"]
+    input: TailHarvestDecisionInput
 
 
 class TailHarvestDecisionOutput(BaseModel):
@@ -19,6 +177,53 @@ class TailHarvestDecisionOutput(BaseModel):
 
     harvest: bool
     reason: str | None = None
+
+
+class TailHarvestDecisionResponse(ExternalDecisionResponseEnvelope):
+    decision_type: Literal["tail_hedge_harvest"]
+    as_of_session: date
+    output: TailHarvestDecisionOutput
+
+
+def build_tail_harvest_request(
+    *,
+    generated_at: datetime,
+    dry_run: bool,
+    tail_hedge: TailHedgeConfig,
+    regime_weight_base: str,
+    regime_margin_usage: float,
+    account: dict[str, float],
+    opportunity: dict[str, Any],
+    underlyings: dict[str, dict[str, Any]],
+    hedge_positions: list[dict[str, Any]],
+    market_data: ExternalDecisionMarketData,
+) -> ExternalDecisionRequest:
+    request = build_external_decision_request(
+        decision_type=TAIL_HARVEST_DECISION_TYPE,
+        generated_at=generated_at,
+        dry_run=dry_run,
+        input_data={
+            "strategy": {
+                "name": "tail_hedge",
+                "annual_budget": float(tail_hedge.annual_budget),
+                "regime_weight_base": regime_weight_base,
+                "regime_margin_usage": regime_margin_usage,
+            },
+            "host_constraints": {
+                "baseline_band_triggered": True,
+                "requires_approved_same_symbol_hard_underweight_buy": True,
+                "state_owned_active_profitable_puts_only": True,
+                "host_selects_contracts_quantities_and_limit_prices": True,
+            },
+            "account": account,
+            "opportunity": opportunity,
+            "underlyings": underlyings,
+            "hedge_positions": hedge_positions,
+            "market_data": market_data.request_input(),
+        },
+    )
+    TailHarvestDecisionRequest.model_validate(request.model_dump(mode="json"))
+    return request
 
 
 def validate_tail_harvest_response(

--- a/thetagang/target_weight_policy.py
+++ b/thetagang/target_weight_policy.py
@@ -1,19 +1,145 @@
 from __future__ import annotations
 
 import math
-from datetime import date, datetime
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
+from thetagang.accounting import AccountingError, AccountMetric, BrokerAccountSnapshot
 from thetagang.config_models import TargetWeightPolicyConfig
 from thetagang.external_decisions import (
+    DecisionInput,
     ExternalDecisionError,
+    ExternalDecisionMarketData,
+    ExternalDecisionRequest,
+    ExternalDecisionRequestEnvelope,
     ExternalDecisionResponse,
+    ExternalDecisionResponseEnvelope,
+    build_external_decision_request,
     validate_market_decision_response,
 )
 
+if TYPE_CHECKING:
+    from thetagang.config import Config
+
 TARGET_WEIGHT_DECISION_TYPE = "regime_target_weights"
 TARGET_WEIGHT_POLICY_STATE_EVENT = "target_weight_policy_state"
+
+
+class VolatilityWeightInput(DecisionInput):
+    enabled: bool
+    target_vol: float
+    lookback_days: int
+    min_weight: float
+    max_weight: float
+    rebalance_band: float
+    smoothing_factor: float
+    increase_smoothing_factor: float | None
+    decrease_smoothing_factor: float | None
+
+
+class VolatilityContext(DecisionInput):
+    config: VolatilityWeightInput | None
+    calculation: dict[str, float] | None = Field(
+        description="Host calculation diagnostics; absent when unavailable."
+    )
+
+
+class AbsoluteTrendInput(DecisionInput):
+    enabled: bool
+    lookback_days: int
+    risk_off_multiplier: float
+
+
+class ExecutionConstraints(DecisionInput):
+    trading_allowed: bool
+    rebalance_mode: Literal["both", "buy_only", "sell_only", "off"]
+    min_threshold_shares: int | None
+    min_threshold_amount: float | None
+    min_threshold_percent: float | None
+    min_threshold_percent_relative: float | None
+
+
+class TargetWeightSymbolInput(DecisionInput):
+    configured_weight: float
+    post_volatility_weight: float
+    current_weight: float
+    current_value: float
+    current_shares: int
+    market_price: float
+    volatility_weight: VolatilityContext
+    absolute_trend: AbsoluteTrendInput | None
+    execution_constraints: ExecutionConstraints
+
+
+class RatioGateInput(DecisionInput):
+    enabled: bool
+    anchor: str
+    drift_max: float
+    vol_min: float | None
+
+
+class TargetWeightStrategyInput(DecisionInput):
+    name: Literal["regime_rebalance"]
+    weight_base: Literal["net_liq", "net_liq_ex_options"]
+    margin_usage: float
+    lookback_days: int
+    soft_band: float
+    hard_band: float
+    hard_band_rebalance_fraction: float
+    cooldown_days: int
+    last_rebalance_at: AwareDatetime | None
+    choppiness_min: float
+    efficiency_max: float
+    flow_trade_min: float
+    flow_trade_stop: float
+    flow_imbalance_tau: float
+    deficit_rail_start: float
+    deficit_rail_stop: float
+    ratio_gate: RatioGateInput | None
+
+
+class TargetWeightAccountInput(DecisionInput):
+    metrics: dict[str, float] = Field(
+        description="Available IBKR metrics; missing metrics are omitted, never zero-filled."
+    )
+    rebalance_base_value: float
+    excluded_option_value: float
+
+
+class TargetWeightPortfolioInput(DecisionInput):
+    configured_total_weight: float
+    post_volatility_total_weight: float
+
+
+class MultiplierConstraints(DecisionInput):
+    min_multiplier: float
+    max_multiplier: float
+    clamp_to_volatility_bounds: bool
+
+
+class TotalWeightConstraint(DecisionInput):
+    max_total_weight: float | None
+    effective_max_total_weight: float
+    default_prevents_additional_leverage: bool
+
+
+class TargetWeightDecisionInput(DecisionInput):
+    """USD values and fractional weights for the regime target multiplier hook."""
+
+    strategy: TargetWeightStrategyInput
+    account: TargetWeightAccountInput
+    portfolio: TargetWeightPortfolioInput
+    symbols: dict[str, TargetWeightSymbolInput]
+    adjustment_constraints: dict[str, MultiplierConstraints]
+    total_weight_constraint: TotalWeightConstraint
+    market_data: ExternalDecisionMarketData
+
+
+class TargetWeightDecisionRequest(ExternalDecisionRequestEnvelope):
+    decision_type: Literal["regime_target_weights"]
+    input: TargetWeightDecisionInput
 
 
 class TargetWeightMultiplier(BaseModel):
@@ -27,6 +153,12 @@ class TargetWeightDecisionOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     adjustments: dict[str, TargetWeightMultiplier]
+
+
+class TargetWeightDecisionResponse(ExternalDecisionResponseEnvelope):
+    decision_type: Literal["regime_target_weights"]
+    as_of_session: date
+    output: TargetWeightDecisionOutput
 
 
 def validate_target_weight_response(
@@ -89,3 +221,269 @@ def validate_target_weight_response(
                 "configured bounds"
             )
     return output.adjustments
+
+
+def target_weight_policy_total_limit(
+    effective_weights: dict[str, float], policy: Any
+) -> float:
+    return max(sum(effective_weights.values()), policy.max_total_weight or 1.0)
+
+
+def apply_target_weight_adjustments(
+    effective_weights: dict[str, float],
+    adjustments: dict[str, TargetWeightMultiplier],
+    *,
+    policy: TargetWeightPolicyConfig,
+    volatility_bounds: dict[str, tuple[float, float]],
+    eps: float,
+) -> tuple[dict[str, float], dict[str, dict[str, float]]]:
+    """Apply the same host allocation limits during live planning and replay."""
+
+    adjusted_weights = dict(effective_weights)
+    details: dict[str, dict[str, float]] = {}
+    for symbol, adjustment in adjustments.items():
+        baseline_weight = effective_weights[symbol]
+        raw_weight = baseline_weight * adjustment.multiplier
+        if not math.isfinite(raw_weight) or raw_weight < 0:
+            raise ExternalDecisionError(
+                f"target weight policy produced an invalid weight for {symbol}"
+            )
+        effective_weight = raw_weight
+        if policy.symbols[symbol].clamp_to_volatility_bounds:
+            minimum, maximum = volatility_bounds[symbol]
+            effective_weight = max(minimum, min(effective_weight, maximum))
+        if effective_weight > 1:
+            raise ExternalDecisionError(
+                f"target weight policy produced an invalid weight for {symbol}"
+            )
+        adjusted_weights[symbol] = effective_weight
+        details[symbol] = {
+            "baseline_weight": baseline_weight,
+            "raw_weight": raw_weight,
+            "effective_weight": effective_weight,
+        }
+    if (
+        sum(adjusted_weights.values())
+        > target_weight_policy_total_limit(effective_weights, policy) + eps
+    ):
+        raise ExternalDecisionError(
+            "target weight policy exceeds the permitted total weight"
+        )
+    return adjusted_weights, details
+
+
+def build_target_weight_symbol_input(
+    config: Config,
+    symbol: str,
+    *,
+    symbol_config: Any,
+    volatility_detail: dict[str, float] | None,
+    effective_weight: float,
+    total_value: float,
+    current_position: int,
+    current_value: float,
+    market_price: float,
+) -> dict[str, Any]:
+    volatility_weight = getattr(symbol_config, "volatility_weight", None)
+    volatility_config = None
+    if volatility_weight is not None:
+        volatility_config = {
+            "enabled": bool(volatility_weight.enabled),
+            "target_vol": float(volatility_weight.target_vol),
+            "lookback_days": int(volatility_weight.lookback_days),
+            "min_weight": float(volatility_weight.min_weight),
+            "max_weight": float(volatility_weight.max_weight),
+            "rebalance_band": float(volatility_weight.rebalance_band),
+            "smoothing_factor": float(volatility_weight.smoothing_factor),
+            "increase_smoothing_factor": (
+                float(volatility_weight.increase_smoothing_factor)
+                if volatility_weight.increase_smoothing_factor is not None
+                else None
+            ),
+            "decrease_smoothing_factor": (
+                float(volatility_weight.decrease_smoothing_factor)
+                if volatility_weight.decrease_smoothing_factor is not None
+                else None
+            ),
+        }
+
+    absolute_trend = getattr(symbol_config, "absolute_trend", None)
+    absolute_trend_config = None
+    if absolute_trend is not None:
+        absolute_trend_config = {
+            "enabled": bool(absolute_trend.enabled),
+            "lookback_days": int(absolute_trend.lookback_days),
+            "risk_off_multiplier": float(absolute_trend.risk_off_multiplier),
+        }
+
+    rebalance_policy_fn = getattr(config, "regime_rebalance_policy", None)
+    rebalance_policy = (
+        rebalance_policy_fn(symbol) if callable(rebalance_policy_fn) else None
+    )
+
+    def resolved_threshold(name: str) -> Any:
+        policy_value = getattr(rebalance_policy, name, None)
+        if policy_value is not None:
+            return policy_value
+        suffix = name.removeprefix("min_threshold_")
+        buy_value = getattr(
+            symbol_config,
+            f"buy_only_min_threshold_{suffix}",
+            None,
+        )
+        if buy_value is not None:
+            return buy_value
+        return getattr(
+            symbol_config,
+            f"sell_only_min_threshold_{suffix}",
+            None,
+        )
+
+    return {
+        "configured_weight": float(symbol_config.weight),
+        "post_volatility_weight": effective_weight,
+        "current_weight": current_value / total_value,
+        "current_value": current_value,
+        "current_shares": current_position,
+        "market_price": market_price,
+        "volatility_weight": {
+            "config": volatility_config,
+            "calculation": volatility_detail,
+        },
+        "absolute_trend": absolute_trend_config,
+        "execution_constraints": {
+            "trading_allowed": bool(config.trading_is_allowed(symbol)),
+            "rebalance_mode": (
+                rebalance_policy.mode.value if rebalance_policy is not None else "both"
+            ),
+            "min_threshold_shares": resolved_threshold("min_threshold_shares"),
+            "min_threshold_amount": resolved_threshold("min_threshold_amount"),
+            "min_threshold_percent": resolved_threshold("min_threshold_percent"),
+            "min_threshold_percent_relative": resolved_threshold(
+                "min_threshold_percent_relative"
+            ),
+        },
+    }
+
+
+def build_target_weight_request(
+    *,
+    generated_at: datetime,
+    dry_run: bool,
+    config: Config,
+    effective_weights: dict[str, float],
+    symbols: list[str],
+    symbol_configs: dict[str, Any],
+    volatility_details: dict[str, dict[str, float]],
+    account: BrokerAccountSnapshot,
+    regime_margin_usage: float,
+    total_value: float,
+    excluded_value: float,
+    last_rebalance: datetime | None,
+    current_positions: dict[str, int],
+    current_values: dict[str, float],
+    market_prices: dict[str, float],
+    market_data: ExternalDecisionMarketData,
+) -> ExternalDecisionRequest:
+    regime_rebalance = config.strategies.regime_rebalance
+    policy = regime_rebalance.target_weight_policy
+    ratio_gate = getattr(regime_rebalance, "ratio_gate", None)
+    account_metrics: dict[str, float] = {}
+    for metric in AccountMetric:
+        try:
+            account_metrics[metric.value] = account.value(metric)
+        except AccountingError:
+            continue
+
+    allowed_total_weight = target_weight_policy_total_limit(
+        effective_weights,
+        policy,
+    )
+    request = build_external_decision_request(
+        decision_type=TARGET_WEIGHT_DECISION_TYPE,
+        generated_at=generated_at,
+        dry_run=dry_run,
+        input_data={
+            "strategy": {
+                "name": "regime_rebalance",
+                "weight_base": regime_rebalance.weight_base.value,
+                "margin_usage": regime_margin_usage,
+                "lookback_days": int(regime_rebalance.lookback_days),
+                "soft_band": float(regime_rebalance.soft_band),
+                "hard_band": float(regime_rebalance.hard_band),
+                "hard_band_rebalance_fraction": float(
+                    regime_rebalance.hard_band_rebalance_fraction
+                ),
+                "cooldown_days": int(regime_rebalance.cooldown_days),
+                "last_rebalance_at": (
+                    last_rebalance.astimezone(UTC).isoformat()
+                    if last_rebalance is not None
+                    else None
+                ),
+                "choppiness_min": float(regime_rebalance.choppiness_min),
+                "efficiency_max": float(regime_rebalance.efficiency_max),
+                "flow_trade_min": float(regime_rebalance.flow_trade_min),
+                "flow_trade_stop": float(regime_rebalance.flow_trade_stop),
+                "flow_imbalance_tau": float(regime_rebalance.flow_imbalance_tau),
+                "deficit_rail_start": float(regime_rebalance.deficit_rail_start),
+                "deficit_rail_stop": float(regime_rebalance.deficit_rail_stop),
+                "ratio_gate": (
+                    {
+                        "enabled": bool(ratio_gate.enabled),
+                        "anchor": str(ratio_gate.anchor),
+                        "drift_max": float(ratio_gate.drift_max),
+                        "vol_min": (
+                            float(ratio_gate.vol_min)
+                            if ratio_gate.vol_min is not None
+                            else None
+                        ),
+                    }
+                    if ratio_gate is not None
+                    else None
+                ),
+            },
+            "account": {
+                "metrics": account_metrics,
+                "rebalance_base_value": total_value,
+                "excluded_option_value": excluded_value,
+            },
+            "portfolio": {
+                "configured_total_weight": sum(
+                    float(symbol_configs[symbol].weight) for symbol in symbols
+                ),
+                "post_volatility_total_weight": sum(effective_weights.values()),
+            },
+            "symbols": {
+                symbol: build_target_weight_symbol_input(
+                    config,
+                    symbol,
+                    symbol_config=symbol_configs[symbol],
+                    volatility_detail=volatility_details.get(symbol),
+                    effective_weight=effective_weights[symbol],
+                    total_value=total_value,
+                    current_position=current_positions[symbol],
+                    current_value=current_values[symbol],
+                    market_price=market_prices[symbol],
+                )
+                for symbol in symbols
+            },
+            "adjustment_constraints": {
+                symbol: {
+                    "min_multiplier": limits.min_multiplier,
+                    "max_multiplier": limits.max_multiplier,
+                    "clamp_to_volatility_bounds": (limits.clamp_to_volatility_bounds),
+                }
+                for symbol, limits in policy.symbols.items()
+            },
+            "total_weight_constraint": {
+                "max_total_weight": policy.max_total_weight,
+                "effective_max_total_weight": allowed_total_weight,
+                "default_prevents_additional_leverage": (
+                    policy.max_total_weight is None
+                ),
+            },
+            "market_data": market_data.request_input(),
+        },
+    )
+    TargetWeightDecisionRequest.model_validate(request.model_dump(mode="json"))
+    return request

--- a/thetagang/target_weight_policy.py
+++ b/thetagang/target_weight_policy.py
@@ -145,7 +145,7 @@ class TargetWeightDecisionRequest(ExternalDecisionRequestEnvelope):
 class TargetWeightMultiplier(BaseModel):
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
-    multiplier: float = Field(..., ge=0.0)
+    multiplier: float = Field(..., ge=0.0, strict=True)
     reason: str | None = None
 
 
@@ -176,16 +176,6 @@ def validate_target_weight_response(
         decision_name="target weight policy",
     )
 
-    raw_adjustments = response.output.get("adjustments")
-    if isinstance(raw_adjustments, dict):
-        for raw_adjustment in raw_adjustments.values():
-            if not isinstance(raw_adjustment, dict):
-                continue
-            multiplier = raw_adjustment.get("multiplier")
-            if isinstance(multiplier, bool) or not isinstance(multiplier, (int, float)):
-                raise ExternalDecisionError(
-                    "target weight policy returned invalid adjustments"
-                )
     try:
         output = TargetWeightDecisionOutput.model_validate(response.output)
     except ValueError as exc:
@@ -211,10 +201,6 @@ def validate_target_weight_response(
     for symbol, adjustment in output.adjustments.items():
         multiplier = adjustment.multiplier
         limits = policy.symbols[symbol]
-        if not math.isfinite(multiplier):
-            raise ExternalDecisionError(
-                f"target weight policy multiplier for {symbol} is not finite"
-            )
         if multiplier < limits.min_multiplier or multiplier > limits.max_multiplier:
             raise ExternalDecisionError(
                 f"target weight policy multiplier for {symbol} is outside "
@@ -224,7 +210,7 @@ def validate_target_weight_response(
 
 
 def target_weight_policy_total_limit(
-    effective_weights: dict[str, float], policy: Any
+    effective_weights: dict[str, float], policy: TargetWeightPolicyConfig
 ) -> float:
     return max(sum(effective_weights.values()), policy.max_total_weight or 1.0)
 
@@ -287,34 +273,16 @@ def build_target_weight_symbol_input(
     volatility_weight = getattr(symbol_config, "volatility_weight", None)
     volatility_config = None
     if volatility_weight is not None:
-        volatility_config = {
-            "enabled": bool(volatility_weight.enabled),
-            "target_vol": float(volatility_weight.target_vol),
-            "lookback_days": int(volatility_weight.lookback_days),
-            "min_weight": float(volatility_weight.min_weight),
-            "max_weight": float(volatility_weight.max_weight),
-            "rebalance_band": float(volatility_weight.rebalance_band),
-            "smoothing_factor": float(volatility_weight.smoothing_factor),
-            "increase_smoothing_factor": (
-                float(volatility_weight.increase_smoothing_factor)
-                if volatility_weight.increase_smoothing_factor is not None
-                else None
-            ),
-            "decrease_smoothing_factor": (
-                float(volatility_weight.decrease_smoothing_factor)
-                if volatility_weight.decrease_smoothing_factor is not None
-                else None
-            ),
-        }
+        volatility_config = VolatilityWeightInput.model_validate(
+            volatility_weight, from_attributes=True
+        ).model_dump(mode="json")
 
     absolute_trend = getattr(symbol_config, "absolute_trend", None)
     absolute_trend_config = None
     if absolute_trend is not None:
-        absolute_trend_config = {
-            "enabled": bool(absolute_trend.enabled),
-            "lookback_days": int(absolute_trend.lookback_days),
-            "risk_off_multiplier": float(absolute_trend.risk_off_multiplier),
-        }
+        absolute_trend_config = AbsoluteTrendInput.model_validate(
+            absolute_trend, from_attributes=True
+        ).model_dump(mode="json")
 
     rebalance_policy_fn = getattr(config, "regime_rebalance_policy", None)
     rebalance_policy = (
@@ -428,16 +396,9 @@ def build_target_weight_request(
                 "deficit_rail_start": float(regime_rebalance.deficit_rail_start),
                 "deficit_rail_stop": float(regime_rebalance.deficit_rail_stop),
                 "ratio_gate": (
-                    {
-                        "enabled": bool(ratio_gate.enabled),
-                        "anchor": str(ratio_gate.anchor),
-                        "drift_max": float(ratio_gate.drift_max),
-                        "vol_min": (
-                            float(ratio_gate.vol_min)
-                            if ratio_gate.vol_min is not None
-                            else None
-                        ),
-                    }
+                    RatioGateInput.model_validate(
+                        ratio_gate, from_attributes=True
+                    ).model_dump(mode="json")
                     if ratio_gate is not None
                     else None
                 ),
@@ -468,11 +429,9 @@ def build_target_weight_request(
                 for symbol in symbols
             },
             "adjustment_constraints": {
-                symbol: {
-                    "min_multiplier": limits.min_multiplier,
-                    "max_multiplier": limits.max_multiplier,
-                    "clamp_to_volatility_bounds": (limits.clamp_to_volatility_bounds),
-                }
+                symbol: MultiplierConstraints.model_validate(
+                    limits, from_attributes=True
+                ).model_dump(mode="json")
                 for symbol, limits in policy.symbols.items()
             },
             "total_weight_constraint": {

--- a/thetagang/target_weight_policy.py
+++ b/thetagang/target_weight_policy.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import math
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from thetagang.config_models import TargetWeightPolicyConfig
+from thetagang.external_decisions import (
+    ExternalDecisionError,
+    ExternalDecisionResponse,
+    validate_market_decision_response,
+)
+
+TARGET_WEIGHT_DECISION_TYPE = "regime_target_weights"
+TARGET_WEIGHT_POLICY_STATE_EVENT = "target_weight_policy_state"
+
+
+class TargetWeightMultiplier(BaseModel):
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+    multiplier: float = Field(..., ge=0.0)
+    reason: str | None = None
+
+
+class TargetWeightDecisionOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    adjustments: dict[str, TargetWeightMultiplier]
+
+
+def validate_target_weight_response(
+    response: ExternalDecisionResponse,
+    *,
+    policy: TargetWeightPolicyConfig,
+    history_dates: list[date],
+    now: datetime,
+) -> dict[str, TargetWeightMultiplier]:
+    validate_market_decision_response(
+        response,
+        history_dates=history_dates,
+        max_signal_age_sessions=policy.max_signal_age_sessions,
+        now=now,
+        decision_name="target weight policy",
+    )
+
+    raw_adjustments = response.output.get("adjustments")
+    if isinstance(raw_adjustments, dict):
+        for raw_adjustment in raw_adjustments.values():
+            if not isinstance(raw_adjustment, dict):
+                continue
+            multiplier = raw_adjustment.get("multiplier")
+            if isinstance(multiplier, bool) or not isinstance(multiplier, (int, float)):
+                raise ExternalDecisionError(
+                    "target weight policy returned invalid adjustments"
+                )
+    try:
+        output = TargetWeightDecisionOutput.model_validate(response.output)
+    except ValueError as exc:
+        raise ExternalDecisionError(
+            "target weight policy returned invalid adjustments"
+        ) from exc
+
+    expected_symbols = set(policy.symbols)
+    response_symbols = set(output.adjustments)
+    if response_symbols != expected_symbols:
+        missing = sorted(expected_symbols - response_symbols)
+        unknown = sorted(response_symbols - expected_symbols)
+        differences = []
+        if missing:
+            differences.append(f"missing={','.join(missing)}")
+        if unknown:
+            differences.append(f"unknown={','.join(unknown)}")
+        raise ExternalDecisionError(
+            "target weight policy response symbols do not match configuration"
+            + (f" ({'; '.join(differences)})" if differences else "")
+        )
+
+    for symbol, adjustment in output.adjustments.items():
+        multiplier = adjustment.multiplier
+        limits = policy.symbols[symbol]
+        if not math.isfinite(multiplier):
+            raise ExternalDecisionError(
+                f"target weight policy multiplier for {symbol} is not finite"
+            )
+        if multiplier < limits.min_multiplier or multiplier > limits.max_multiplier:
+            raise ExternalDecisionError(
+                f"target weight policy multiplier for {symbol} is outside "
+                "configured bounds"
+            )
+    return output.adjustments

--- a/thetagang/target_weight_policy.py
+++ b/thetagang/target_weight_policy.py
@@ -116,6 +116,18 @@ class TargetWeightPortfolioInput(DecisionInput):
 class MultiplierConstraints(DecisionInput):
     min_multiplier: float
     max_multiplier: float
+    min_target_weight: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional floor as a fraction of the regime capital base, before absolute trend.",
+    )
+    max_target_weight: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional ceiling as a fraction of the regime capital base, before absolute trend.",
+    )
     clamp_to_volatility_bounds: bool
 
 
@@ -234,10 +246,25 @@ def apply_target_weight_adjustments(
             raise ExternalDecisionError(
                 f"target weight policy produced an invalid weight for {symbol}"
             )
-        effective_weight = raw_weight
-        if policy.symbols[symbol].clamp_to_volatility_bounds:
-            minimum, maximum = volatility_bounds[symbol]
-            effective_weight = max(minimum, min(effective_weight, maximum))
+        limits = policy.symbols[symbol]
+        minimum = (
+            limits.min_target_weight if limits.min_target_weight is not None else 0.0
+        )
+        maximum = (
+            limits.max_target_weight
+            if limits.max_target_weight is not None
+            else math.inf
+        )
+        if limits.clamp_to_volatility_bounds:
+            volatility_minimum, volatility_maximum = volatility_bounds[symbol]
+            minimum = max(minimum, volatility_minimum)
+            maximum = min(maximum, volatility_maximum)
+        if minimum > maximum:
+            raise ExternalDecisionError(
+                f"target weight policy for {symbol} has target bounds that "
+                "do not overlap volatility bounds"
+            )
+        effective_weight = max(minimum, min(raw_weight, maximum))
         if effective_weight > 1:
             raise ExternalDecisionError(
                 f"target weight policy produced an invalid weight for {symbol}"


### PR DESCRIPTION
## Summary

Add an opt-in API for outsourcing selected decisions to external models without adding their training, inference, or dependency stack to ThetaGang. Named command providers receive versioned JSON context; ThetaGang retains responsibility for validating decisions, applying strategy gates, and selecting and executing orders. Both hooks are disabled by default.

## Decision hooks

- **`regime_target_weights`** supplies bounded per-symbol multipliers after volatility weighting and before absolute-trend controls. ThetaGang enforces multiplier bounds, optional per-symbol `min_target_weight` / `max_target_weight` floors and ceilings, optional volatility clamping, and a total-exposure ceiling. Target bounds are fractions of the configured strategy capital base, applied after multiplication and before absolute trend; enabling both clamps uses their intersection and rejects conflicting ranges. The original volatility calculation and smoothing remain unchanged. By default, that ceiling is the larger of 100% or the pre-decision total; configuration can explicitly permit more. Accepted decisions are reused during replanning within the same run, with expiry checked again before reuse. The `managed_stocks` capital base is unsupported for this hook.
- **`tail_hedge_harvest`** approves or vetoes an already eligible harvest associated with an approved same-symbol hard-underweight stock buy. The request includes hedge ownership, protected-underlying context, host-planned sales, and market history. ThetaGang re-quotes and rechecks ownership, conflicts, profitability, allocation bands, and decision expiry before persisting recovery intent or queuing orders. The response cannot specify contracts, quantities, or prices.

## Provider contract and tooling

- Direct command execution without a shell, using one JSON request on stdin and one response on stdout. Enforce timeouts, response-size limits, an explicit integer schema version, request identity, strict numeric/boolean decision values, completed-session freshness, and optional expiry. Clean up subprocesses and pipes on failure or cancellation, including the process group on POSIX.
- Supply aligned completed-session IBKR daily closes with unique chronological sessions and finite positive numeric prices and decision-specific account, portfolio, and strategy context. Reference symbols can be outside the traded portfolio; explicit exchange overrides use separate persistent history entries.
- Publish four v1 request/response JSON schemas, complete fixtures, configuration and protocol documentation, and a standard-library reference provider that needs no ThetaGang installation.
- Add `python -m thetagang.decision_check` to export schemas, run a provider against a saved request, or validate a saved response without starting the trading runtime or connecting to IBKR. It shares production response validators and target-weight math; harvest checks validate the external contract, without replaying live execution gates.

Providers are trusted local programs running with ThetaGang's OS permissions. Process separation isolates dependencies; it is not a security sandbox.

## Failure behavior

- Target-weight failures use the post-volatility baseline or abort planning, according to configuration. A failed sizing signal also prevents harvesting from funding the affected underlying. Response and target-application failures retain the configured failure behavior for the rest of the run, even if later baseline weights would make a rejected adjustment affordable.
- Harvest failures preserve the eligible baseline harvest, skip it, or abort planning. A valid veto is always honored. Failures and applied decisions are recorded in logs and decision telemetry.

## Validation

Validated at `8bf365b8`:

- `uv run pytest --cov=thetagang` — **734 passed, 82% coverage**, including schema consistency, reference-provider isolation, response validation, subprocess cleanup, persistent rejection during replanning, invalid market-history rejection, independent target bounds in live planning and offline replay, volatility smoothing and trend ordering, and harvest revalidation tests.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `uv run pre-commit run --all-files`, `uv lock --check`, and `git diff --check` — passed.
- GitHub CI at `8bf365b8` — pending after push; the prior head passed all eight Python 3.11–3.14 test jobs and the Docker image build.
