### PR TITLE
feat: graduate absolute-trend risk reduction

### DIFF
--- a/docs/external-decisions.md
+++ b/docs/external-decisions.md
@@ -68,6 +68,11 @@ The `input` for `regime_target_weights` contains:
 Explicit primary-exchange overrides use separate persistent history entries,
 so missing API bars cannot be filled with another listing's cached prices.
 
+The absolute-trend configuration includes `risk_off_ramp_width` (default `0.0`
+for the original step reduction). Providers can require an explicit host ramp,
+such as `0.10`, when validating their strategy configuration. ThetaGang applies
+the ramp after the provider multiplier; providers must not apply it themselves.
+
 The listed TQQQ sizing features—returns, moving-average distance, trend,
 realized volatility, volatility acceleration, drawdown, close-based choppiness,
 efficiency, relative trends, correlations, and PCA concentration—can all be

--- a/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
+++ b/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
@@ -14,6 +14,13 @@
         "risk_off_multiplier": {
           "title": "Risk Off Multiplier",
           "type": "number"
+        },
+        "risk_off_ramp_width": {
+          "default": 0.0,
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Risk Off Ramp Width",
+          "type": "number"
         }
       },
       "required": [

--- a/examples/external_decisions/regime_target_weights.request.json
+++ b/examples/external_decisions/regime_target_weights.request.json
@@ -70,7 +70,8 @@
         "absolute_trend": {
           "enabled": true,
           "lookback_days": 168,
-          "risk_off_multiplier": 0.15
+          "risk_off_multiplier": 0.15,
+          "risk_off_ramp_width": 0.0
         },
         "execution_constraints": {
           "trading_allowed": true,

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -603,7 +603,7 @@ def test_symbol_absolute_trend_defaults_disabled() -> None:
     assert absolute_trend.enabled is False
     assert absolute_trend.lookback_days == 168
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.15)
-    assert absolute_trend.risk_off_ramp_width == pytest.approx(0.10)
+    assert absolute_trend.risk_off_ramp_width == pytest.approx(0.0)
 
 
 @pytest.mark.parametrize("width", [-0.1, 1.1, float("nan"), float("inf")])

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -579,6 +579,7 @@ def test_symbol_accepts_absolute_trend_config() -> None:
         "enabled": True,
         "lookback_days": 168,
         "risk_off_multiplier": 0.15,
+        "risk_off_ramp_width": 0.20,
     }
 
     config = Config(**data)
@@ -588,6 +589,7 @@ def test_symbol_accepts_absolute_trend_config() -> None:
     assert absolute_trend.enabled is True
     assert absolute_trend.lookback_days == 168
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.15)
+    assert absolute_trend.risk_off_ramp_width == pytest.approx(0.20)
 
 
 def test_symbol_absolute_trend_defaults_disabled() -> None:
@@ -601,12 +603,24 @@ def test_symbol_absolute_trend_defaults_disabled() -> None:
     assert absolute_trend.enabled is False
     assert absolute_trend.lookback_days == 168
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.15)
+    assert absolute_trend.risk_off_ramp_width == pytest.approx(0.10)
+
+
+@pytest.mark.parametrize("width", [-0.1, 1.1, float("nan"), float("inf")])
+def test_symbol_absolute_trend_rejects_invalid_ramp_width(width: float) -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {
+        "risk_off_ramp_width": width,
+    }
+    with pytest.raises(ValueError, match="risk_off_ramp_width"):
+        Config(**data)
 
 
 def test_symbol_absolute_trend_allows_zero_risk_off_multiplier() -> None:
     data = _base_config({"strategies": ["wheel"]})
     data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {
         "risk_off_multiplier": 0.0,
+        "risk_off_ramp_width": 0.0,
     }
 
     config = Config(**data)
@@ -614,6 +628,7 @@ def test_symbol_absolute_trend_allows_zero_risk_off_multiplier() -> None:
     absolute_trend = config.portfolio.symbols["AAA"].absolute_trend
     assert absolute_trend is not None
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.0)
+    assert absolute_trend.risk_off_ramp_width == pytest.approx(0.0)
 
 
 def _enable_target_weight_policy(data: dict[str, Any]) -> None:

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -564,12 +564,14 @@ def _absolute_trend(
     *,
     lookback_days: int = 168,
     risk_off_multiplier: float = 0.15,
+    risk_off_ramp_width: float = 0.10,
     enabled: bool = True,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         enabled=enabled,
         lookback_days=lookback_days,
         risk_off_multiplier=risk_off_multiplier,
+        risk_off_ramp_width=risk_off_ramp_width,
     )
 
 
@@ -1072,7 +1074,7 @@ async def test_model_target_bounds_preserve_smoothing_capital_base_and_trend(
     _mock_regime_histories(
         manager,
         mocker,
-        {"AAA": [100.0, 100.0, 100.0, 90.0], "BBB": [100.0] * 4},
+        {"AAA": [100.0, 100.0, 100.0, 95.0], "BBB": [100.0] * 4},
     )
     manager.ibkr.request_executions = mocker.AsyncMock(return_value=[])
     positions = _regime_stock_positions(aaa=2, bbb=2)
@@ -1101,7 +1103,7 @@ async def test_model_target_bounds_preserve_smoothing_capital_base_and_trend(
     assert policy["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.20)
     trend = manager.data_store.get_last_event_payload("absolute_trend_state")
     assert trend["symbols"]["AAA"]["pre_trend_target"] == pytest.approx(0.20)
-    assert trend["symbols"]["AAA"]["final_target"] == pytest.approx(0.05)
+    assert trend["symbols"]["AAA"]["final_target"] == pytest.approx(0.125)
     assert symbol_config.volatility_weight.min_weight == 0.25
     assert symbol_config.volatility_weight.smoothing_factor == 0.5
 
@@ -2142,10 +2144,48 @@ async def test_absolute_trend_risk_boundaries(
         history_cache,
     )
 
-    expected_multiplier = 0.15 if expected_risk_off else 1.0
+    expected_multiplier = 0.915 if expected_risk_off else 1.0
     assert details["AAA"]["risk_off"] is expected_risk_off
     assert details["AAA"]["applied_multiplier"] == pytest.approx(expected_multiplier)
     assert weights["AAA"] == pytest.approx(0.4 * expected_multiplier)
+
+
+@pytest.mark.parametrize(
+    "closes, width, floor, expected",
+    [
+        ([100.0, 100.0, 100.0, 105.0], 0.10, 0.25, 1.0),
+        ([100.0, 100.0, 100.0, 100.0], 0.10, 0.25, 1.0),
+        ([100.0, 100.0, 100.0, 99.0], 0.10, 0.25, 0.925),
+        ([100.0, 100.0, 100.0, 95.0], 0.10, 0.25, 0.625),
+        ([110.0, 95.0, 95.0, 95.0], 0.10, 0.25, 0.625),
+        ([100.0, 115.0, 115.0, 95.0], 0.10, 0.25, 0.625),
+        ([100.0, 100.0, 100.0, 90.0], 0.10, 0.25, 0.25),
+        ([100.0, 100.0, 100.0, 80.0], 0.10, 0.25, 0.25),
+        ([100.0, 100.0, 100.0, 99.0], 0.0, 0.25, 0.25),
+        ([100.0, 100.0, 100.0, 95.0], 0.10, 0.0, 0.5),
+        ([100.0, 100.0, 100.0, 90.0], 0.10, 0.0, 0.0),
+        ([100.0, 100.0, 100.0, 95.0], 0.10, 1.0, 1.0),
+    ],
+)
+@pytest.mark.asyncio
+async def test_absolute_trend_ramp(
+    portfolio_manager: Any,
+    mocker: Any,
+    closes: list[float],
+    width: float,
+    floor: float,
+    expected: float,
+) -> None:
+    portfolio_manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        lookback_days=3, risk_off_multiplier=floor, risk_off_ramp_width=width
+    )
+    weights, details = await portfolio_manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4, "BBB": 0.5},
+        portfolio_manager.config.portfolio.symbols,
+        _absolute_trend_history_cache(mocker, closes, lookback_days=3),
+    )
+    assert details["AAA"]["applied_multiplier"] == pytest.approx(expected)
+    assert weights == pytest.approx({"AAA": 0.4 * expected, "BBB": 0.5})
 
 
 @pytest.mark.parametrize(
@@ -2257,13 +2297,14 @@ async def test_regime_history_cache_keys_primary_exchange_overrides(mocker):
     )
 
 
+@pytest.mark.parametrize("width, expected_target", [(0.10, 0.06), (0.20, 0.23)])
 @pytest.mark.asyncio
 async def test_absolute_trend_reuses_persisted_state_when_history_fails(
-    portfolio_manager_with_db, mocker
+    portfolio_manager_with_db, mocker, width: float, expected_target: float
 ):
     portfolio_manager_with_db.config.portfolio.symbols[
         "AAA"
-    ].absolute_trend = _absolute_trend()
+    ].absolute_trend = _absolute_trend(risk_off_ramp_width=width)
     portfolio_manager_with_db.data_store.record_event(
         "absolute_trend_state",
         {"symbols": {"AAA": _absolute_trend_signal_payload()}},
@@ -2281,7 +2322,7 @@ async def test_absolute_trend_reuses_persisted_state_when_history_fails(
         history_cache,
     )
 
-    assert weights["AAA"] == pytest.approx(0.06)
+    assert weights["AAA"] == pytest.approx(expected_target)
     assert details["AAA"]["risk_off"] is True
     assert details["AAA"]["history_source"] == "persisted"
 

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1085,6 +1085,9 @@ async def test_model_target_bounds_preserve_smoothing_capital_base_and_trend(
     )
 
     request = provider.requests[0].input
+    assert request["symbols"]["AAA"]["absolute_trend"][
+        "risk_off_ramp_width"
+    ] == pytest.approx(0.10)
     assert request["account"]["rebalance_base_value"] == pytest.approx(2250.0)
     assert request["adjustment_constraints"]["AAA"] == {
         "min_multiplier": 0.5,

--- a/tests/test_target_weight_policy.py
+++ b/tests/test_target_weight_policy.py
@@ -8,10 +8,18 @@ from thetagang.external_decisions import (
     ExternalDecisionResponse,
 )
 from thetagang.target_weight_policy import (
+    AbsoluteTrendInput,
     TargetWeightMultiplier,
     apply_target_weight_adjustments,
     validate_target_weight_response,
 )
+
+
+def test_absolute_trend_request_defaults_to_cliff() -> None:
+    trend = AbsoluteTrendInput.model_validate(
+        {"enabled": True, "lookback_days": 250, "risk_off_multiplier": 0.25}
+    )
+    assert trend.risk_off_ramp_width == 0.0
 
 
 def _policy() -> TargetWeightPolicyConfig:

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -565,7 +565,7 @@ daily_stddev_window = "30 D"
   # lookback_days = 168
   # risk_off_multiplier = 0.25
   # Ramp from 1.0 at the lower of the moving average and lookback reference
-  # to the floor 10% below it. Set width to 0 for the original step reduction.
+  # to the floor 10% below it. Width defaults to 0 (original step reduction).
   # risk_off_ramp_width = 0.10
   # The target DTE may also be specified per-symbol, and takes precedence over
   # `target.dte`

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -563,7 +563,10 @@ daily_stddev_window = "30 D"
   # [portfolio.symbols.QQQ.absolute_trend]
   # enabled = false
   # lookback_days = 168
-  # risk_off_multiplier = 0.15
+  # risk_off_multiplier = 0.25
+  # Ramp from 1.0 at the lower of the moving average and lookback reference
+  # to the floor 10% below it. Set width to 0 for the original step reduction.
+  # risk_off_ramp_width = 0.10
   # The target DTE may also be specified per-symbol, and takes precedence over
   # `target.dte`
   dte = 60

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -758,7 +758,7 @@ class SymbolConfig(BaseModel):
         enabled: bool = Field(default=False)
         lookback_days: int = Field(default=168, ge=2)
         risk_off_multiplier: float = Field(default=0.15, ge=0.0, le=1.0)
-        risk_off_ramp_width: float = Field(default=0.10, ge=0.0, le=1.0)
+        risk_off_ramp_width: float = Field(default=0.0, ge=0.0, le=1.0)
 
     weight: float = Field(..., ge=0, le=1)
     primary_exchange: str = Field(default="", min_length=1)

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -758,6 +758,7 @@ class SymbolConfig(BaseModel):
         enabled: bool = Field(default=False)
         lookback_days: int = Field(default=168, ge=2)
         risk_off_multiplier: float = Field(default=0.15, ge=0.0, le=1.0)
+        risk_off_ramp_width: float = Field(default=0.10, ge=0.0, le=1.0)
 
     weight: float = Field(..., ge=0, le=1)
     primary_exchange: str = Field(default="", min_length=1)

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -285,10 +285,19 @@ class _AbsoluteTrendSignal:
         *,
         pre_trend_target: float,
         risk_off_multiplier: float,
+        risk_off_ramp_width: float,
         history_source: str,
         history_failure: str | None = None,
     ) -> dict[str, Any]:
         applied_multiplier = risk_off_multiplier if self.risk_off else 1.0
+        if self.risk_off and risk_off_ramp_width > 0:
+            # Both trend conditions must weaken before reaching the floor.
+            threshold = min(self.moving_average, self.momentum_reference_close)
+            depth = (threshold - self.latest_close) / threshold
+            progress = min(depth / risk_off_ramp_width, 1.0)
+            applied_multiplier = max(
+                risk_off_multiplier, 1.0 - (1.0 - risk_off_multiplier) * progress
+            )
         details: dict[str, Any] = {
             "lookback_days": self.lookback_days,
             "latest_session": self.latest_session,
@@ -2573,6 +2582,7 @@ class RegimeRebalanceEngine:
             details = signal.target_details(
                 pre_trend_target=adjusted_weights[symbol],
                 risk_off_multiplier=float(trend_configs[symbol].risk_off_multiplier),
+                risk_off_ramp_width=float(trend_configs[symbol].risk_off_ramp_width),
                 history_source=history_source,
                 history_failure=history_failure,
             )

--- a/thetagang/target_weight_policy.py
+++ b/thetagang/target_weight_policy.py
@@ -50,6 +50,7 @@ class AbsoluteTrendInput(DecisionInput):
     enabled: bool
     lookback_days: int
     risk_off_multiplier: float
+    risk_off_ramp_width: float = Field(default=0.0, ge=0.0, le=1.0)
 
 
 class ExecutionConstraints(DecisionInput):


### PR DESCRIPTION
## Summary

Replace the native absolute-trend cliff with a configurable linear ramp. ThetaGang continues applying trend protection after volatility targeting and the optional external multiplier.

## User Impact

With `risk_off_ramp_width = 0.10` and `risk_off_multiplier = 0.25`, the target multiplier is 0.925 at 1% below both trend thresholds, 0.625 at 5%, and 0.25 at 10% or more. The ramp is opt-in: width defaults to 0, preserving the previous cliff for existing configurations. The sample shows a 0.25 floor, while the library's existing 0.15 floor default is unchanged.

## Root Cause

The absolute-trend calculation immediately applied the floor whenever price crossed below both the moving average and lookback reference, creating a discontinuous target reduction.

## Fix

Interpolate from 1.0 to the configured floor using the percentage shortfall below the lower trend threshold. Apply the same calculation to fresh history and persisted-state fallback. Validate ramp width within [0, 1] and retain zero-floor liquidation support. Include the host ramp width in the external-provider request and published schema so providers can validate the host strategy without calculating the ramp themselves.

## Validation

- `uv run pytest --cov=thetagang -q`: 752 passed, 82% total coverage; 229 resource warnings.
- `uv run ruff check .`, `uv run ruff format --check .`, and `uv run ty check`: passed.
- `uv run pre-commit run --all-files`: passed.
- Regression coverage includes ramp boundaries, differing trend thresholds, zero width, floor endpoints, persisted fallback, and application after external target adjustment.

