### PR TITLE
feat: explicit absolute-trend exit policy and provider rejections

### DIFF
--- a/docs/external-decisions.md
+++ b/docs/external-decisions.md
@@ -103,6 +103,20 @@ the entry rule no longer held), `sessions_in_state`, `previous_state`, and the
 active `mode`, `exit_depth`, and `min_dwell_sessions`. Boundary chatter and rule
 differences are read from those events, not inferred from trade counts.
 
+Each `absolute_trend_state` event carries the payload `state_version` that wrote
+it, and every symbol records `state_reset_reason`: null when the previous record
+was applied as-is or when no record existed (a cold start), and otherwise why it
+could not be. A record written by an older `state_version` is salvaged by its
+recorded risk state and reported as `legacy_payload`, so an upgrade keeps any
+hysteresis-held risk-off and only restarts the dwell counter. A record that
+claims the current version and is still unreadable is `invalid_persisted_state`
+(or `unsupported_state_version` when only the version is wrong). Deadband mode
+aborts regime-rebalance planning in that case, because a reset there can release
+exposure the deadband was holding; cliff mode re-resolves from the entry rule,
+which cannot change exposure, and says so in the event. An A/B that counts drift
+sessions must therefore filter on `state_reset_reason` rather than assume every
+reset shows up as drift.
+
 The listed TQQQ sizing features—returns, moving-average distance, trend,
 realized volatility, volatility acceleration, drawdown, close-based choppiness,
 efficiency, relative trends, correlations, and PCA concentration—can all be

--- a/docs/external-decisions.md
+++ b/docs/external-decisions.md
@@ -68,10 +68,40 @@ The `input` for `regime_target_weights` contains:
 Explicit primary-exchange overrides use separate persistent history entries,
 so missing API bars cannot be filled with another listing's cached prices.
 
-The absolute-trend configuration includes `risk_off_ramp_width` (default `0.0`
-for the original step reduction). Providers can require an explicit host ramp,
-such as `0.10`, when validating their strategy configuration. ThetaGang applies
-the ramp after the provider multiplier; providers must not apply it themselves.
+The absolute-trend configuration publishes the host's resolved entry and exit
+rule as `absolute_trend.policy`: `mode` (`cliff` or `deadband`), `exit_depth`,
+and `min_dwell_sessions`. Risk-off is entered when the latest completed close is
+below the lower of the moving average and the momentum reference close. A
+`cliff` exits as soon as that rule stops holding. A `deadband` holds risk-off
+until the close is at least `exit_depth` above the entry threshold and the state
+has lasted at least `min_dwell_sessions` sessions; a `deadband` must set
+`exit_depth > 0` or `min_dwell_sessions >= 2`, because a one-session dwell is
+already true when risk-off is entered. ThetaGang
+resolves and applies the whole rule after the provider multiplier; providers must
+not re-derive it.
+
+Providers validate the published policy by exact match. Pass the policy the model
+was built for as the provider command's only argument, for example
+`command = ["/opt/tqqq-policy/.venv/bin/python", "-m", "tqqq_policy", "{\"mode\": \"deadband\", \"exit_depth\": 0.02, \"min_dwell_sessions\": 3}"]`.
+The [reference provider](../examples/external_decisions/provider.py) performs
+that comparison and rejects a mismatch with a nonzero exit. Target-weight
+requests carry the resolved policy as a nested `absolute_trend.policy` object;
+`tail_hedge_harvest` publishes the same `mode`, `exit_depth`, and
+`min_dwell_sessions` flat inside each `target_modifiers.absolute_trend`
+diagnostic. A host deployment
+whose resolved policy differs from the provider's assumption therefore fails
+loudly instead of silently sizing on a rule the model never saw.
+
+`deadband` is opt-in and has to earn its place. A change that claims a deadband
+helps must first beat the same `cliff` configuration on a matched A/B — identical
+symbols, sessions, sizing, and market history — including forced slow-grind
+episodes where the close oscillates around the entry threshold. The
+`absolute_trend_state` event exists to make that comparison measurable: every
+session records the raw `shortfall` below the entry threshold, whether the
+session was a `state_transition` or `within_band_drift` (risk-off retained while
+the entry rule no longer held), `sessions_in_state`, `previous_state`, and the
+active `mode`, `exit_depth`, and `min_dwell_sessions`. Boundary chatter and rule
+differences are read from those events, not inferred from trade counts.
 
 The listed TQQQ sizing features—returns, moving-average distance, trend,
 realized volatility, volatility acceleration, drawdown, close-based choppiness,
@@ -145,9 +175,20 @@ run. This prevents a tail-harvest replan from receiving a different model signal
 mid-execution.
 Its expiry is checked again before reuse; an expired decision follows the
 configured failure policy without invoking the provider again.
-Any response or target-application failure keeps the hook in its configured
-failure behavior for the rest of that run, even if later baseline weights would
-make a rejected adjustment fit within the exposure ceiling.
+
+`on_error` covers unavailability rather than refused decisions: a provider that
+cannot be started, times out or exceeds `max_response_bytes`, a signal outside the
+configured freshness limits (`max_signal_age_sessions` or `expires_at`), host-side
+market-history collection failures, and expired cached decisions. A provider
+**rejection** is a different, alerted, hard-failure path: a nonzero provider
+exit, an unparsable or malformed response, a signal the host refuses (wrong
+request identity, wrong symbol set, out-of-bounds multiplier, invalid or
+conflicting target bounds, target weights that break the exposure ceiling), or an
+unconfigured provider name. A rejection aborts planning regardless of `on_error`
+and is never collapsed into `on_error = "baseline"`, because baseline sizing would
+trade on a decision the host has already refused. A failed decision also stays
+failed for the rest of the run, even if later baseline weights would make a
+rejected adjustment fit within the exposure ceiling.
 
 ## Tail-harvest decision
 
@@ -259,11 +300,12 @@ primary_exchange = "ARCA"
 ```
 
 `on_error = "baseline"` retains the unmodified post-volatility target when
-history collection, process execution, or response validation fails. The
-failure is visible in logs and persisted decision telemetry. When that target
-policy controls a tail-hedge underlying, harvesting is not allowed to fund the
-symbol unless the sizing signal was fresh and valid. `on_error = "abort"`
-aborts regime-rebalance planning instead.
+history collection, process execution, or transport unavailability prevents a
+decision. The failure is visible in logs and persisted decision telemetry. When
+that target policy controls a tail-hedge underlying, harvesting is not allowed to
+fund the symbol unless the sizing signal was fresh and valid. `on_error = "abort"`
+aborts regime-rebalance planning instead. Neither setting applies to a provider
+rejection, which always aborts (see above).
 
 For `tail_hedge_harvest`, `baseline` preserves the existing eligible harvest,
 `skip` declines it, and `abort` stops planning. A valid provider veto is not an

--- a/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
+++ b/docs/external-decisions/schemas/regime_target_weights.request.v1.schema.json
@@ -11,24 +11,52 @@
           "title": "Lookback Days",
           "type": "integer"
         },
+        "policy": {
+          "$ref": "#/$defs/AbsoluteTrendPolicyInput"
+        },
         "risk_off_multiplier": {
           "title": "Risk Off Multiplier",
-          "type": "number"
-        },
-        "risk_off_ramp_width": {
-          "default": 0.0,
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Risk Off Ramp Width",
           "type": "number"
         }
       },
       "required": [
         "enabled",
         "lookback_days",
-        "risk_off_multiplier"
+        "risk_off_multiplier",
+        "policy"
       ],
       "title": "AbsoluteTrendInput",
+      "type": "object"
+    },
+    "AbsoluteTrendPolicyInput": {
+      "additionalProperties": false,
+      "properties": {
+        "exit_depth": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Exit Depth",
+          "type": "number"
+        },
+        "min_dwell_sessions": {
+          "minimum": 0,
+          "title": "Min Dwell Sessions",
+          "type": "integer"
+        },
+        "mode": {
+          "enum": [
+            "cliff",
+            "deadband"
+          ],
+          "title": "Mode",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mode",
+        "exit_depth",
+        "min_dwell_sessions"
+      ],
+      "title": "AbsoluteTrendPolicyInput",
       "type": "object"
     },
     "ExecutionConstraints": {

--- a/examples/external_decisions/provider.py
+++ b/examples/external_decisions/provider.py
@@ -2,6 +2,12 @@
 
 Run with your provider environment's Python. No ThetaGang imports are needed.
 This is a neutral sizing / harvest-veto example, not a trading recommendation.
+
+The host publishes the resolved absolute-trend policy (mode, exit_depth,
+min_dwell_sessions) in every request. A provider whose sizing assumes a
+particular rule must pass that rule as the only command argument; a host
+deployment that does not match it exactly is rejected instead of silently
+diverging from the model's assumptions.
 """
 
 from __future__ import annotations
@@ -9,6 +15,99 @@ from __future__ import annotations
 import json
 import sys
 from typing import Any
+
+POLICY_FIELDS = ("mode", "exit_depth", "min_dwell_sessions")
+POLICY_MODES = ("cliff", "deadband")
+
+
+def expected_policy() -> dict[str, Any] | None:
+    if len(sys.argv) < 2:
+        return None
+    policy = json.loads(sys.argv[1])
+    if not isinstance(policy, dict) or set(policy) != set(POLICY_FIELDS):
+        raise ValueError(f"expected absolute-trend policy must use {POLICY_FIELDS}")
+    return policy
+
+
+def published_policy(symbol: str, trend: dict[str, Any]) -> dict[str, Any]:
+    """Return the resolved policy in whichever shape the request publishes it.
+
+    Target-weight requests publish the nested `absolute_trend.policy` object.
+    Harvest modifier diagnostics describe the same rule with flat keys.
+    """
+
+    nested = trend.get("policy")
+    if nested is not None:
+        if not isinstance(nested, dict) or set(nested) != set(POLICY_FIELDS):
+            raise ValueError(f"{symbol}: absolute trend policy fields are missing")
+        return nested
+    policy = {field: trend.get(field) for field in POLICY_FIELDS}
+    missing = sorted(field for field, value in policy.items() if value is None)
+    if missing:
+        raise ValueError(
+            f"{symbol}: absolute trend policy is missing {', '.join(missing)}"
+        )
+    return policy
+
+
+def validate_policy(symbol: str, policy: Any, expected: dict[str, Any] | None) -> None:
+    """Fail loudly unless the host resolved exactly the rule the provider models."""
+
+    if not isinstance(policy, dict) or set(policy) != set(POLICY_FIELDS):
+        raise ValueError(f"{symbol}: absolute trend policy fields are missing")
+    if not isinstance(policy["exit_depth"], (int, float)) or isinstance(
+        policy["exit_depth"], bool
+    ):
+        raise TypeError(f"{symbol}: exit_depth must be a number")
+    if not isinstance(policy["min_dwell_sessions"], int) or isinstance(
+        policy["min_dwell_sessions"], bool
+    ):
+        raise TypeError(f"{symbol}: min_dwell_sessions must be an integer")
+    if policy["mode"] not in POLICY_MODES:
+        raise ValueError(f"{symbol}: unknown absolute trend mode: {policy['mode']}")
+    # Mirror the host's validation exactly: a cliff carries no hysteresis, and a
+    # deadband must carry enough of it to differ from a cliff.
+    hysteresis = policy["exit_depth"] > 0 or policy["min_dwell_sessions"] >= 2
+    if policy["mode"] == "cliff" and (
+        policy["exit_depth"] > 0 or policy["min_dwell_sessions"] > 0
+    ):
+        raise ValueError(
+            f"{symbol}: cliff absolute trend policy must not set hysteresis"
+        )
+    if policy["mode"] == "deadband" and not hysteresis:
+        raise ValueError(
+            f"{symbol}: deadband absolute trend policy requires hysteresis"
+        )
+    if expected is not None and policy != expected:
+        raise ValueError(
+            f"{symbol}: host absolute trend policy {policy} does not match the "
+            f"provider's expected policy {expected}"
+        )
+
+
+def validate_request_policies(
+    request: dict[str, Any], expected: dict[str, Any] | None
+) -> None:
+    context = request["input"]
+    if request["decision_type"] == "regime_target_weights":
+        candidates = {
+            symbol: symbol_input.get("absolute_trend")
+            for symbol, symbol_input in context["symbols"].items()
+        }
+        active = [
+            (symbol, trend)
+            for symbol, trend in candidates.items()
+            if trend is not None and trend.get("enabled", False)
+        ]
+    else:
+        # Harvest modifier diagnostics are only published for active modifiers.
+        active = [
+            (symbol, underlying["target_modifiers"]["absolute_trend"])
+            for symbol, underlying in context["underlyings"].items()
+            if underlying.get("target_modifiers", {}).get("absolute_trend") is not None
+        ]
+    for symbol, trend in active:
+        validate_policy(symbol, published_policy(symbol, trend), expected)
 
 
 def decide(request: dict[str, Any]) -> dict[str, Any]:
@@ -29,6 +128,11 @@ def main() -> None:
     request = json.load(sys.stdin)
     if type(request["schema_version"]) is not int or request["schema_version"] != 1:
         raise ValueError("Unsupported schema_version")
+    try:
+        validate_request_policies(request, expected_policy())
+    except (TypeError, ValueError) as exc:
+        print(f"absolute trend policy rejected: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
     response = {
         "schema_version": 1,
         "request_id": request["request_id"],

--- a/examples/external_decisions/regime_target_weights.request.json
+++ b/examples/external_decisions/regime_target_weights.request.json
@@ -71,7 +71,11 @@
           "enabled": true,
           "lookback_days": 168,
           "risk_off_multiplier": 0.15,
-          "risk_off_ramp_width": 0.0
+          "policy": {
+            "mode": "deadband",
+            "exit_depth": 0.02,
+            "min_dwell_sessions": 3
+          }
         },
         "execution_constraints": {
           "trading_allowed": true,

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -579,7 +579,11 @@ def test_symbol_accepts_absolute_trend_config() -> None:
         "enabled": True,
         "lookback_days": 168,
         "risk_off_multiplier": 0.15,
-        "risk_off_ramp_width": 0.20,
+        "policy": {
+            "mode": "deadband",
+            "exit_depth": 0.02,
+            "min_dwell_sessions": 3,
+        },
     }
 
     config = Config(**data)
@@ -589,10 +593,12 @@ def test_symbol_accepts_absolute_trend_config() -> None:
     assert absolute_trend.enabled is True
     assert absolute_trend.lookback_days == 168
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.15)
-    assert absolute_trend.risk_off_ramp_width == pytest.approx(0.20)
+    assert absolute_trend.policy.mode == "deadband"
+    assert absolute_trend.policy.exit_depth == pytest.approx(0.02)
+    assert absolute_trend.policy.min_dwell_sessions == 3
 
 
-def test_symbol_absolute_trend_defaults_disabled() -> None:
+def test_symbol_absolute_trend_defaults_to_disabled_cliff() -> None:
     data = _base_config({"strategies": ["wheel"]})
     data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {}
 
@@ -603,16 +609,76 @@ def test_symbol_absolute_trend_defaults_disabled() -> None:
     assert absolute_trend.enabled is False
     assert absolute_trend.lookback_days == 168
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.15)
-    assert absolute_trend.risk_off_ramp_width == pytest.approx(0.0)
+    assert absolute_trend.policy.mode == "cliff"
+    assert absolute_trend.policy.exit_depth == pytest.approx(0.0)
+    assert absolute_trend.policy.min_dwell_sessions == 0
 
 
 @pytest.mark.parametrize("width", [-0.1, 1.1, float("nan"), float("inf")])
-def test_symbol_absolute_trend_rejects_invalid_ramp_width(width: float) -> None:
+def test_symbol_absolute_trend_rejects_invalid_exit_depth(width: float) -> None:
     data = _base_config({"strategies": ["wheel"]})
     data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {
-        "risk_off_ramp_width": width,
+        "policy": {"mode": "deadband", "exit_depth": width},
+    }
+    with pytest.raises(ValueError, match="exit_depth"):
+        Config(**data)
+
+
+def test_symbol_absolute_trend_rejects_deleted_ramp_width() -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {
+        "risk_off_ramp_width": 0.10,
     }
     with pytest.raises(ValueError, match="risk_off_ramp_width"):
+        Config(**data)
+
+
+@pytest.mark.parametrize(
+    ("mode", "exit_depth", "min_dwell_sessions"),
+    [
+        ("deadband", 0.05, 0),
+        ("deadband", 0.0, 2),
+        ("deadband", 0.05, 3),
+        ("cliff", 0.0, 0),
+    ],
+)
+def test_symbol_absolute_trend_accepts_hysteresis_arms(
+    mode: str, exit_depth: float, min_dwell_sessions: int
+) -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {
+        "policy": {
+            "mode": mode,
+            "exit_depth": exit_depth,
+            "min_dwell_sessions": min_dwell_sessions,
+        },
+    }
+
+    config = Config(**data)
+
+    absolute_trend = config.portfolio.symbols["AAA"].absolute_trend
+    assert absolute_trend is not None
+    policy = absolute_trend.policy
+    assert policy.mode == mode
+    assert policy.exit_depth == pytest.approx(exit_depth)
+    assert policy.min_dwell_sessions == min_dwell_sessions
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {"mode": "cliff", "exit_depth": 0.02},
+        {"mode": "cliff", "min_dwell_sessions": 3},
+        {"mode": "deadband"},
+        {"mode": "deadband", "min_dwell_sessions": 1},
+    ],
+)
+def test_symbol_absolute_trend_rejects_inactive_hysteresis(
+    policy: dict[str, Any],
+) -> None:
+    data = _base_config({"strategies": ["wheel"]})
+    data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {"policy": policy}
+    with pytest.raises(ValueError, match="policy"):
         Config(**data)
 
 
@@ -620,7 +686,6 @@ def test_symbol_absolute_trend_allows_zero_risk_off_multiplier() -> None:
     data = _base_config({"strategies": ["wheel"]})
     data["portfolio"]["symbols"]["AAA"]["absolute_trend"] = {
         "risk_off_multiplier": 0.0,
-        "risk_off_ramp_width": 0.0,
     }
 
     config = Config(**data)
@@ -628,7 +693,7 @@ def test_symbol_absolute_trend_allows_zero_risk_off_multiplier() -> None:
     absolute_trend = config.portfolio.symbols["AAA"].absolute_trend
     assert absolute_trend is not None
     assert absolute_trend.risk_off_multiplier == pytest.approx(0.0)
-    assert absolute_trend.risk_off_ramp_width == pytest.approx(0.0)
+    assert absolute_trend.policy.mode == "cliff"
 
 
 def _enable_target_weight_policy(data: dict[str, Any]) -> None:

--- a/tests/test_decision_check.py
+++ b/tests/test_decision_check.py
@@ -84,6 +84,112 @@ def test_reference_provider_runs_with_only_standard_library(decision: str) -> No
         assert report["post_policy_weights"] == {"TQQQ": 0.4, "QQQ": 0.5}
 
 
+@pytest.mark.parametrize(
+    ("policy", "expected_exit"),
+    [
+        ('{"mode": "deadband", "exit_depth": 0.02, "min_dwell_sessions": 3}', 0),
+        ('{"mode": "cliff", "exit_depth": 0.0, "min_dwell_sessions": 0}', 1),
+    ],
+)
+def test_reference_provider_validates_published_policy(
+    policy: str, expected_exit: int
+) -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "check",
+            "--request",
+            str(EXAMPLES / "regime_target_weights.request.json"),
+            "--",
+            sys.executable,
+            "-I",
+            "-S",
+            str(EXAMPLES / "provider.py"),
+            policy,
+        ],
+    )
+
+    assert result.exit_code == expected_exit, result.output
+    if expected_exit != 0:
+        assert "does not match the provider's expected policy" in result.output
+
+
+def _flat_absolute_trend_diagnostics() -> dict[str, Any]:
+    """The exact flat shape the host publishes in harvest modifier diagnostics."""
+
+    from thetagang.strategies.regime_engine import (
+        _AbsoluteTrendPolicy,
+        _AbsoluteTrendSignal,
+        _AbsoluteTrendState,
+    )
+
+    signal = _AbsoluteTrendSignal(
+        lookback_days=3,
+        latest_session="2026-09-02",
+        latest_close=99.0,
+        moving_average=100.0,
+        momentum_reference_close=101.0,
+        lookback_return=99.0 / 101.0 - 1.0,
+    )
+    return signal.target_details(
+        state=_AbsoluteTrendState(
+            latest_session="2026-09-02",
+            state="risk_off",
+            previous_state="risk_on",
+            sessions_in_state=1,
+            state_transition=True,
+            within_band_drift=False,
+        ),
+        policy=_AbsoluteTrendPolicy("cliff", 0.0, 0),
+        pre_trend_target=0.4,
+        risk_off_multiplier=0.15,
+        history_source="fresh",
+    )
+
+
+@pytest.mark.parametrize(
+    ("expected_policy", "expected_exit"),
+    [
+        (None, 0),
+        ('{"mode": "cliff", "exit_depth": 0.0, "min_dwell_sessions": 0}', 0),
+        ('{"mode": "deadband", "exit_depth": 0.02, "min_dwell_sessions": 3}', 1),
+    ],
+)
+def test_reference_provider_reads_flat_harvest_policy(
+    tmp_path: Path, expected_policy: str | None, expected_exit: int
+) -> None:
+    request = json.loads((EXAMPLES / "tail_hedge_harvest.request.json").read_text())
+    symbol = next(iter(request["input"]["underlyings"]))
+    diagnostics = _flat_absolute_trend_diagnostics()
+    request["input"]["underlyings"][symbol]["target_modifiers"]["absolute_trend"] = (
+        diagnostics
+    )
+    request_path = tmp_path / "tail_hedge_harvest.request.json"
+    request_path.write_text(json.dumps(request))
+    # Harvest diagnostics carry the resolved rule flat, unlike the nested
+    # `policy` object published for target-weight symbols.
+    assert "policy" not in diagnostics
+    assert diagnostics["mode"] == "cliff"
+
+    command = [
+        "check",
+        "--request",
+        str(request_path),
+        "--",
+        sys.executable,
+        "-I",
+        "-S",
+        str(EXAMPLES / "provider.py"),
+    ]
+    if expected_policy is not None:
+        command.append(expected_policy)
+    result = CliRunner().invoke(cli, command)
+
+    assert result.exit_code == expected_exit, result.output
+    if expected_exit != 0:
+        assert "does not match the provider's expected policy" in result.output
+
+
 def replay(
     tmp_path: Path,
     *,

--- a/tests/test_external_decisions.py
+++ b/tests/test_external_decisions.py
@@ -10,6 +10,7 @@ from thetagang.external_decisions import (
     ExternalDecisionError,
     ExternalDecisionMarketData,
     ExternalDecisionProviders,
+    ExternalDecisionRejection,
     ExternalDecisionRequest,
 )
 
@@ -117,8 +118,35 @@ async def test_command_provider_rejects_non_json_output() -> None:
         }
     )
 
-    with pytest.raises(ExternalDecisionError, match="invalid JSON"):
+    # A provider that answered with garbage is a rejection, not an outage.
+    with pytest.raises(ExternalDecisionRejection, match="invalid JSON"):
         await providers.decide("fixture", _request())
+
+
+@pytest.mark.asyncio
+async def test_command_provider_nonzero_exit_is_a_rejection() -> None:
+    providers = ExternalDecisionProviders(
+        {
+            "fixture": ExternalDecisionProviderConfig(
+                command=[
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stderr.write('policy mismatch'); sys.exit(3)",
+                ]
+            )
+        }
+    )
+
+    with pytest.raises(ExternalDecisionRejection, match="status 3: policy mismatch"):
+        await providers.decide("fixture", _request())
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_provider_is_a_rejection() -> None:
+    providers = ExternalDecisionProviders({})
+
+    with pytest.raises(ExternalDecisionRejection, match="not configured"):
+        await providers.decide("missing", _request())
 
 
 @pytest.mark.asyncio
@@ -232,5 +260,5 @@ json.dump({
         }
     )
 
-    with pytest.raises(ExternalDecisionError, match="request_id mismatch"):
+    with pytest.raises(ExternalDecisionRejection, match="request_id mismatch"):
         await providers.decide("fixture", _request())

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -13,6 +13,8 @@ from thetagang.accounting import BrokerAccountSnapshot
 from thetagang.config import Config
 from thetagang.db import DataStore, ExecutionRecord
 from thetagang.external_decisions import (
+    ExternalDecisionError,
+    ExternalDecisionRejection,
     ExternalDecisionRequest,
     ExternalDecisionResponse,
 )
@@ -91,6 +93,13 @@ class _FixedTargetWeightProvider:
                 }
             },
         )
+
+
+class _UnavailableProvider:
+    async def decide(
+        self, request: ExternalDecisionRequest
+    ) -> ExternalDecisionResponse:
+        raise ExternalDecisionError("external decision provider could not be started")
 
 
 class _FixedTailHarvestProvider:
@@ -564,14 +573,20 @@ def _absolute_trend(
     *,
     lookback_days: int = 168,
     risk_off_multiplier: float = 0.15,
-    risk_off_ramp_width: float = 0.10,
+    mode: str = "cliff",
+    exit_depth: float = 0.0,
+    min_dwell_sessions: int = 0,
     enabled: bool = True,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         enabled=enabled,
         lookback_days=lookback_days,
         risk_off_multiplier=risk_off_multiplier,
-        risk_off_ramp_width=risk_off_ramp_width,
+        policy=SimpleNamespace(
+            mode=mode,
+            exit_depth=exit_depth,
+            min_dwell_sessions=min_dwell_sessions,
+        ),
     )
 
 
@@ -591,15 +606,27 @@ def _absolute_trend_history_cache(
     )
 
 
-def _absolute_trend_signal_payload(*, risk_off: bool = True) -> dict[str, object]:
+def _absolute_trend_signal_payload(
+    *,
+    lookback_days: int = 168,
+    risk_off: bool = True,
+    sessions_in_state: int = 1,
+    state_transition: bool = False,
+    within_band_drift: bool = False,
+) -> dict[str, object]:
     return {
-        "lookback_days": 168,
+        "lookback_days": lookback_days,
         "latest_session": "2026-08-21",
         "latest_close": 90.0,
         "moving_average": 100.0,
         "momentum_reference_close": 105.0,
         "lookback_return": 90.0 / 105.0 - 1.0,
         "risk_off": risk_off,
+        "state": "risk_off" if risk_off else "risk_on",
+        "previous_state": None,
+        "sessions_in_state": sessions_in_state,
+        "state_transition": state_transition,
+        "within_band_drift": within_band_drift,
     }
 
 
@@ -1085,9 +1112,16 @@ async def test_model_target_bounds_preserve_smoothing_capital_base_and_trend(
     )
 
     request = provider.requests[0].input
-    assert request["symbols"]["AAA"]["absolute_trend"][
-        "risk_off_ramp_width"
-    ] == pytest.approx(0.10)
+    assert request["symbols"]["AAA"]["absolute_trend"] == {
+        "enabled": True,
+        "lookback_days": 3,
+        "risk_off_multiplier": 0.25,
+        "policy": {
+            "mode": "cliff",
+            "exit_depth": 0.0,
+            "min_dwell_sessions": 0,
+        },
+    }
     assert request["account"]["rebalance_base_value"] == pytest.approx(2250.0)
     assert request["adjustment_constraints"]["AAA"] == {
         "min_multiplier": 0.5,
@@ -1106,7 +1140,7 @@ async def test_model_target_bounds_preserve_smoothing_capital_base_and_trend(
     assert policy["symbols"]["AAA"]["effective_weight"] == pytest.approx(0.20)
     trend = manager.data_store.get_last_event_payload("absolute_trend_state")
     assert trend["symbols"]["AAA"]["pre_trend_target"] == pytest.approx(0.20)
-    assert trend["symbols"]["AAA"]["final_target"] == pytest.approx(0.125)
+    assert trend["symbols"]["AAA"]["final_target"] == pytest.approx(0.05)
     assert symbol_config.volatility_weight.min_weight == 0.25
     assert symbol_config.volatility_weight.smoothing_factor == 0.5
 
@@ -1191,12 +1225,10 @@ def test_external_target_weight_policy_converts_naive_local_time_to_utc(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("on_error", ["baseline", "abort"])
-@pytest.mark.parametrize("initially_accepted", [False, True])
-async def test_rejected_target_weights_stay_rejected_until_next_run(
+async def test_rejected_target_weight_decision_aborts_even_on_baseline(
     portfolio_manager: Any,
     mocker: Any,
     on_error: str,
-    initially_accepted: bool,
 ) -> None:
     engine = portfolio_manager.regime_engine
     policy = _target_weight_policy()
@@ -1211,32 +1243,71 @@ async def test_rejected_target_weights_stay_rejected_until_next_run(
         )
     )
     context = _target_weight_policy_context(portfolio_manager)
-    baseline = {"AAA": 0.4, "BBB": 0.5}
-    if initially_accepted:
-        weights, _ = await engine._apply_target_weight_policy(baseline, **context)
-        assert weights["AAA"] == pytest.approx(0.44)
 
-    # Reject the cached multiplier when its targets exceed the exposure ceiling.
-    # A later post-fill replan must retain that failure even if the new baseline
-    # would make the same multiplier affordable again.
-    for current_baseline in ({"AAA": 0.5, "BBB": 0.5}, baseline):
-        if on_error == "abort":
-            with pytest.raises(RuntimeError, match="permitted total weight"):
-                await engine._apply_target_weight_policy(current_baseline, **context)
-        else:
-            weights, details = await engine._apply_target_weight_policy(
-                current_baseline, **context
-            )
-            assert weights == current_baseline
-            assert details["AAA"]["status"] == "baseline"
-            assert details["AAA"]["risk_ready"] is False
-    assert len(provider.requests) == 1
-
-    engine.begin_run()
-    weights, details = await engine._apply_target_weight_policy(baseline, **context)
+    weights, details = await engine._apply_target_weight_policy(
+        {"AAA": 0.4, "BBB": 0.5}, **context
+    )
     assert weights["AAA"] == pytest.approx(0.44)
-    assert details["AAA"]["risk_ready"] is True
+    assert details["AAA"]["status"] == "applied"
+
+    # The cached decision is refused once its targets break the exposure
+    # ceiling. Baseline sizing would trade on a decision the host rejected, so
+    # the run aborts whatever `on_error` says.
+    with pytest.raises(ExternalDecisionRejection, match="permitted total weight"):
+        await engine._apply_target_weight_policy({"AAA": 0.5, "BBB": 0.5}, **context)
+    assert len(provider.requests) == 1
+    outcome = engine._target_weight_policy_outcome
+    assert outcome is not None and outcome.rejected is True
+
+    # The rejection must not stick across runs: the next run asks the provider
+    # again instead of permanently sizing on baseline targets.
+    engine.begin_run()
+    weights, details = await engine._apply_target_weight_policy(
+        {"AAA": 0.4, "BBB": 0.5}, **context
+    )
+    assert weights["AAA"] == pytest.approx(0.44)
+    assert details["AAA"]["status"] == "applied"
     assert len(provider.requests) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("on_error", "expected"),
+    [("baseline", "baseline"), ("abort", "abort")],
+)
+async def test_unavailable_target_weight_provider_degrades_per_on_error(
+    portfolio_manager: Any,
+    mocker: Any,
+    on_error: str,
+    expected: str,
+) -> None:
+    engine = portfolio_manager.regime_engine
+    policy = _target_weight_policy()
+    policy.on_error = on_error
+    portfolio_manager.config.strategies.regime_rebalance.target_weight_policy = policy
+    portfolio_manager.external_decisions.replace("fixture", _UnavailableProvider())
+    engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            _required_regime_history_dates(4),
+            {"AAA": [100.0] * 4, "BBB": [100.0] * 4},
+        )
+    )
+    baseline = {"AAA": 0.4, "BBB": 0.5}
+
+    if expected == "abort":
+        with pytest.raises(RuntimeError, match="External target weight policy failed"):
+            await engine._apply_target_weight_policy(
+                baseline, **_target_weight_policy_context(portfolio_manager)
+            )
+        return
+
+    weights, details = await engine._apply_target_weight_policy(
+        baseline, **_target_weight_policy_context(portfolio_manager)
+    )
+    assert weights == baseline
+    assert details["AAA"]["status"] == "baseline"
+    assert details["AAA"]["risk_ready"] is False
+    assert "could not be started" in details["AAA"]["error"]
 
 
 @pytest.mark.asyncio
@@ -1425,16 +1496,15 @@ async def test_external_target_weight_policy_clamps_to_volatility_bounds(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("clamp", [True, False])
 async def test_external_target_weight_policy_caps_before_checking_final_weight(
-    portfolio_manager: Any, mocker: Any, clamp: bool
+    portfolio_manager: Any, mocker: Any
 ) -> None:
     manager = portfolio_manager
     manager.config.portfolio.symbols["AAA"].volatility_weight = _volatility_weight(
         max_weight=1.0
     )
     manager.config.strategies.regime_rebalance.target_weight_policy = (
-        _target_weight_policy(clamp_to_volatility_bounds=clamp)
+        _target_weight_policy(clamp_to_volatility_bounds=True)
     )
     manager.external_decisions.replace("fixture", _FixedTargetWeightProvider(1.1))
     manager.regime_engine._get_regime_aligned_closes = mocker.AsyncMock(
@@ -1450,18 +1520,39 @@ async def test_external_target_weight_policy_caps_before_checking_final_weight(
         **_target_weight_policy_context(manager),
     )
 
-    if clamp:
-        assert weights == {"AAA": 1.0, "BBB": 0.0}
-        assert details["AAA"]["raw_weight"] == pytest.approx(1.045)
-        assert details["AAA"]["status"] == "applied"
-    else:
-        assert weights == baseline
-        assert details["AAA"]["status"] == "baseline"
-        assert "invalid weight" in details["AAA"]["error"]
+    assert weights == {"AAA": 1.0, "BBB": 0.0}
+    assert details["AAA"]["raw_weight"] == pytest.approx(1.045)
+    assert details["AAA"]["status"] == "applied"
 
 
 @pytest.mark.asyncio
-async def test_external_target_weight_policy_falls_back_on_invalid_signal(
+async def test_external_target_weight_policy_rejects_uncapped_overweight(
+    portfolio_manager: Any, mocker: Any
+) -> None:
+    manager = portfolio_manager
+    manager.config.portfolio.symbols["AAA"].volatility_weight = _volatility_weight(
+        max_weight=1.0
+    )
+    manager.config.strategies.regime_rebalance.target_weight_policy = (
+        _target_weight_policy(clamp_to_volatility_bounds=False)
+    )
+    manager.external_decisions.replace("fixture", _FixedTargetWeightProvider(1.1))
+    manager.regime_engine._get_regime_aligned_closes = mocker.AsyncMock(
+        return_value=(
+            _required_regime_history_dates(4),
+            {"AAA": [100.0] * 4, "BBB": [100.0] * 4},
+        )
+    )
+
+    with pytest.raises(ExternalDecisionRejection, match="invalid weight"):
+        await manager.regime_engine._apply_target_weight_policy(
+            {"AAA": 0.95, "BBB": 0.0},
+            **_target_weight_policy_context(manager),
+        )
+
+
+@pytest.mark.asyncio
+async def test_external_target_weight_policy_rejects_out_of_bounds_signal(
     portfolio_manager, mocker
 ):
     regime_rebalance = portfolio_manager.config.strategies.regime_rebalance
@@ -1480,19 +1571,13 @@ async def test_external_target_weight_policy_falls_back_on_invalid_signal(
     )
     baseline = {"AAA": 0.36, "BBB": 0.45}
 
-    (
-        adjusted,
-        details,
-    ) = await portfolio_manager.regime_engine._apply_target_weight_policy(
-        baseline,
-        **_target_weight_policy_context(portfolio_manager),
-    )
-
-    assert adjusted == baseline
-    assert details["AAA"]["status"] == "baseline"
-    assert details["AAA"]["multiplier"] == 1.0
-    assert details["AAA"]["risk_ready"] is False
-    assert "outside configured bounds" in details["AAA"]["error"]
+    # A malformed sizing signal is a provider rejection, not an outage: the
+    # hook must not quietly fall back to baseline targets.
+    with pytest.raises(ExternalDecisionRejection, match="outside configured bounds"):
+        await portfolio_manager.regime_engine._apply_target_weight_policy(
+            baseline,
+            **_target_weight_policy_context(portfolio_manager),
+        )
 
 
 @pytest.mark.asyncio
@@ -2148,48 +2233,247 @@ async def test_absolute_trend_risk_boundaries(
         history_cache,
     )
 
-    expected_multiplier = 0.915 if expected_risk_off else 1.0
+    expected_multiplier = 0.15 if expected_risk_off else 1.0
     assert details["AAA"]["risk_off"] is expected_risk_off
     assert details["AAA"]["applied_multiplier"] == pytest.approx(expected_multiplier)
     assert weights["AAA"] == pytest.approx(0.4 * expected_multiplier)
 
 
 @pytest.mark.parametrize(
-    "closes, width, floor, expected",
+    (
+        "closes",
+        "policy",
+        "previous_risk_off",
+        "previous_sessions",
+        "expected_state",
+        "expected_previous_state",
+        "expected_transition",
+        "expected_drift",
+        "expected_sessions",
+        "expected_multiplier",
+        "expected_shortfall",
+    ),
     [
-        ([100.0, 100.0, 100.0, 105.0], 0.10, 0.25, 1.0),
-        ([100.0, 100.0, 100.0, 100.0], 0.10, 0.25, 1.0),
-        ([100.0, 100.0, 100.0, 99.0], 0.10, 0.25, 0.925),
-        ([100.0, 100.0, 100.0, 95.0], 0.10, 0.25, 0.625),
-        ([110.0, 95.0, 95.0, 95.0], 0.10, 0.25, 0.625),
-        ([100.0, 115.0, 115.0, 95.0], 0.10, 0.25, 0.625),
-        ([100.0, 100.0, 100.0, 90.0], 0.10, 0.25, 0.25),
-        ([100.0, 100.0, 100.0, 80.0], 0.10, 0.25, 0.25),
-        ([100.0, 100.0, 100.0, 99.0], 0.0, 0.25, 0.25),
-        ([100.0, 100.0, 100.0, 95.0], 0.10, 0.0, 0.5),
-        ([100.0, 100.0, 100.0, 90.0], 0.10, 0.0, 0.0),
-        ([100.0, 100.0, 100.0, 95.0], 0.10, 1.0, 1.0),
+        pytest.param(
+            [100.0, 100.0, 100.0, 102.0],
+            {"mode": "deadband", "exit_depth": 0.05},
+            True,
+            2,
+            "risk_off",
+            "risk_off",
+            False,
+            True,
+            3,
+            0.25,
+            0.0,
+            id="holds-inside-exit-depth",
+        ),
+        pytest.param(
+            [100.0, 100.0, 100.0, 105.0],
+            {"mode": "deadband", "exit_depth": 0.05},
+            True,
+            2,
+            "risk_on",
+            "risk_off",
+            True,
+            False,
+            1,
+            1.0,
+            0.0,
+            id="exits-at-exit-depth",
+        ),
+        pytest.param(
+            [100.0, 100.0, 100.0, 99.0],
+            {"mode": "deadband", "exit_depth": 0.05},
+            True,
+            2,
+            "risk_off",
+            "risk_off",
+            False,
+            False,
+            3,
+            0.25,
+            0.01,
+            id="continues-below-entry-threshold",
+        ),
+        pytest.param(
+            [100.0, 100.0, 100.0, 110.0],
+            {"mode": "deadband", "exit_depth": 0.02, "min_dwell_sessions": 3},
+            True,
+            2,
+            "risk_off",
+            "risk_off",
+            False,
+            True,
+            3,
+            0.25,
+            0.0,
+            id="minimum-dwell-blocks-exit",
+        ),
+        pytest.param(
+            [100.0, 100.0, 100.0, 110.0],
+            {"mode": "deadband", "exit_depth": 0.02, "min_dwell_sessions": 3},
+            True,
+            3,
+            "risk_on",
+            "risk_off",
+            True,
+            False,
+            1,
+            1.0,
+            0.0,
+            id="minimum-dwell-satisfied",
+        ),
+        pytest.param(
+            [100.0, 100.0, 100.0, 110.0],
+            {"mode": "deadband", "min_dwell_sessions": 2},
+            True,
+            1,
+            "risk_off",
+            "risk_off",
+            False,
+            True,
+            2,
+            0.25,
+            0.0,
+            id="minimum-dwell-two-is-live",
+        ),
+        pytest.param(
+            [100.0, 100.0, 100.0, 110.0],
+            {"mode": "cliff"},
+            True,
+            2,
+            "risk_on",
+            "risk_off",
+            True,
+            False,
+            1,
+            1.0,
+            0.0,
+            id="cliff-ignores-exit-hysteresis",
+        ),
+        pytest.param(
+            [100.0, 100.0, 100.0, 90.0],
+            {"mode": "cliff"},
+            False,
+            4,
+            "risk_off",
+            "risk_on",
+            True,
+            False,
+            1,
+            0.25,
+            0.10,
+            id="enters-risk-off-from-risk-on",
+        ),
+        pytest.param(
+            [100.0, 100.0, 100.0, 110.0],
+            {"mode": "cliff"},
+            False,
+            4,
+            "risk_on",
+            "risk_on",
+            False,
+            False,
+            5,
+            1.0,
+            0.0,
+            id="holds-risk-on",
+        ),
     ],
 )
 @pytest.mark.asyncio
-async def test_absolute_trend_ramp(
-    portfolio_manager: Any,
+async def test_absolute_trend_policy_exit_hysteresis(
+    portfolio_manager_with_db: Any,
     mocker: Any,
     closes: list[float],
-    width: float,
-    floor: float,
-    expected: float,
+    policy: dict[str, Any],
+    previous_risk_off: bool,
+    previous_sessions: int,
+    expected_state: str,
+    expected_previous_state: str,
+    expected_transition: bool,
+    expected_drift: bool,
+    expected_sessions: int,
+    expected_multiplier: float,
+    expected_shortfall: float,
 ) -> None:
-    portfolio_manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
-        lookback_days=3, risk_off_multiplier=floor, risk_off_ramp_width=width
+    manager = portfolio_manager_with_db
+    manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        lookback_days=3, risk_off_multiplier=0.25, **policy
     )
-    weights, details = await portfolio_manager.regime_engine._apply_absolute_trend(
-        {"AAA": 0.4, "BBB": 0.5},
-        portfolio_manager.config.portfolio.symbols,
+    manager.data_store.record_event(
+        "absolute_trend_state",
+        {
+            "symbols": {
+                "AAA": _absolute_trend_signal_payload(
+                    lookback_days=3,
+                    risk_off=previous_risk_off,
+                    sessions_in_state=previous_sessions,
+                )
+            }
+        },
+    )
+
+    weights, details = await manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        manager.config.portfolio.symbols,
         _absolute_trend_history_cache(mocker, closes, lookback_days=3),
     )
-    assert details["AAA"]["applied_multiplier"] == pytest.approx(expected)
-    assert weights == pytest.approx({"AAA": 0.4 * expected, "BBB": 0.5})
+
+    trend = details["AAA"]
+    assert trend["state"] == expected_state
+    assert trend["previous_state"] == expected_previous_state
+    assert trend["state_transition"] is expected_transition
+    assert trend["within_band_drift"] is expected_drift
+    assert trend["sessions_in_state"] == expected_sessions
+    assert trend["shortfall"] == pytest.approx(expected_shortfall)
+    assert trend["applied_multiplier"] == pytest.approx(expected_multiplier)
+    assert weights["AAA"] == pytest.approx(0.4 * expected_multiplier)
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_same_session_replan_keeps_transition(
+    portfolio_manager_with_db: Any, mocker: Any
+) -> None:
+    manager = portfolio_manager_with_db
+    manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        lookback_days=3, mode="deadband", exit_depth=0.05
+    )
+    dates = _required_regime_history_dates(4)
+    manager.data_store.record_event(
+        "absolute_trend_state",
+        {
+            "symbols": {
+                "AAA": _absolute_trend_signal_payload(
+                    lookback_days=3,
+                    sessions_in_state=4,
+                    state_transition=True,
+                    within_band_drift=True,
+                )
+                | {"latest_session": str(dates[-1])}
+            }
+        },
+    )
+    history_cache = SimpleNamespace(
+        get=mocker.AsyncMock(
+            return_value=(dates, {"AAA": [100.0, 100.0, 100.0, 102.0]})
+        )
+    )
+
+    _, details = await manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        manager.config.portfolio.symbols,
+        history_cache,
+    )
+
+    # The same completed session must not advance its dwell counter or
+    # relabel its transition.
+    assert details["AAA"]["sessions_in_state"] == 4
+    assert details["AAA"]["state_transition"] is True
+    assert details["AAA"]["within_band_drift"] is True
+    assert details["AAA"]["state"] == "risk_off"
+    assert details["AAA"]["applied_multiplier"] == pytest.approx(0.15)
 
 
 @pytest.mark.parametrize(
@@ -2301,17 +2585,24 @@ async def test_regime_history_cache_keys_primary_exchange_overrides(mocker):
     )
 
 
-@pytest.mark.parametrize("width, expected_target", [(0.10, 0.06), (0.20, 0.23)])
 @pytest.mark.asyncio
 async def test_absolute_trend_reuses_persisted_state_when_history_fails(
-    portfolio_manager_with_db, mocker, width: float, expected_target: float
+    portfolio_manager_with_db, mocker
 ):
     portfolio_manager_with_db.config.portfolio.symbols[
         "AAA"
-    ].absolute_trend = _absolute_trend(risk_off_ramp_width=width)
+    ].absolute_trend = _absolute_trend()
     portfolio_manager_with_db.data_store.record_event(
         "absolute_trend_state",
-        {"symbols": {"AAA": _absolute_trend_signal_payload()}},
+        {
+            "symbols": {
+                "AAA": _absolute_trend_signal_payload(
+                    sessions_in_state=4,
+                    state_transition=True,
+                    within_band_drift=True,
+                )
+            }
+        },
     )
     history_cache = SimpleNamespace(
         get=mocker.AsyncMock(side_effect=TimeoutError("history unavailable"))
@@ -2326,9 +2617,16 @@ async def test_absolute_trend_reuses_persisted_state_when_history_fails(
         history_cache,
     )
 
-    assert weights["AAA"] == pytest.approx(expected_target)
-    assert details["AAA"]["risk_off"] is True
-    assert details["AAA"]["history_source"] == "persisted"
+    # Without fresh history the persisted session is republished verbatim:
+    # neither the dwell counter nor the transition label may advance.
+    assert weights["AAA"] == pytest.approx(0.06)
+    trend = details["AAA"]
+    assert trend["risk_off"] is True
+    assert trend["history_source"] == "persisted"
+    assert trend["sessions_in_state"] == 4
+    assert trend["state_transition"] is True
+    assert trend["within_band_drift"] is True
+    assert trend["history_failure"] == "TimeoutError"
 
 
 @pytest.mark.asyncio
@@ -2367,8 +2665,8 @@ async def test_absolute_trend_excludes_current_run_state_when_requested(
     [
         pytest.param(None, id="missing"),
         pytest.param(
-            _absolute_trend_signal_payload(risk_off=False),
-            id="inconsistent-risk-state",
+            {**_absolute_trend_signal_payload(), "state": "sideways"},
+            id="invalid-state",
         ),
     ],
 )
@@ -2478,6 +2776,14 @@ async def test_absolute_trend_preserves_volatility_state_and_forces_hard_band_se
     assert trend["moving_average"] == pytest.approx(100.0)
     assert trend["lookback_return"] == pytest.approx(-0.1)
     assert trend["state"] == "risk_off"
+    assert trend["previous_state"] is None
+    assert trend["sessions_in_state"] == 1
+    assert trend["state_transition"] is False
+    assert trend["within_band_drift"] is False
+    assert trend["shortfall"] == pytest.approx(0.10)
+    assert trend["mode"] == "cliff"
+    assert trend["exit_depth"] == pytest.approx(0.0)
+    assert trend["min_dwell_sessions"] == 0
     assert trend["pre_trend_target"] == pytest.approx(0.4)
     assert trend["final_target"] == pytest.approx(0.06)
     assert trend["applied_multiplier"] == pytest.approx(0.15)
@@ -4876,6 +5182,41 @@ def test_external_tail_harvest_abort_failure_policy(portfolio_manager) -> None:
             policy=SimpleNamespace(on_error="abort", provider="tail-fixture"),
             error="provider unavailable",
         )
+
+
+@pytest.mark.parametrize("on_error", ["baseline", "skip", "abort"])
+@pytest.mark.asyncio
+async def test_external_tail_harvest_rejection_is_always_fatal(
+    portfolio_manager_with_db, mocker, on_error: str
+) -> None:
+    # A provider that answered with an unusable decision must abort instead of
+    # preserving (`baseline`) or declining (`skip`) the harvest.
+    portfolio_manager = portfolio_manager_with_db
+    provider = _FixedTailHarvestProvider("not-a-bool")
+    payload, _sessions = _prepare_external_tail_harvest(
+        portfolio_manager,
+        mocker,
+        provider=provider,
+        con_id=799,
+        unrealized_pnl=70.0,
+    )
+    portfolio_manager.config.strategies.tail_hedge.harvest_decision.on_error = on_error
+    _set_tail_quotes(portfolio_manager, mocker, {799: 1.20})
+
+    with pytest.raises(
+        ExternalDecisionRejection, match="rejected the provider decision"
+    ):
+        await portfolio_manager.regime_engine._apply_tail_harvest(
+            orders=[("BBB", "NYSE", 7)],
+            net_liquidation=2_000.0,
+            market_prices={"BBB": 85.0},
+            regime_summary=_tail_harvest_regime_summary(),
+            hard_underweight_symbols={"BBB"},
+            cohorts=payload.open_cohorts,
+        )
+
+    assert portfolio_manager.orders.records() == []
+    assert len(provider.requests) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_regime_rebalance.py
+++ b/tests/test_regime_rebalance.py
@@ -590,6 +590,37 @@ def _absolute_trend(
     )
 
 
+def _record_absolute_trend_state(
+    manager: Any,
+    symbols: dict[str, object],
+    *,
+    state_version: int | None = 1,
+) -> None:
+    payload: dict[str, object] = {"symbols": symbols}
+    if state_version is not None:
+        payload["state_version"] = state_version
+    manager.data_store.record_event("absolute_trend_state", payload)
+
+
+def _legacy_absolute_trend_payload(
+    *,
+    lookback_days: int = 3,
+    risk_off: bool = True,
+    latest_session: str = "2026-08-21",
+) -> dict[str, object]:
+    """The pre-version record shape: signal fields plus a risk state."""
+
+    return {
+        "lookback_days": lookback_days,
+        "latest_session": latest_session,
+        "latest_close": 90.0,
+        "moving_average": 100.0,
+        "momentum_reference_close": 105.0,
+        "lookback_return": 90.0 / 105.0 - 1.0,
+        "risk_off": risk_off,
+    }
+
+
 def _absolute_trend_history_cache(
     mocker,
     closes: list[float],
@@ -2402,16 +2433,14 @@ async def test_absolute_trend_policy_exit_hysteresis(
     manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
         lookback_days=3, risk_off_multiplier=0.25, **policy
     )
-    manager.data_store.record_event(
-        "absolute_trend_state",
+    _record_absolute_trend_state(
+        manager,
         {
-            "symbols": {
-                "AAA": _absolute_trend_signal_payload(
-                    lookback_days=3,
-                    risk_off=previous_risk_off,
-                    sessions_in_state=previous_sessions,
-                )
-            }
+            "AAA": _absolute_trend_signal_payload(
+                lookback_days=3,
+                risk_off=previous_risk_off,
+                sessions_in_state=previous_sessions,
+            )
         },
     )
 
@@ -2422,6 +2451,7 @@ async def test_absolute_trend_policy_exit_hysteresis(
     )
 
     trend = details["AAA"]
+    assert trend["state_reset_reason"] is None
     assert trend["state"] == expected_state
     assert trend["previous_state"] == expected_previous_state
     assert trend["state_transition"] is expected_transition
@@ -2433,6 +2463,196 @@ async def test_absolute_trend_policy_exit_hysteresis(
 
 
 @pytest.mark.asyncio
+async def test_absolute_trend_legacy_state_keeps_hysteresis_held_risk_off(
+    portfolio_manager_with_db: Any, mocker: Any
+) -> None:
+    """A record from an older payload version must not release held risk-off.
+
+    The close sits above the entry threshold but inside the exit band, so only
+    the persisted state can keep the symbol risk-off. Re-deriving from the
+    entry rule here would re-risk the symbol, which is exactly what the
+    deadband exists to prevent.
+    """
+
+    manager = portfolio_manager_with_db
+    manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        lookback_days=3, risk_off_multiplier=0.25, mode="deadband", exit_depth=0.05
+    )
+    _record_absolute_trend_state(
+        manager,
+        {"AAA": _legacy_absolute_trend_payload(lookback_days=3, risk_off=True)},
+        state_version=None,
+    )
+    history_cache = _absolute_trend_history_cache(
+        mocker, [100.0, 100.0, 100.0, 102.0], lookback_days=3
+    )
+
+    weights, details = await manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        manager.config.portfolio.symbols,
+        history_cache,
+    )
+
+    trend = details["AAA"]
+    assert trend["state"] == "risk_off"
+    assert trend["state_reset_reason"] == "legacy_payload"
+    assert trend["sessions_in_state"] == 2
+    assert trend["within_band_drift"] is True
+    assert trend["applied_multiplier"] == pytest.approx(0.25)
+    assert weights["AAA"] == pytest.approx(0.1)
+
+    # Replanning the same session republishes the record, so the reset reason
+    # stays visible to an A/B that counts drift sessions.
+    _weights, replan = await manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        manager.config.portfolio.symbols,
+        _absolute_trend_history_cache(
+            mocker, [100.0, 100.0, 100.0, 102.0], lookback_days=3
+        ),
+    )
+    assert replan["AAA"]["state_reset_reason"] == "legacy_payload"
+    assert replan["AAA"]["state"] == "risk_off"
+    assert replan["AAA"]["sessions_in_state"] == 2
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_legacy_state_still_enters_risk_off(
+    portfolio_manager_with_db: Any, mocker: Any
+) -> None:
+    manager = portfolio_manager_with_db
+    manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        lookback_days=3, risk_off_multiplier=0.25
+    )
+    _record_absolute_trend_state(
+        manager,
+        {"AAA": _legacy_absolute_trend_payload(lookback_days=3, risk_off=False)},
+        state_version=None,
+    )
+
+    _, details = await manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        manager.config.portfolio.symbols,
+        _absolute_trend_history_cache(
+            mocker, [100.0, 100.0, 100.0, 90.0], lookback_days=3
+        ),
+    )
+
+    trend = details["AAA"]
+    assert trend["state"] == "risk_off"
+    assert trend["previous_state"] == "risk_on"
+    assert trend["state_transition"] is True
+    assert trend["state_reset_reason"] == "legacy_payload"
+    assert trend["applied_multiplier"] == pytest.approx(0.25)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            {**_absolute_trend_signal_payload(lookback_days=3), "state": "sideways"},
+            id="corrupt-versioned-state",
+        ),
+        pytest.param(
+            {
+                key: value
+                for key, value in _legacy_absolute_trend_payload(
+                    lookback_days=3
+                ).items()
+                if key != "risk_off"
+            },
+            id="legacy-without-risk-state",
+        ),
+    ],
+)
+async def test_absolute_trend_unusable_state_fails_closed_in_deadband(
+    portfolio_manager_with_db: Any, mocker: Any, payload: dict[str, object]
+) -> None:
+    manager = portfolio_manager_with_db
+    manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        lookback_days=3, mode="deadband", exit_depth=0.05
+    )
+    _record_absolute_trend_state(
+        manager,
+        {"AAA": payload},
+        state_version=None if "state" not in payload else 1,
+    )
+
+    with pytest.raises(RuntimeError, match="cannot resolve a deadband state"):
+        await manager.regime_engine._apply_absolute_trend(
+            {"AAA": 0.4},
+            manager.config.portfolio.symbols,
+            _absolute_trend_history_cache(
+                mocker, [100.0, 100.0, 100.0, 102.0], lookback_days=3
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_unusable_state_resets_cliff_with_reason(
+    portfolio_manager_with_db: Any, mocker: Any
+) -> None:
+    manager = portfolio_manager_with_db
+    manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend(
+        lookback_days=3, risk_off_multiplier=0.25
+    )
+    _record_absolute_trend_state(
+        manager,
+        {
+            "AAA": {
+                **_absolute_trend_signal_payload(lookback_days=3),
+                "state": "sideways",
+            }
+        },
+    )
+
+    _, details = await manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        manager.config.portfolio.symbols,
+        _absolute_trend_history_cache(
+            mocker, [100.0, 100.0, 100.0, 90.0], lookback_days=3
+        ),
+    )
+
+    # A cliff derives its state from the entry rule alone, so the reset loses
+    # bookkeeping only, and the reason keeps it visible.
+    trend = details["AAA"]
+    assert trend["state"] == "risk_off"
+    assert trend["previous_state"] is None
+    assert trend["state_reset_reason"] == "invalid_persisted_state"
+    assert trend["applied_multiplier"] == pytest.approx(0.25)
+
+
+@pytest.mark.asyncio
+async def test_absolute_trend_legacy_state_serves_unavailable_history(
+    portfolio_manager_with_db: Any, mocker: Any
+) -> None:
+    manager = portfolio_manager_with_db
+    manager.config.portfolio.symbols["AAA"].absolute_trend = _absolute_trend()
+    _record_absolute_trend_state(
+        manager,
+        {"AAA": _legacy_absolute_trend_payload(lookback_days=168, risk_off=True)},
+        state_version=None,
+    )
+    history_cache = SimpleNamespace(
+        get=mocker.AsyncMock(side_effect=TimeoutError("history unavailable"))
+    )
+
+    weights, details = await manager.regime_engine._apply_absolute_trend(
+        {"AAA": 0.4},
+        manager.config.portfolio.symbols,
+        history_cache,
+    )
+
+    trend = details["AAA"]
+    assert weights["AAA"] == pytest.approx(0.06)
+    assert trend["history_source"] == "persisted"
+    assert trend["state"] == "risk_off"
+    assert trend["state_reset_reason"] == "legacy_payload"
+    assert trend["sessions_in_state"] == 1
+
+
+@pytest.mark.asyncio
 async def test_absolute_trend_same_session_replan_keeps_transition(
     portfolio_manager_with_db: Any, mocker: Any
 ) -> None:
@@ -2441,18 +2661,16 @@ async def test_absolute_trend_same_session_replan_keeps_transition(
         lookback_days=3, mode="deadband", exit_depth=0.05
     )
     dates = _required_regime_history_dates(4)
-    manager.data_store.record_event(
-        "absolute_trend_state",
+    _record_absolute_trend_state(
+        manager,
         {
-            "symbols": {
-                "AAA": _absolute_trend_signal_payload(
-                    lookback_days=3,
-                    sessions_in_state=4,
-                    state_transition=True,
-                    within_band_drift=True,
-                )
-                | {"latest_session": str(dates[-1])}
-            }
+            "AAA": _absolute_trend_signal_payload(
+                lookback_days=3,
+                sessions_in_state=4,
+                state_transition=True,
+                within_band_drift=True,
+            )
+            | {"latest_session": str(dates[-1])}
         },
     )
     history_cache = SimpleNamespace(
@@ -2592,16 +2810,14 @@ async def test_absolute_trend_reuses_persisted_state_when_history_fails(
     portfolio_manager_with_db.config.portfolio.symbols[
         "AAA"
     ].absolute_trend = _absolute_trend()
-    portfolio_manager_with_db.data_store.record_event(
-        "absolute_trend_state",
+    _record_absolute_trend_state(
+        portfolio_manager_with_db,
         {
-            "symbols": {
-                "AAA": _absolute_trend_signal_payload(
-                    sessions_in_state=4,
-                    state_transition=True,
-                    within_band_drift=True,
-                )
-            }
+            "AAA": _absolute_trend_signal_payload(
+                sessions_in_state=4,
+                state_transition=True,
+                within_band_drift=True,
+            )
         },
     )
     history_cache = SimpleNamespace(
@@ -2678,9 +2894,9 @@ async def test_absolute_trend_history_failure_without_valid_state_aborts(
         "AAA"
     ].absolute_trend = _absolute_trend()
     if persisted_signal is not None:
-        portfolio_manager_with_db.data_store.record_event(
-            "absolute_trend_state",
-            {"symbols": {"AAA": persisted_signal}},
+        _record_absolute_trend_state(
+            portfolio_manager_with_db,
+            {"AAA": persisted_signal},
         )
     history_cache = SimpleNamespace(
         get=mocker.AsyncMock(side_effect=TimeoutError("history unavailable"))
@@ -2701,9 +2917,11 @@ async def test_absolute_trend_invalid_persisted_symbol_map_aborts_cleanly(
     portfolio_manager_with_db.config.portfolio.symbols[
         "AAA"
     ].absolute_trend = _absolute_trend()
+    # A symbol map that is not a dict is corrupt rather than legacy, so the
+    # record still claims the current version.
     portfolio_manager_with_db.data_store.record_event(
         "absolute_trend_state",
-        {"symbols": []},
+        {"state_version": 1, "symbols": []},
     )
     history_cache = SimpleNamespace(
         get=mocker.AsyncMock(side_effect=TimeoutError("history unavailable"))
@@ -2780,6 +2998,8 @@ async def test_absolute_trend_preserves_volatility_state_and_forces_hard_band_se
     assert trend["sessions_in_state"] == 1
     assert trend["state_transition"] is False
     assert trend["within_band_drift"] is False
+    # No record existed, so this is a cold start rather than a reset.
+    assert trend["state_reset_reason"] is None
     assert trend["shortfall"] == pytest.approx(0.10)
     assert trend["mode"] == "cliff"
     assert trend["exit_depth"] == pytest.approx(0.0)

--- a/tests/test_target_weight_policy.py
+++ b/tests/test_target_weight_policy.py
@@ -5,6 +5,7 @@ import pytest
 from thetagang.config_models import TargetWeightPolicyConfig
 from thetagang.external_decisions import (
     ExternalDecisionError,
+    ExternalDecisionRejection,
     ExternalDecisionResponse,
 )
 from thetagang.target_weight_policy import (
@@ -15,11 +16,11 @@ from thetagang.target_weight_policy import (
 )
 
 
-def test_absolute_trend_request_defaults_to_cliff() -> None:
-    trend = AbsoluteTrendInput.model_validate(
-        {"enabled": True, "lookback_days": 250, "risk_off_multiplier": 0.25}
-    )
-    assert trend.risk_off_ramp_width == 0.0
+def test_absolute_trend_request_requires_resolved_policy() -> None:
+    with pytest.raises(ValueError, match="policy"):
+        AbsoluteTrendInput.model_validate(
+            {"enabled": True, "lookback_days": 250, "risk_off_multiplier": 0.25}
+        )
 
 
 def _policy() -> TargetWeightPolicyConfig:
@@ -70,7 +71,7 @@ def test_target_weight_response_accepts_current_bounded_signal(
 def test_target_weight_response_rejects_invalid_multiplier(
     multiplier: object,
 ) -> None:
-    with pytest.raises(ExternalDecisionError, match="invalid|bounds"):
+    with pytest.raises(ExternalDecisionRejection, match="invalid|bounds"):
         validate_target_weight_response(
             _response(multiplier=multiplier),
             policy=_policy(),
@@ -92,7 +93,7 @@ def test_target_weight_response_rejects_stale_session() -> None:
 def test_target_weight_response_requires_market_session() -> None:
     response = _response().model_copy(update={"as_of_session": None})
 
-    with pytest.raises(ExternalDecisionError, match="requires as_of_session"):
+    with pytest.raises(ExternalDecisionRejection, match="requires as_of_session"):
         validate_target_weight_response(
             response,
             policy=_policy(),
@@ -115,7 +116,7 @@ def test_target_weight_response_rejects_expired_signal() -> None:
 
 
 def test_target_weight_response_requires_configured_symbol_set() -> None:
-    with pytest.raises(ExternalDecisionError, match="symbols do not match"):
+    with pytest.raises(ExternalDecisionRejection, match="symbols do not match"):
         validate_target_weight_response(
             _response(symbol="QQQ"),
             policy=_policy(),
@@ -181,7 +182,9 @@ def test_target_bounds_apply_after_multiplication(
 )
 def test_target_application_rejects_disjoint_clamps(bounds: dict[str, float]) -> None:
     policy = TargetWeightPolicyConfig(symbols={"IBIT": bounds})
-    with pytest.raises(ExternalDecisionError, match="do not overlap volatility bounds"):
+    with pytest.raises(
+        ExternalDecisionRejection, match="do not overlap volatility bounds"
+    ):
         apply_target_weight_adjustments(
             {"IBIT": 0.25},
             {"IBIT": TargetWeightMultiplier(multiplier=1.0)},
@@ -198,7 +201,7 @@ def test_target_floors_cannot_bypass_total_exposure_limit() -> None:
             for symbol in ("TQQQ", "IBIT")
         }
     )
-    with pytest.raises(ExternalDecisionError, match="permitted total weight"):
+    with pytest.raises(ExternalDecisionRejection, match="permitted total weight"):
         apply_target_weight_adjustments(
             {"TQQQ": 0.4, "IBIT": 0.4},
             {

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -560,13 +560,25 @@ daily_stddev_window = "30 D"
   weight = 0.3
   # Optional post-volatility absolute-trend target modifier. It uses only
   # completed sessions and defaults to disabled when absent or enabled=false.
+  # Risk-off is entered when the latest close is below the lower of the moving
+  # average and the lookback reference close, and the target is reduced by
+  # `risk_off_multiplier` for as long as that state holds.
+  #
+  # `absolute_trend.policy` is the explicit exit rule. A "cliff" (the default)
+  # exits as soon as the entry rule stops holding. A "deadband" holds risk-off
+  # until the close is at least `exit_depth` above the entry threshold and the
+  # state has lasted at least `min_dwell_sessions` sessions; it must set
+  # `exit_depth > 0` or `min_dwell_sessions >= 2`. Cliff mode requires both
+  # hysteresis parameters to stay at zero. The resolved policy is published to
+  # external decision providers, which validate it by exact match.
   # [portfolio.symbols.QQQ.absolute_trend]
   # enabled = false
   # lookback_days = 168
   # risk_off_multiplier = 0.25
-  # Ramp from 1.0 at the lower of the moving average and lookback reference
-  # to the floor 10% below it. Width defaults to 0 (original step reduction).
-  # risk_off_ramp_width = 0.10
+  # [portfolio.symbols.QQQ.absolute_trend.policy]
+  # mode = "deadband" # cliff | deadband
+  # exit_depth = 0.02
+  # min_dwell_sessions = 3
   # The target DTE may also be specified per-symbol, and takes precedence over
   # `target.dte`
   dte = 60

--- a/thetagang/config_models.py
+++ b/thetagang/config_models.py
@@ -754,11 +754,42 @@ class SymbolConfig(BaseModel):
                 raise ValueError("volatility_weight.max_weight must be >= min_weight")
             return self
 
+    class AbsoluteTrendPolicy(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        mode: Literal["cliff", "deadband"] = Field(default="cliff")
+        exit_depth: float = Field(default=0.0, ge=0.0, le=1.0)
+        min_dwell_sessions: int = Field(default=0, ge=0)
+
+        @model_validator(mode="after")
+        def validate_mode_hysteresis(self) -> Self:
+            # A cliff exits as soon as the entry rule stops holding, so
+            # hysteresis parameters would be silently ignored.
+            if self.mode == "cliff":
+                if self.exit_depth > 0.0 or self.min_dwell_sessions > 0:
+                    raise ValueError(
+                        "absolute_trend.policy.exit_depth and "
+                        "min_dwell_sessions require mode='deadband'"
+                    )
+                return self
+            # Dwell of one session is already true when a risk-off state is
+            # entered, which would make 'deadband' indistinguishable from a cliff.
+            if self.exit_depth == 0.0 and self.min_dwell_sessions < 2:
+                raise ValueError(
+                    "absolute_trend.policy mode='deadband' requires exit_depth > 0 "
+                    "or min_dwell_sessions >= 2"
+                )
+            return self
+
     class AbsoluteTrend(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
         enabled: bool = Field(default=False)
         lookback_days: int = Field(default=168, ge=2)
         risk_off_multiplier: float = Field(default=0.15, ge=0.0, le=1.0)
-        risk_off_ramp_width: float = Field(default=0.0, ge=0.0, le=1.0)
+        policy: "SymbolConfig.AbsoluteTrendPolicy" = Field(
+            default_factory=lambda: SymbolConfig.AbsoluteTrendPolicy()
+        )
 
     weight: float = Field(..., ge=0, le=1)
     primary_exchange: str = Field(default="", min_length=1)

--- a/thetagang/external_decisions.py
+++ b/thetagang/external_decisions.py
@@ -21,6 +21,14 @@ class ExternalDecisionError(RuntimeError):
     """Raised when an external provider cannot return a valid decision."""
 
 
+class ExternalDecisionRejection(ExternalDecisionError):
+    """Raised when a provider answered but its decision is unacceptable.
+
+    A rejection is a provider-side fault, so it never degrades to baseline
+    sizing. Only transport unavailability may fall back per ``on_error``.
+    """
+
+
 class _ResponseTooLargeError(RuntimeError):
     pass
 
@@ -303,7 +311,7 @@ class CommandExternalDecisionProvider:
         if process.returncode != 0:
             error_text = stderr.decode("utf-8", errors="replace").strip()
             error_suffix = f": {error_text[:512]}" if error_text else ""
-            raise ExternalDecisionError(
+            raise ExternalDecisionRejection(
                 f"external decision provider exited with status "
                 f"{process.returncode}{error_suffix}"
             )
@@ -317,17 +325,17 @@ def parse_external_decision_response(stdout: bytes) -> ExternalDecisionResponse:
             parse_constant=lambda value: _raise_invalid_constant(value),
         )
     except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
-        raise ExternalDecisionError(
+        raise ExternalDecisionRejection(
             "external decision provider returned invalid JSON"
         ) from exc
     if not isinstance(decoded, dict):
-        raise ExternalDecisionError(
+        raise ExternalDecisionRejection(
             "external decision provider response must be a JSON object"
         )
     try:
         return ExternalDecisionResponse.model_validate(decoded)
     except ValueError as exc:
-        raise ExternalDecisionError(
+        raise ExternalDecisionRejection(
             "external decision provider returned an invalid response envelope"
         ) from exc
 
@@ -358,7 +366,7 @@ class ExternalDecisionProviders:
     ) -> ExternalDecisionResponse:
         provider = self._providers.get(provider_name)
         if provider is None:
-            raise ExternalDecisionError(
+            raise ExternalDecisionRejection(
                 f"external decision provider is not configured: {provider_name}"
             )
         response = await provider.decide(request)
@@ -370,9 +378,11 @@ def validate_response_identity(
     response: ExternalDecisionResponseEnvelope, request: ExternalDecisionRequestEnvelope
 ) -> None:
     if response.request_id != request.request_id:
-        raise ExternalDecisionError("external decision response request_id mismatch")
+        raise ExternalDecisionRejection(
+            "external decision response request_id mismatch"
+        )
     if response.decision_type != request.decision_type:
-        raise ExternalDecisionError("external decision response type mismatch")
+        raise ExternalDecisionRejection("external decision response type mismatch")
 
 
 def validate_market_decision_response(
@@ -392,13 +402,15 @@ def validate_market_decision_response(
     latest_session = history_dates[-1]
     signal_session = response.as_of_session
     if signal_session is None:
-        raise ExternalDecisionError(f"{decision_name} response requires as_of_session")
+        raise ExternalDecisionRejection(
+            f"{decision_name} response requires as_of_session"
+        )
     if signal_session > latest_session:
-        raise ExternalDecisionError(f"{decision_name} signal is from the future")
+        raise ExternalDecisionRejection(f"{decision_name} signal is from the future")
     try:
         signal_index = history_dates.index(signal_session)
     except ValueError as exc:
-        raise ExternalDecisionError(
+        raise ExternalDecisionRejection(
             f"{decision_name} signal is not aligned to a supplied session"
         ) from exc
     signal_age_sessions = len(history_dates) - signal_index - 1

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -94,6 +94,13 @@ REGIME_HISTORY_TIMEFRAME = "1 day"
 REGIME_HISTORY_MAX_ATTEMPTS = 3
 REGIME_HISTORY_RETRY_DELAY_SECONDS = 0.25
 ABSOLUTE_TREND_STATE_EVENT = "absolute_trend_state"
+# Version of the persisted absolute-trend record. Records written by an older
+# version are salvaged by their recorded risk state; only records that claim
+# this version and are still unreadable count as corrupt.
+ABSOLUTE_TREND_STATE_VERSION = 1
+_ABSOLUTE_TREND_LEGACY_REASON = "legacy_payload"
+_ABSOLUTE_TREND_INVALID_REASON = "invalid_persisted_state"
+_ABSOLUTE_TREND_VERSION_REASON = "unsupported_state_version"
 TAIL_HEDGE_HARVEST_EVENT = "tail_hedge_harvest"
 TAIL_HEDGE_HARVEST_SCHEMA_VERSION = 2
 
@@ -173,6 +180,10 @@ class RatioGateResult:
 _ABSOLUTE_TREND_STATES = frozenset({"risk_on", "risk_off"})
 
 
+class _UnsupportedAbsoluteTrendStateVersion(ValueError):
+    """Raised when a persisted record predates the current state version."""
+
+
 def _payload_session(payload: dict[str, Any]) -> str:
     latest_session = payload.get("latest_session")
     if not isinstance(latest_session, str):
@@ -214,11 +225,23 @@ class _AbsoluteTrendState:
     sessions_in_state: int
     state_transition: bool
     within_band_drift: bool
+    reset_reason: str | None = None
 
     @classmethod
-    def from_payload(cls, payload: Any, *, lookback_days: int) -> _AbsoluteTrendState:
+    def from_payload(
+        cls,
+        payload: Any,
+        *,
+        lookback_days: int,
+        state_version: int | None,
+    ) -> _AbsoluteTrendState:
         if not isinstance(payload, dict):
             raise TypeError("state_not_an_object")
+        if (
+            type(state_version) is not int
+            or state_version != ABSOLUTE_TREND_STATE_VERSION
+        ):
+            raise _UnsupportedAbsoluteTrendStateVersion(_ABSOLUTE_TREND_VERSION_REASON)
         if payload.get("lookback_days") != lookback_days:
             raise ValueError("lookback_mismatch")
         state = payload.get("state")
@@ -237,6 +260,9 @@ class _AbsoluteTrendState:
         for field in ("state_transition", "within_band_drift"):
             if not isinstance(payload.get(field), bool):
                 raise TypeError(f"invalid_{field}")
+        reset_reason = payload.get("state_reset_reason")
+        if reset_reason is not None and not isinstance(reset_reason, str):
+            raise TypeError("invalid_state_reset_reason")
         return cls(
             latest_session=_payload_session(payload),
             state=state,
@@ -244,7 +270,40 @@ class _AbsoluteTrendState:
             sessions_in_state=sessions_in_state,
             state_transition=bool(payload["state_transition"]),
             within_band_drift=bool(payload["within_band_drift"]),
+            reset_reason=reset_reason,
         )
+
+
+def _salvage_legacy_state(
+    payload: Any, *, lookback_days: int
+) -> _AbsoluteTrendState | None:
+    """Read the risk state from a record written by an older payload version.
+
+    The recorded state is authoritative because only it can tell whether a
+    symbol is risk-off held by hysteresis: re-deriving from the entry rule
+    would release that exposure early, which is the one direction a reset must
+    never take. The dwell counter and transition labels are unrecoverable, so
+    they restart, and the event carries the reset reason.
+    """
+
+    if not isinstance(payload, dict) or payload.get("lookback_days") != lookback_days:
+        return None
+    risk_off = payload.get("risk_off")
+    if not isinstance(risk_off, bool):
+        return None
+    try:
+        latest_session = _payload_session(payload)
+    except (TypeError, ValueError):
+        return None
+    return _AbsoluteTrendState(
+        latest_session=latest_session,
+        state="risk_off" if risk_off else "risk_on",
+        previous_state=None,
+        sessions_in_state=1,
+        state_transition=False,
+        within_band_drift=False,
+        reset_reason=_ABSOLUTE_TREND_LEGACY_REASON,
+    )
 
 
 @dataclass(frozen=True)
@@ -355,8 +414,14 @@ class _AbsoluteTrendSignal:
         *,
         previous: _AbsoluteTrendState | None,
         policy: _AbsoluteTrendPolicy,
+        reset_reason: str | None = None,
     ) -> _AbsoluteTrendState:
-        """Resolve this session's state, holding risk-off through hysteresis."""
+        """Resolve this session's state, holding risk-off through hysteresis.
+
+        `reset_reason` travels into the emitted record whenever the previous
+        record could not be applied as-is, so an A/B that counts drift sessions
+        cannot silently miss a reset.
+        """
 
         if previous is not None and previous.latest_session == self.latest_session:
             # Replanning the same completed session must not advance the dwell
@@ -373,6 +438,7 @@ class _AbsoluteTrendSignal:
                 sessions_in_state=1,
                 state_transition=False,
                 within_band_drift=False,
+                reset_reason=reset_reason,
             )
         if previous.state == "risk_off":
             exit_level = self.threshold * (1.0 + policy.exit_depth)
@@ -388,6 +454,7 @@ class _AbsoluteTrendSignal:
                     sessions_in_state=1,
                     state_transition=True,
                     within_band_drift=False,
+                    reset_reason=reset_reason,
                 )
             return _AbsoluteTrendState(
                 latest_session=self.latest_session,
@@ -398,6 +465,7 @@ class _AbsoluteTrendSignal:
                 # The entry rule no longer holds, so only hysteresis is
                 # keeping this symbol risk-off.
                 within_band_drift=not entry,
+                reset_reason=reset_reason,
             )
         if entry:
             return _AbsoluteTrendState(
@@ -407,6 +475,7 @@ class _AbsoluteTrendSignal:
                 sessions_in_state=1,
                 state_transition=True,
                 within_band_drift=False,
+                reset_reason=reset_reason,
             )
         return _AbsoluteTrendState(
             latest_session=self.latest_session,
@@ -415,6 +484,7 @@ class _AbsoluteTrendSignal:
             sessions_in_state=previous.sessions_in_state + 1,
             state_transition=False,
             within_band_drift=False,
+            reset_reason=reset_reason,
         )
 
     def target_details(
@@ -441,6 +511,7 @@ class _AbsoluteTrendSignal:
             "previous_state": state.previous_state,
             "state_transition": state.state_transition,
             "within_band_drift": state.within_band_drift,
+            "state_reset_reason": state.reset_reason,
             "sessions_in_state": state.sessions_in_state,
             "shortfall": self.shortfall,
             "mode": policy.mode,
@@ -2825,22 +2896,72 @@ class RegimeRebalanceEngine:
         previous_symbols = (
             previous_symbols_raw if isinstance(previous_symbols_raw, dict) else {}
         )
+        previous_state_version = (
+            previous_state.get("state_version")
+            if isinstance(previous_state, dict)
+            else None
+        )
+
+        def abort_unusable_state(symbol: str, reason: str, detail: str) -> None:
+            log.error(
+                f"{symbol}: absolute trend persisted state is unusable "
+                f"({reason}: {detail}); aborting rebalancing."
+            )
+            raise RuntimeError(
+                f"{symbol}: absolute trend cannot resolve a deadband state from "
+                f"the persisted record ({reason})."
+            )
 
         def resolved_previous_state(
-            symbol: str, lookback_days: int
-        ) -> _AbsoluteTrendState | None:
+            symbol: str, lookback_days: int, mode: str
+        ) -> tuple[_AbsoluteTrendState | None, str | None]:
+            """Return the persisted state and why it could not be applied as-is.
+
+            An absent record is a cold start. A record written by an older
+            payload version is salvaged by its recorded risk state. Anything
+            else is corruption, which must not release a hysteresis-held
+            risk-off: deadband mode aborts, while a cliff can reset because its
+            state is derived purely from the entry rule.
+            """
+
+            payload = previous_symbols.get(symbol)
+            if payload is None:
+                return None, None
+            reason = _ABSOLUTE_TREND_INVALID_REASON
+            detail = "unreadable"
             try:
-                return _AbsoluteTrendState.from_payload(
-                    previous_symbols.get(symbol),
+                state = _AbsoluteTrendState.from_payload(
+                    payload,
                     lookback_days=lookback_days,
+                    state_version=previous_state_version,
                 )
-            except (TypeError, ValueError) as exc:
-                if symbol in previous_symbols:
-                    log.warning(
-                        f"{symbol}: ignoring persisted absolute trend state "
-                        f"({exc}); resolving this session from the entry rule."
+            except _UnsupportedAbsoluteTrendStateVersion:
+                reason = _ABSOLUTE_TREND_VERSION_REASON
+                detail = (
+                    f"state_version={previous_state_version!r} is not "
+                    f"{ABSOLUTE_TREND_STATE_VERSION}"
+                )
+                salvaged = _salvage_legacy_state(payload, lookback_days=lookback_days)
+                if salvaged is not None:
+                    log.error(
+                        f"ALERT: {symbol}: persisted absolute trend state predates "
+                        f"the current payload version ({detail}); keeping its "
+                        f"recorded {salvaged.state.replace('_', '-')} state with a "
+                        "reset dwell counter."
                     )
-                return None
+                    return salvaged, _ABSOLUTE_TREND_LEGACY_REASON
+            except (TypeError, ValueError) as exc:
+                detail = str(exc)
+            else:
+                return state, None
+            if mode == "deadband":
+                abort_unusable_state(symbol, reason, detail)
+            log.error(
+                f"ALERT: {symbol}: absolute trend persisted state is unusable "
+                f"({reason}: {detail}); an entry rule reset cannot lose exposure "
+                "in cliff mode, so this session resolves from the entry rule."
+            )
+            return None, reason
 
         def apply_signal(
             symbol: str,
@@ -2873,14 +2994,45 @@ class RegimeRebalanceEngine:
                     payload,
                     lookback_days=lookback_days,
                 )
-                state = _AbsoluteTrendState.from_payload(
-                    payload,
-                    lookback_days=lookback_days,
-                )
             except (TypeError, ValueError) as exc:
                 log.error(
                     f"{symbol}: absolute trend history is unavailable and no "
-                    "valid persisted state exists; aborting rebalancing."
+                    f"valid persisted state exists ({exc}); aborting rebalancing."
+                )
+                raise RuntimeError(
+                    f"{symbol}: absolute trend requires current history or a "
+                    "valid persisted state."
+                ) from exc
+            try:
+                state = _AbsoluteTrendState.from_payload(
+                    payload,
+                    lookback_days=lookback_days,
+                    state_version=previous_state_version,
+                )
+            except _UnsupportedAbsoluteTrendStateVersion:
+                # The closes survive in older records, so a legacy record still
+                # supports the no-history path by its recorded risk state.
+                state = _salvage_legacy_state(payload, lookback_days=lookback_days)
+                if state is None:
+                    log.error(
+                        f"{symbol}: absolute trend history is unavailable and the "
+                        "persisted record predates the current payload version "
+                        "without a usable risk state; aborting rebalancing."
+                    )
+                    raise RuntimeError(
+                        f"{symbol}: absolute trend requires current history or a "
+                        "valid persisted state."
+                    ) from None
+                log.error(
+                    f"ALERT: {symbol}: persisted absolute trend state predates the "
+                    f"current payload version; retaining its recorded "
+                    f"{state.state.replace('_', '-')} state with a reset dwell "
+                    "counter while history is unavailable."
+                )
+            except (TypeError, ValueError) as exc:
+                log.error(
+                    f"{symbol}: absolute trend history is unavailable and the "
+                    f"persisted state is unusable ({exc}); aborting rebalancing."
                 )
                 raise RuntimeError(
                     f"{symbol}: absolute trend requires current history or a "
@@ -2930,9 +3082,15 @@ class RegimeRebalanceEngine:
                     )
                     continue
 
+                previous, reset_reason = resolved_previous_state(
+                    symbol,
+                    lookback_days,
+                    trend_policies[symbol].mode,
+                )
                 state = signal.resolve(
-                    previous=resolved_previous_state(symbol, lookback_days),
+                    previous=previous,
                     policy=trend_policies[symbol],
+                    reset_reason=reset_reason,
                 )
                 details = apply_signal(symbol, signal, state, history_source="fresh")
                 log.notice(
@@ -4322,6 +4480,7 @@ class RegimeRebalanceEngine:
             if trend_details and not self.data_store.record_event(
                 ABSOLUTE_TREND_STATE_EVENT,
                 {
+                    "state_version": ABSOLUTE_TREND_STATE_VERSION,
                     "pre_trend_total_effective_weight": (
                         pre_trend_total_effective_weight
                     ),

--- a/thetagang/strategies/regime_engine.py
+++ b/thetagang/strategies/regime_engine.py
@@ -36,6 +36,7 @@ from thetagang.external_decisions import (
     ExternalDecisionError,
     ExternalDecisionMarketData,
     ExternalDecisionProviders,
+    ExternalDecisionRejection,
     ExternalDecisionResponse,
     external_decision_response_metadata,
     validate_decision_expiry,
@@ -108,6 +109,7 @@ class _TargetWeightPolicyOutcome:
     adjustments: dict[str, TargetWeightMultiplier] | None
     response: ExternalDecisionResponse | None
     error: str | None
+    rejected: bool = False
 
 
 @dataclass(frozen=True)
@@ -168,6 +170,83 @@ class RatioGateResult:
         )
 
 
+_ABSOLUTE_TREND_STATES = frozenset({"risk_on", "risk_off"})
+
+
+def _payload_session(payload: dict[str, Any]) -> str:
+    latest_session = payload.get("latest_session")
+    if not isinstance(latest_session, str):
+        raise TypeError("invalid_latest_session")
+    if not latest_session:
+        raise ValueError("invalid_latest_session")
+    try:
+        date.fromisoformat(latest_session)
+    except ValueError as exc:
+        raise ValueError("invalid_latest_session") from exc
+    return latest_session
+
+
+@dataclass(frozen=True)
+class _AbsoluteTrendPolicy:
+    """Resolved absolute-trend rule published to external decision providers."""
+
+    mode: str
+    exit_depth: float
+    min_dwell_sessions: int
+
+    @classmethod
+    def from_config(cls, config: Any) -> _AbsoluteTrendPolicy:
+        policy = config.policy
+        return cls(
+            mode=str(policy.mode),
+            exit_depth=float(policy.exit_depth),
+            min_dwell_sessions=int(policy.min_dwell_sessions),
+        )
+
+
+@dataclass(frozen=True)
+class _AbsoluteTrendState:
+    """Resolved risk state, including the hysteresis that produced it."""
+
+    latest_session: str
+    state: str
+    previous_state: str | None
+    sessions_in_state: int
+    state_transition: bool
+    within_band_drift: bool
+
+    @classmethod
+    def from_payload(cls, payload: Any, *, lookback_days: int) -> _AbsoluteTrendState:
+        if not isinstance(payload, dict):
+            raise TypeError("state_not_an_object")
+        if payload.get("lookback_days") != lookback_days:
+            raise ValueError("lookback_mismatch")
+        state = payload.get("state")
+        if state not in _ABSOLUTE_TREND_STATES:
+            raise TypeError("invalid_state")
+        previous_state = payload.get("previous_state")
+        if previous_state is not None and previous_state not in _ABSOLUTE_TREND_STATES:
+            raise TypeError("invalid_previous_state")
+        sessions_in_state = payload.get("sessions_in_state")
+        if (
+            isinstance(sessions_in_state, bool)
+            or not isinstance(sessions_in_state, int)
+            or sessions_in_state < 1
+        ):
+            raise TypeError("invalid_sessions_in_state")
+        for field in ("state_transition", "within_band_drift"):
+            if not isinstance(payload.get(field), bool):
+                raise TypeError(f"invalid_{field}")
+        return cls(
+            latest_session=_payload_session(payload),
+            state=state,
+            previous_state=previous_state,
+            sessions_in_state=sessions_in_state,
+            state_transition=bool(payload["state_transition"]),
+            within_band_drift=bool(payload["within_band_drift"]),
+        )
+
+
 @dataclass(frozen=True)
 class _AbsoluteTrendSignal:
     lookback_days: int
@@ -176,7 +255,6 @@ class _AbsoluteTrendSignal:
     moving_average: float
     momentum_reference_close: float
     lookback_return: float
-    risk_off: bool
 
     @classmethod
     def from_history(
@@ -206,10 +284,6 @@ class _AbsoluteTrendSignal:
             moving_average=moving_average,
             momentum_reference_close=momentum_reference_close,
             lookback_return=latest_close / momentum_reference_close - 1.0,
-            risk_off=(
-                latest_close < moving_average
-                and latest_close < momentum_reference_close
-            ),
         )
 
     @classmethod
@@ -224,18 +298,7 @@ class _AbsoluteTrendSignal:
         if payload.get("lookback_days") != lookback_days:
             raise ValueError("lookback_mismatch")
 
-        latest_session = payload.get("latest_session")
-        risk_off = payload.get("risk_off")
-        if not isinstance(latest_session, str):
-            raise TypeError("invalid_latest_session")
-        if not latest_session:
-            raise ValueError("invalid_latest_session")
-        try:
-            date.fromisoformat(latest_session)
-        except ValueError as exc:
-            raise ValueError("invalid_latest_session") from exc
-        if not isinstance(risk_off, bool):
-            raise TypeError("invalid_risk_state")
+        latest_session = _payload_session(payload)
 
         def finite_number(field: str, *, positive: bool = False) -> float:
             value = payload.get(field)
@@ -261,10 +324,6 @@ class _AbsoluteTrendSignal:
             abs_tol=1e-12,
         ):
             raise ValueError("inconsistent_lookback_return")
-        if risk_off != (
-            latest_close < moving_average and latest_close < momentum_reference_close
-        ):
-            raise ValueError("inconsistent_risk_state")
 
         return cls(
             lookback_days=lookback_days,
@@ -273,31 +332,103 @@ class _AbsoluteTrendSignal:
             moving_average=moving_average,
             momentum_reference_close=momentum_reference_close,
             lookback_return=lookback_return,
-            risk_off=risk_off,
         )
 
     @property
-    def state(self) -> str:
-        return "risk_off" if self.risk_off else "risk_on"
+    def threshold(self) -> float:
+        """The lower of the moving average and the momentum reference close."""
+
+        return min(self.moving_average, self.momentum_reference_close)
+
+    @property
+    def entry_risk_off(self) -> bool:
+        return self.latest_close < self.threshold
+
+    @property
+    def shortfall(self) -> float:
+        """Raw fractional shortfall below the entry threshold; zero when on."""
+
+        return max(0.0, (self.threshold - self.latest_close) / self.threshold)
+
+    def resolve(
+        self,
+        *,
+        previous: _AbsoluteTrendState | None,
+        policy: _AbsoluteTrendPolicy,
+    ) -> _AbsoluteTrendState:
+        """Resolve this session's state, holding risk-off through hysteresis."""
+
+        if previous is not None and previous.latest_session == self.latest_session:
+            # Replanning the same completed session must not advance the dwell
+            # counter or relabel that session's transition.
+            return previous
+
+        entry = self.entry_risk_off
+        if previous is None:
+            state = "risk_off" if entry else "risk_on"
+            return _AbsoluteTrendState(
+                latest_session=self.latest_session,
+                state=state,
+                previous_state=None,
+                sessions_in_state=1,
+                state_transition=False,
+                within_band_drift=False,
+            )
+        if previous.state == "risk_off":
+            exit_level = self.threshold * (1.0 + policy.exit_depth)
+            # `min_dwell_sessions` counts completed sessions in risk-off, so
+            # min_dwell_sessions=2 means the state must last at least two
+            # sessions before an exit can be taken.
+            dwell_satisfied = previous.sessions_in_state >= policy.min_dwell_sessions
+            if not entry and self.latest_close >= exit_level and dwell_satisfied:
+                return _AbsoluteTrendState(
+                    latest_session=self.latest_session,
+                    state="risk_on",
+                    previous_state="risk_off",
+                    sessions_in_state=1,
+                    state_transition=True,
+                    within_band_drift=False,
+                )
+            return _AbsoluteTrendState(
+                latest_session=self.latest_session,
+                state="risk_off",
+                previous_state="risk_off",
+                sessions_in_state=previous.sessions_in_state + 1,
+                state_transition=False,
+                # The entry rule no longer holds, so only hysteresis is
+                # keeping this symbol risk-off.
+                within_band_drift=not entry,
+            )
+        if entry:
+            return _AbsoluteTrendState(
+                latest_session=self.latest_session,
+                state="risk_off",
+                previous_state="risk_on",
+                sessions_in_state=1,
+                state_transition=True,
+                within_band_drift=False,
+            )
+        return _AbsoluteTrendState(
+            latest_session=self.latest_session,
+            state="risk_on",
+            previous_state="risk_on",
+            sessions_in_state=previous.sessions_in_state + 1,
+            state_transition=False,
+            within_band_drift=False,
+        )
 
     def target_details(
         self,
         *,
+        state: _AbsoluteTrendState,
+        policy: _AbsoluteTrendPolicy,
         pre_trend_target: float,
         risk_off_multiplier: float,
-        risk_off_ramp_width: float,
         history_source: str,
         history_failure: str | None = None,
     ) -> dict[str, Any]:
-        applied_multiplier = risk_off_multiplier if self.risk_off else 1.0
-        if self.risk_off and risk_off_ramp_width > 0:
-            # Both trend conditions must weaken before reaching the floor.
-            threshold = min(self.moving_average, self.momentum_reference_close)
-            depth = (threshold - self.latest_close) / threshold
-            progress = min(depth / risk_off_ramp_width, 1.0)
-            applied_multiplier = max(
-                risk_off_multiplier, 1.0 - (1.0 - risk_off_multiplier) * progress
-            )
+        risk_off = state.state == "risk_off"
+        applied_multiplier = risk_off_multiplier if risk_off else 1.0
         details: dict[str, Any] = {
             "lookback_days": self.lookback_days,
             "latest_session": self.latest_session,
@@ -305,8 +436,16 @@ class _AbsoluteTrendSignal:
             "moving_average": self.moving_average,
             "momentum_reference_close": self.momentum_reference_close,
             "lookback_return": self.lookback_return,
-            "risk_off": self.risk_off,
-            "state": self.state,
+            "risk_off": risk_off,
+            "state": state.state,
+            "previous_state": state.previous_state,
+            "state_transition": state.state_transition,
+            "within_band_drift": state.within_band_drift,
+            "sessions_in_state": state.sessions_in_state,
+            "shortfall": self.shortfall,
+            "mode": policy.mode,
+            "exit_depth": policy.exit_depth,
+            "min_dwell_sessions": policy.min_dwell_sessions,
             "pre_trend_target": pre_trend_target,
             "final_target": pre_trend_target * applied_multiplier,
             "applied_multiplier": applied_multiplier,
@@ -1170,7 +1309,20 @@ class RegimeRebalanceEngine:
         *,
         policy: TailHarvestDecisionConfig,
         error: str,
+        rejected: bool = False,
     ) -> tuple[bool, dict[str, Any]]:
+        if rejected:
+            # A provider that answered with an unusable decision is not the
+            # same as an unavailable provider: baseline behavior would harvest
+            # without a valid approval.
+            log.error(
+                f"ALERT: external tail harvest decision provider={policy.provider} "
+                f"rejected the decision; aborting regime rebalancing ({error})."
+            )
+            raise ExternalDecisionRejection(
+                f"External tail harvest decision rejected the provider decision: "
+                f"{error}"
+            )
         if policy.on_error == "abort":
             raise RuntimeError(f"External tail harvest decision failed: {error}")
         harvest = policy.on_error == "baseline"
@@ -1265,6 +1417,12 @@ class RegimeRebalanceEngine:
                     provider=policy.provider,
                 ),
             }
+        except ExternalDecisionRejection as exc:
+            return self._tail_harvest_decision_fallback(
+                policy=policy,
+                error=f"{type(exc).__name__}: {exc}",
+                rejected=True,
+            )
         except Exception as exc:  # noqa: BLE001
             return self._tail_harvest_decision_fallback(
                 policy=policy,
@@ -2423,12 +2581,23 @@ class RegimeRebalanceEngine:
         *,
         policy: TargetWeightPolicyConfig,
         error: str,
+        rejected: bool = False,
     ) -> tuple[dict[str, float], dict[str, dict[str, Any]]]:
         # A failed application invalidates the signal for the rest of this run,
         # just like a failed response. Replanning must not revive rejected risk.
         self._target_weight_policy_outcome = _TargetWeightPolicyOutcome(
-            adjustments=None, response=None, error=error
+            adjustments=None, response=None, error=error, rejected=rejected
         )
+        if rejected:
+            # The provider answered and the answer was refused. Baseline sizing
+            # would silently trade on a decision the host has rejected.
+            log.error(
+                f"ALERT: external target weight policy provider={policy.provider} "
+                f"rejected the decision; aborting regime rebalancing ({error})."
+            )
+            raise ExternalDecisionRejection(
+                f"External target weight policy rejected the provider decision: {error}"
+            )
         if policy.on_error == "abort":
             raise RuntimeError(
                 f"External target weight policy failed: {error}"
@@ -2532,6 +2701,13 @@ class RegimeRebalanceEngine:
                     response=response,
                     error=None,
                 )
+            except ExternalDecisionRejection as exc:
+                self._target_weight_policy_outcome = _TargetWeightPolicyOutcome(
+                    adjustments=None,
+                    response=None,
+                    error=f"{type(exc).__name__}: {exc}",
+                    rejected=True,
+                )
             except Exception as exc:  # noqa: BLE001
                 self._target_weight_policy_outcome = _TargetWeightPolicyOutcome(
                     adjustments=None,
@@ -2549,6 +2725,7 @@ class RegimeRebalanceEngine:
                 effective_weights,
                 policy=policy,
                 error=outcome.error or "provider returned no adjustments",
+                rejected=outcome.rejected,
             )
 
         try:
@@ -2580,6 +2757,13 @@ class RegimeRebalanceEngine:
                 }
                 for symbol, adjustment in outcome.adjustments.items()
             }
+        except ExternalDecisionRejection as exc:
+            return self._target_weight_policy_fallback(
+                effective_weights,
+                policy=policy,
+                error=f"{type(exc).__name__}: {exc}",
+                rejected=True,
+            )
         except (AttributeError, KeyError, TypeError, ExternalDecisionError) as exc:
             return self._target_weight_policy_fallback(
                 effective_weights,
@@ -2608,6 +2792,7 @@ class RegimeRebalanceEngine:
         adjusted_weights = dict(effective_weights)
         trend_details: dict[str, dict[str, Any]] = {}
         trend_configs: dict[str, Any] = {}
+        trend_policies: dict[str, _AbsoluteTrendPolicy] = {}
         trend_symbols_by_lookback: dict[int, list[str]] = {}
 
         for symbol in effective_weights:
@@ -2615,12 +2800,16 @@ class RegimeRebalanceEngine:
             if absolute_trend is None or not getattr(absolute_trend, "enabled", False):
                 continue
             trend_configs[symbol] = absolute_trend
+            trend_policies[symbol] = _AbsoluteTrendPolicy.from_config(absolute_trend)
             lookback_days = int(absolute_trend.lookback_days)
             trend_symbols_by_lookback.setdefault(lookback_days, []).append(symbol)
 
         if not trend_symbols_by_lookback:
             return adjusted_weights, trend_details
 
+        # The persisted state carries the hysteresis that only held risk-off
+        # while the entry rule no longer applied, so it is required even when
+        # this session's history is available.
         previous_state = (
             self.data_store.get_last_event_payload(
                 ABSOLUTE_TREND_STATE_EVENT,
@@ -2637,17 +2826,35 @@ class RegimeRebalanceEngine:
             previous_symbols_raw if isinstance(previous_symbols_raw, dict) else {}
         )
 
+        def resolved_previous_state(
+            symbol: str, lookback_days: int
+        ) -> _AbsoluteTrendState | None:
+            try:
+                return _AbsoluteTrendState.from_payload(
+                    previous_symbols.get(symbol),
+                    lookback_days=lookback_days,
+                )
+            except (TypeError, ValueError) as exc:
+                if symbol in previous_symbols:
+                    log.warning(
+                        f"{symbol}: ignoring persisted absolute trend state "
+                        f"({exc}); resolving this session from the entry rule."
+                    )
+                return None
+
         def apply_signal(
             symbol: str,
             signal: _AbsoluteTrendSignal,
+            state: _AbsoluteTrendState,
             *,
             history_source: str,
             history_failure: str | None = None,
         ) -> dict[str, Any]:
             details = signal.target_details(
+                state=state,
+                policy=trend_policies[symbol],
                 pre_trend_target=adjusted_weights[symbol],
                 risk_off_multiplier=float(trend_configs[symbol].risk_off_multiplier),
-                risk_off_ramp_width=float(trend_configs[symbol].risk_off_ramp_width),
                 history_source=history_source,
                 history_failure=history_failure,
             )
@@ -2660,9 +2867,14 @@ class RegimeRebalanceEngine:
             lookback_days: int,
             failure_reason: str,
         ) -> None:
+            payload = previous_symbols.get(symbol)
             try:
                 signal = _AbsoluteTrendSignal.from_payload(
-                    previous_symbols.get(symbol),
+                    payload,
+                    lookback_days=lookback_days,
+                )
+                state = _AbsoluteTrendState.from_payload(
+                    payload,
                     lookback_days=lookback_days,
                 )
             except (TypeError, ValueError) as exc:
@@ -2678,13 +2890,14 @@ class RegimeRebalanceEngine:
             details = apply_signal(
                 symbol,
                 signal,
+                state,
                 history_source="persisted",
                 history_failure=failure_reason,
             )
             log.warning(
                 f"{symbol}: absolute trend history unavailable "
                 f"({failure_reason}); retaining persisted "
-                f"{signal.state.replace('_', '-')} state with target "
+                f"{state.state.replace('_', '-')} state with target "
                 f"{pfmt(details['pre_trend_target'])}->"
                 f"{pfmt(details['final_target'])}."
             )
@@ -2717,12 +2930,18 @@ class RegimeRebalanceEngine:
                     )
                     continue
 
-                details = apply_signal(symbol, signal, history_source="fresh")
+                state = signal.resolve(
+                    previous=resolved_previous_state(symbol, lookback_days),
+                    policy=trend_policies[symbol],
+                )
+                details = apply_signal(symbol, signal, state, history_source="fresh")
                 log.notice(
                     f"{symbol}: absolute trend latest={signal.latest_close:.4f} "
                     f"average_{lookback_days}d={signal.moving_average:.4f} "
                     f"return_{lookback_days}d={pfmt(signal.lookback_return)} "
-                    f"state={signal.state.replace('_', '-')} "
+                    f"state={state.state.replace('_', '-')} "
+                    f"sessions={state.sessions_in_state} "
+                    f"mode={trend_policies[symbol].mode} "
                     f"multiplier={ffmt(details['applied_multiplier'])} "
                     f"target={pfmt(details['pre_trend_target'])}->"
                     f"{pfmt(details['final_target'])}"

--- a/thetagang/tail_harvest_decision.py
+++ b/thetagang/tail_harvest_decision.py
@@ -8,8 +8,8 @@ from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 from thetagang.config_models import TailHarvestDecisionConfig, TailHedgeConfig
 from thetagang.external_decisions import (
     DecisionInput,
-    ExternalDecisionError,
     ExternalDecisionMarketData,
+    ExternalDecisionRejection,
     ExternalDecisionRequest,
     ExternalDecisionRequestEnvelope,
     ExternalDecisionResponse,
@@ -243,6 +243,6 @@ def validate_tail_harvest_response(
     try:
         return TailHarvestDecisionOutput.model_validate(response.output)
     except ValueError as exc:
-        raise ExternalDecisionError(
+        raise ExternalDecisionRejection(
             "tail harvest decision returned an invalid output"
         ) from exc

--- a/thetagang/target_weight_policy.py
+++ b/thetagang/target_weight_policy.py
@@ -10,8 +10,8 @@ from thetagang.accounting import AccountingError, AccountMetric, BrokerAccountSn
 from thetagang.config_models import TargetWeightPolicyConfig
 from thetagang.external_decisions import (
     DecisionInput,
-    ExternalDecisionError,
     ExternalDecisionMarketData,
+    ExternalDecisionRejection,
     ExternalDecisionRequest,
     ExternalDecisionRequestEnvelope,
     ExternalDecisionResponse,
@@ -46,11 +46,17 @@ class VolatilityContext(DecisionInput):
     )
 
 
+class AbsoluteTrendPolicyInput(DecisionInput):
+    mode: Literal["cliff", "deadband"]
+    exit_depth: float = Field(ge=0.0, le=1.0)
+    min_dwell_sessions: int = Field(ge=0)
+
+
 class AbsoluteTrendInput(DecisionInput):
     enabled: bool
     lookback_days: int
     risk_off_multiplier: float
-    risk_off_ramp_width: float = Field(default=0.0, ge=0.0, le=1.0)
+    policy: AbsoluteTrendPolicyInput
 
 
 class ExecutionConstraints(DecisionInput):
@@ -192,7 +198,7 @@ def validate_target_weight_response(
     try:
         output = TargetWeightDecisionOutput.model_validate(response.output)
     except ValueError as exc:
-        raise ExternalDecisionError(
+        raise ExternalDecisionRejection(
             "target weight policy returned invalid adjustments"
         ) from exc
 
@@ -206,7 +212,7 @@ def validate_target_weight_response(
             differences.append(f"missing={','.join(missing)}")
         if unknown:
             differences.append(f"unknown={','.join(unknown)}")
-        raise ExternalDecisionError(
+        raise ExternalDecisionRejection(
             "target weight policy response symbols do not match configuration"
             + (f" ({'; '.join(differences)})" if differences else "")
         )
@@ -215,7 +221,7 @@ def validate_target_weight_response(
         multiplier = adjustment.multiplier
         limits = policy.symbols[symbol]
         if multiplier < limits.min_multiplier or multiplier > limits.max_multiplier:
-            raise ExternalDecisionError(
+            raise ExternalDecisionRejection(
                 f"target weight policy multiplier for {symbol} is outside "
                 "configured bounds"
             )
@@ -244,7 +250,7 @@ def apply_target_weight_adjustments(
         baseline_weight = effective_weights[symbol]
         raw_weight = baseline_weight * adjustment.multiplier
         if not math.isfinite(raw_weight) or raw_weight < 0:
-            raise ExternalDecisionError(
+            raise ExternalDecisionRejection(
                 f"target weight policy produced an invalid weight for {symbol}"
             )
         limits = policy.symbols[symbol]
@@ -261,13 +267,13 @@ def apply_target_weight_adjustments(
             minimum = max(minimum, volatility_minimum)
             maximum = min(maximum, volatility_maximum)
         if minimum > maximum:
-            raise ExternalDecisionError(
+            raise ExternalDecisionRejection(
                 f"target weight policy for {symbol} has target bounds that "
                 "do not overlap volatility bounds"
             )
         effective_weight = max(minimum, min(raw_weight, maximum))
         if effective_weight > 1:
-            raise ExternalDecisionError(
+            raise ExternalDecisionRejection(
                 f"target weight policy produced an invalid weight for {symbol}"
             )
         adjusted_weights[symbol] = effective_weight
@@ -280,7 +286,7 @@ def apply_target_weight_adjustments(
         sum(adjusted_weights.values())
         > target_weight_policy_total_limit(effective_weights, policy) + eps
     ):
-        raise ExternalDecisionError(
+        raise ExternalDecisionRejection(
             "target weight policy exceeds the permitted total weight"
         )
     return adjusted_weights, details


### PR DESCRIPTION
## Summary

The absolute-trend target modifier had an implicit exit rule: leave risk-off as
soon as the close recovered above the lower of the moving average and the
momentum reference close, optionally softened by a `risk_off_ramp_width`
interpolation. That rule could not express hysteresis, its ramp mixed a
risk-depth ramp into what is really a state decision, and the only record of it
was the resulting multiplier, so boundary chatter had to be inferred from trade
counts. Separately, any external-decision failure — including a provider that
answered with garbage or refused the host's configuration — degraded to
`on_error = "baseline"`, which silently trades on a decision the host rejected.

This branch makes the entry/exit rule an explicit policy object, persists and
versions the risk state it needs to resume, publishes the policy to external
decision providers, and gives provider rejections their own alerted hard-failure
path.

## User Impact

- `absolute_trend.policy = {mode, exit_depth, min_dwell_sessions}` defaults to
  `cliff`, which reproduces the old step reduction exactly. `deadband` is opt-in
  and holds risk-off until the close clears `exit_depth` above the entry
  threshold and the state has lasted `min_dwell_sessions` sessions.
- `risk_off_ramp_width` is gone. A config that still sets it now fails
  validation instead of being ignored, and cliff mode rejects hysteresis
  parameters rather than silently dropping them.
- Providers see the resolved policy in the request and can fail loudly when the
  host's rule is not the rule the model was built for, instead of sizing on a
  rule it never saw.
- A provider rejection (nonzero exit, unparsable or malformed response,
  out-of-bounds multiplier, refused targets, unconfigured provider) now logs an
  ALERT and aborts planning. Only genuine unavailability (cannot start, timeout,
  oversized response, stale or expired signal, host history failure) still
  degrades to post-volatility baseline targets.
- `absolute_trend_state` records the raw shortfall, `state_transition`,
  `within_band_drift`, `sessions_in_state`, `previous_state`, the active mode and
  parameters, and `state_reset_reason`, so a deadband claim can be checked
  against a matched A/B rather than inferred from trade counts, and a state read
  failure cannot hide inside those counts.
- An unreadable persisted risk state no longer silently releases a
  hysteresis-held risk-off: deadband mode aborts planning, cliff mode
  re-resolves from the entry rule and says so in the event.

## Root Cause

The exit rule lived as an implicit branch inside `_AbsoluteTrendSignal`: risk-off
was re-derived from closes each session, so the modifier had no memory and no way
to express asymmetric exit depth or a minimum dwell. The optional ramp papered
over the missing hysteresis with a continuous multiplier, and the external
decision layer treated every failure mode as one class, so a provider rejection
and a provider timeout both ended in baseline sizing.

Carrying memory introduced a second failure mode: a persisted record that exists
but cannot be read was treated as a cold start, which in deadband mode released
risk-off, reset the dwell counter, and emitted telemetry indistinguishable from
a genuine first run. The record shape also had no version, so every deployment
would have hit that on the first session after upgrade, and again on any
mixed-version rollout, with no way for the host to tell "no record" from
"unreadable record".

## Fix

- `SymbolConfig.AbsoluteTrendPolicy` (`mode`, `exit_depth`,
  `min_dwell_sessions`) with cross-field validation, and `AbsoluteTrend.policy`
  replacing `risk_off_ramp_width`; `extra="forbid"` so deleted keys fail loudly.
- `_AbsoluteTrendPolicy` / `_AbsoluteTrendState` in the regime engine resolve the
  session state from the persisted record plus the policy: cliff exits on the
  entry rule, deadband requires `threshold * (1 + exit_depth)` and at least
  `min_dwell_sessions` completed sessions in the state. Same-session replans
  republish the persisted record verbatim, so dwell and transition labels cannot
  drift.
- The `absolute_trend_state` event is versioned with a payload `state_version`
  and stores the per-symbol risk state needed to resume hysteresis. A record
  from an older version is salvaged by its recorded risk state and reported as
  `legacy_payload`: the state survives, the dwell counter and transition labels
  restart, and nothing is released. A record claiming the current version that
  is still unreadable is `invalid_persisted_state` or `unsupported_state_version`;
  deadband mode aborts on it, cliff mode resets from the entry rule. Cold starts
  and clean reads report `null`, so absent and unusable stay distinguishable, and
  the no-history path salvages legacy records too instead of aborting.
- `ExternalDecisionRejection` subclasses `ExternalDecisionError` and is raised
  wherever a provider answered but the answer is unacceptable; both decision
  paths alert and abort on it before their broad handlers, and
  `validate_tail_harvest_response` now raises it for malformed output.
- Docs, `thetagang.toml` comments, the published request schema, and the example
  request updated to the new contract.

## Validation

- `uv run pytest` — 783 passed.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check` — clean.
- `python -m thetagang.decision_check check` against the example request, with
  the reference provider given a matching and a mismatching expected policy
  (exit 0 / exit 1 with the mismatch reason).
- A slow-grind A/B over a 16-session series oscillating around the entry
  threshold: cliff reported 15 transitions and 0 drift sessions; deadband with
  `exit_depth = 0.02` reported 0 transitions and 8 drift sessions.
- State-recovery cases pinned by test: a legacy record on a deadband symbol whose
  close sits inside the exit band stays risk-off with `state_reset_reason`
  `legacy_payload` (and keeps that reason across a same-session replan); a
  corrupt current-version record aborts in deadband mode and resets with a
  recorded reason in cliff mode; a cold start reports `null`.
- Review-driven fixes were each proven discriminating by re-running their tests
  against the pre-fix behavior: flat harvest policy (provider exited 1 on every
  harvest request), malformed harvest output (all three `on_error` values either
  harvested or declined instead of aborting), the dwell off-by-one that made
  `min_dwell_sessions = 2` behave exactly like a cliff, and the unreadable-record
  reset that released a hysteresis-held risk-off.
