### PR TITLE
perf: reuse regime history within each run

### DIFF
--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -608,3 +608,21 @@ async def test_cancel_order_is_blocked_in_dry_run(mock_ib):
     ibkr.cancel_order(order)
 
     mock_ib.cancelOrder.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("duration", "expected"),
+    [
+        ("364 D", "364 D"),
+        ("365 D", "365 D"),
+        ("366 D", "2 Y"),
+        ("730 D", "2 Y"),
+        ("731 D", "3 Y"),
+        ("2 Y", "2 Y"),
+    ],
+)
+async def test_historical_duration_boundaries(ibkr, mock_ib, duration, expected):
+    mock_ib.reqHistoricalDataAsync = AsyncMock(return_value=[])
+    await ibkr.request_historical_data(Stock("AAA", "SMART", "USD"), duration)
+    assert mock_ib.reqHistoricalDataAsync.await_args is not None
+    assert mock_ib.reqHistoricalDataAsync.await_args.args[2] == expected

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -1356,7 +1356,8 @@ async def test_exchange_override_history_does_not_mix_persisted_listings(
     assert prices == {"AAA": [200.0] * 4}
 
     manager.ibkr.ib.reqHistoricalDataAsync.return_value = []
-    # Exercise the persistent fallback, bypassing the per-plan memory cache.
+    # Exercise persistent recovery in a new run for both listings.
+    manager.regime_engine.begin_run()
     _, default_prices = await manager.regime_engine._get_regime_aligned_closes(
         ["AAA"],
         3,
@@ -6397,3 +6398,86 @@ async def test_volatility_sizing_failure_blocks_harvest_but_not_regime_order(
     assert orders == [("AAA", "NYSE", -1), ("BBB", "NYSE", 2)]
     assert portfolio_manager.orders.records() == []
     portfolio_manager.ibkr.get_ticker_for_contract.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_history_fetches_maximum_window_and_serves_overlaps(
+    portfolio_manager, mocker
+):
+    engine = portfolio_manager.regime_engine
+    config = portfolio_manager.config
+    config.portfolio.symbols["AAA"].volatility_weight = _volatility_weight(
+        lookback_days=4
+    )
+    config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(lookback_days=6)
+    policy = _target_weight_policy()
+    policy.market_data.lookback_days = 8
+    config.strategies.regime_rebalance.target_weight_policy = policy
+    dates = [date(2026, 8, 3) + timedelta(days=i) for i in range(9)]
+    mocker.patch.object(
+        engine, "_get_required_history_dates", side_effect=lambda n: dates[-n:]
+    )
+    mocker.patch.object(engine, "_now", return_value=datetime(2026, 8, 12, tzinfo=UTC))
+    bars = [SimpleNamespace(date=d, close=100.0 + i) for i, d in enumerate(dates)]
+    bars.append(SimpleNamespace(date=date(2026, 8, 12), close=999.0))
+    portfolio_manager.ibkr.request_historical_data = mocker.AsyncMock(return_value=bars)
+
+    await engine._get_regime_aligned_closes(["AAA"], 4, 0)
+    market = await engine._load_external_market_data(
+        market_data_config=policy.market_data,
+        strategy_symbols=["AAA", "BBB"],
+        symbol_configs=config.portfolio.symbols,
+        decision_name="test",
+    )
+    assert market.sessions == dates
+    assert market.closes == {
+        "AAA": [100.0 + i for i in range(9)],
+        "BBB": [100.0 + i for i in range(9)],
+    }
+    assert await engine._get_regime_aligned_closes(["BBB", "AAA"], 6, 0) == (
+        dates[-7:],
+        {"BBB": [102.0 + i for i in range(7)], "AAA": [102.0 + i for i in range(7)]},
+    )
+    await engine._get_regime_aligned_closes(["AAA", "BBB"], 3, 2)
+    assert portfolio_manager.ibkr.request_historical_data.await_count == 2
+    assert {
+        call.args[1]
+        for call in portfolio_manager.ibkr.request_historical_data.await_args_list
+    } == {"10 D"}
+    await engine._get_regime_aligned_closes(
+        ["AAA"], 3, 0, primary_exchanges={"AAA": "NYSE"}
+    )
+    assert portfolio_manager.ibkr.request_historical_data.await_count == 2
+    engine.begin_run()
+    await engine._get_regime_aligned_closes(["AAA"], 4, 0)
+    assert portfolio_manager.ibkr.request_historical_data.await_count == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("complete", [True, False])
+async def test_run_history_reuses_sqlite_recovery_and_rejects_gaps(
+    portfolio_manager_with_db, mocker, complete
+):
+    manager = portfolio_manager_with_db
+    engine = manager.regime_engine
+    dates = [bar.date.date() for bar in _regime_bars([100.0] * 4)]
+    mocker.patch.object(
+        engine, "_get_required_history_dates", side_effect=lambda n: dates[-n:]
+    )
+    _seed_regime_history_cache(manager, [100.0] * (4 if complete else 3))
+    manager.ibkr.request_historical_data = mocker.AsyncMock(
+        return_value=_regime_bars([100.0])
+    )
+    if not complete:
+        for _ in range(2):
+            with pytest.raises(ValueError, match="fresh historical data"):
+                await engine._get_regime_aligned_closes(["AAA"], 3, 0)
+    else:
+        await engine._get_regime_aligned_closes(["AAA"], 3, 0)
+        read = mocker.spy(manager.data_store, "get_historical_bars")
+        assert await engine._get_regime_aligned_closes(["AAA"], 2, 0) == (
+            dates[-3:],
+            {"AAA": [100.0] * 3},
+        )
+        read.assert_not_called()
+    assert manager.ibkr.request_historical_data.await_count == 1

--- a/thetagang/ibkr.py
+++ b/thetagang/ibkr.py
@@ -107,6 +107,9 @@ class IBKR:
         *,
         cache_symbol: str | None = None,
     ) -> BarDataList:
+        amount, unit = duration.split()
+        if unit == "D" and int(amount) > 365:
+            duration = f"{(int(amount) + 364) // 365} Y"
         bars = await self.ib.reqHistoricalDataAsync(
             contract,
             "",

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -397,6 +397,9 @@ class RegimeRebalanceEngine:
         self.data_store = data_store
         self.external_decisions = external_decisions or ExternalDecisionProviders()
         self.dry_run = dry_run
+        self._history_closes: dict[
+            tuple[str, str], tuple[date, date, dict[date, float]]
+        ] = {}
         self._target_weight_policy_outcome: _TargetWeightPolicyOutcome | None = None
         self._get_primary_exchange = get_primary_exchange
         self._now = now_provider
@@ -415,9 +418,10 @@ class RegimeRebalanceEngine:
         self.regime_rebalance_order_ref_prefix = "tg:regime-rebalance"
 
     def begin_run(self) -> None:
-        """Clear decisions that may only be reused within one manager run."""
+        """Clear decisions and history that may only be reused within one run."""
 
         self._target_weight_policy_outcome = None
+        self._history_closes.clear()
 
     def _reserve_cash_for_post_management(self, amount: float) -> None:
         if self._set_reserved_cash_for_post_management is None:
@@ -1733,7 +1737,7 @@ class RegimeRebalanceEngine:
             aligned: list[float] = []
             for date_point in sorted_dates:
                 close = closes_by_symbol[symbol].get(date_point)
-                if close is None or math.isnan(close) or math.isclose(close, 0):
+                if close is None or not math.isfinite(close) or close <= 0:
                     log.error(
                         f"Invalid close for {symbol} on {date_point} (close={close})."
                     )
@@ -1972,25 +1976,6 @@ class RegimeRebalanceEngine:
         )
         return symbol, []
 
-    async def _fetch_regime_history_closes(
-        self,
-        symbols: list[str],
-        duration: str,
-        primary_exchanges: dict[str, str] | None = None,
-    ) -> ClosesBySymbol:
-        tasks: list[Coroutine[Any, Any, tuple[str, list[Any]]]] = [
-            self._fetch_regime_history_bars(
-                symbol,
-                duration,
-                (primary_exchanges or {}).get(symbol),
-            )
-            for symbol in symbols
-        ]
-        histories = await log.track_async(
-            tasks, description="Fetching regime rebalancing history..."
-        )
-        return {symbol: self._bars_to_closes(bars) for symbol, bars in histories}
-
     @staticmethod
     def _history_cache_symbol(symbol: str, primary_exchange: str | None) -> str:
         # The legacy cache is keyed by ticker alone. Explicit listing overrides
@@ -2037,6 +2022,14 @@ class RegimeRebalanceEngine:
             merged = dict(cached_closes)
             merged.update(api_closes_by_symbol[symbol])
             merged_closes_by_symbol[symbol] = merged
+            key = (
+                symbol,
+                (primary_exchanges or {}).get(symbol)
+                or self.get_primary_exchange(symbol),
+            )
+            if key in self._history_closes:
+                first, last, closes = self._history_closes[key]
+                self._history_closes[key] = (first, last, {**closes, **merged})
         return merged_closes_by_symbol
 
     def _recover_regime_history_from_cache(
@@ -2067,6 +2060,43 @@ class RegimeRebalanceEngine:
         )
         return (dates, aligned_closes)
 
+    def _required_symbol_lookback(self, symbol: str, exchange: str) -> int:
+        regime = self.config.strategies.regime_rebalance
+        lookback = 0
+        if symbol in regime.symbols and exchange == self.get_primary_exchange(symbol):
+            lookback = regime.lookback_days
+            symbol_config = resolve_symbol_configs(
+                self.config, context="regime history"
+            )[symbol]
+            for modifier in (
+                getattr(symbol_config, "volatility_weight", None),
+                getattr(symbol_config, "absolute_trend", None),
+            ):
+                if modifier is not None and modifier.enabled:
+                    lookback = max(lookback, modifier.lookback_days)
+        tail = self.config.strategies.tail_hedge
+        for policy, strategy_symbols in (
+            (getattr(regime, "target_weight_policy", None), regime.symbols),
+            (
+                getattr(tail, "harvest_decision", None),
+                [target.symbol for target in tail.targets],
+            ),
+        ):
+            if policy is None or not policy.enabled:
+                continue
+            market = policy.market_data
+            configured = market.symbols.get(symbol)
+            if configured is None and not (
+                market.include_strategy_symbols and symbol in strategy_symbols
+            ):
+                continue
+            policy_exchange = (
+                configured.primary_exchange.strip() if configured else ""
+            ) or self.get_primary_exchange(symbol)
+            if exchange == policy_exchange:
+                lookback = max(lookback, market.lookback_days)
+        return lookback
+
     async def _get_regime_aligned_closes(
         self,
         symbols: list[str],
@@ -2091,11 +2121,46 @@ class RegimeRebalanceEngine:
                 "Regime-aware rebalancing requires a valid history request window.",
                 cache_recoverable=False,
             )
-        duration = f"{calendar_days} D"
-        api_closes_by_symbol = await self._fetch_regime_history_closes(
-            symbols,
-            duration,
-            primary_exchanges,
+
+        async def load_symbol(symbol: str) -> tuple[str, dict[date, float]]:
+            exchange = (primary_exchanges or {}).get(
+                symbol
+            ) or self.get_primary_exchange(symbol)
+            key = (symbol, exchange)
+            lookback = max(
+                lookback_days, self._required_symbol_lookback(symbol, exchange)
+            )
+            fetch_dates = (
+                required_dates
+                if lookback == lookback_days
+                else self._get_required_history_dates(lookback + 1)
+            )
+            if not fetch_dates:
+                raise RegimeHistoryValidationError(
+                    "Regime-aware rebalancing requires completed session dates.",
+                    cache_recoverable=False,
+                )
+            cached = self._history_closes.get(key)
+            if (
+                cached is None
+                or cached[0] > fetch_dates[0]
+                or cached[1] != fetch_dates[-1]
+            ):
+                days = (self._now().date() - fetch_dates[0]).days + 1
+                _, bars = await self._fetch_regime_history_bars(
+                    symbol, f"{days} D", (primary_exchanges or {}).get(symbol)
+                )
+                closes = self._bars_to_closes(bars)
+                self._history_closes[key] = (fetch_dates[0], fetch_dates[-1], closes)
+            else:
+                closes = cached[2]
+            return symbol, closes
+
+        api_closes_by_symbol = dict(
+            await log.track_async(
+                [load_symbol(symbol) for symbol in dict.fromkeys(symbols)],
+                description="Fetching regime rebalancing history...",
+            )
         )
 
         try:


### PR DESCRIPTION
## Summary

Reuse regime history within each manager run across native volatility sizing, external-hook market data, absolute trend, and regime gates.

## User Impact

Overlapping requests reuse each listing's largest configured history window, reducing IBKR requests while preserving aligned completed-session history in `input.market_data`. SQLite remains the only persistent cache.

## Root Cause

The existing cache matched entire requests, including symbol order and lookback. Different consumers therefore fetched overlapping history repeatedly.

## Fix

Cache daily closes by symbol and resolved primary exchange, plan the maximum configured lookback before fetching, and clear history at `begin_run()`. Keep concurrent fetching across symbols and reuse SQLite recovery results in memory. Validate requested sessions on retrieval, reject nonfinite/nonpositive closes, and round IBKR day durations over 365 days up to whole years.

## Validation

- Full suite: `uv run pytest --cov=thetagang -q` — 743 passed, 82% coverage.
- Final committed tree: `uv run pytest tests/test_regime_rebalance.py tests/test_ibkr.py -q --disable-warnings` — 204 passed.
- `uv run pre-commit run --all-files`, `uv run ty check`, and `git diff --check` passed.
- Regression coverage includes overlapping windows, primary-exchange isolation, SQLite recovery reuse, incomplete-history rejection, run reset, completed-session hook alignment, and duration boundaries.

IBKR calls were mocked; live broker behavior has not been exercised.
