### PR TITLE
feat(config): load config values from environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,5 @@ cython_debug/
 *.ipynb
 
 # Ignore local db for testing
+/thetagang.db
 data/thetagang.db

--- a/README.md
+++ b/README.md
@@ -452,11 +452,16 @@ much, consider [running ThetaGang with Docker](#running-with-docker).
 curl -Lq https://raw.githubusercontent.com/brndnmtthws/thetagang/main/thetagang.toml -o ./thetagang.toml
 ```
 
-At a minimum, update:
 - `account.number`
 - `ibc.userid` and `ibc.password`
 - `ibc.tradingMode = "paper"`
 - your `symbols.<SYMBOL>.weight` allocations
+
+Secrets don't need to live in the file: any config string supports `$VAR`,
+`${VAR}`, and `${VAR:-default}` from the environment (e.g.
+`password = "${IBKR_PASSWORD}"`), which is handy for `ibc.userid`,
+`ibc.password`, and `account.number`. Unset variables without a default abort
+startup with an error naming the variable.
 
 If you're running locally (not Docker), update the Docker defaults:
 - `ibc.ibcIni` should point to your local `config.ini`

--- a/tests/test_config_new.py
+++ b/tests/test_config_new.py
@@ -9,6 +9,7 @@ from thetagang.config import (
     Config,
     RebalanceMode,
     config_deprecation_warnings,
+    expand_env_vars_in_config_doc,
     stage_enabled_map,
     stage_enabled_map_from_run,
 )
@@ -1248,3 +1249,57 @@ def test_v2_rejects_transitional_infrastructure_key() -> None:
                 },
             }
         )
+
+
+def test_env_expansion_resolves_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("IBKR_USERID", "someuser")
+    monkeypatch.setenv("IBKR_PASSWORD", "s3cret")
+    doc = {
+        "runtime": {
+            "account": {"number": "$IBKR_ACCOUNT"},
+            "ibc": {"userid": "${IBKR_USERID}", "password": "${IBKR_PASSWORD}"},
+        }
+    }
+    monkeypatch.setenv("IBKR_ACCOUNT", "DU1234567")
+    assert expand_env_vars_in_config_doc(doc) == {
+        "runtime": {
+            "account": {"number": "DU1234567"},
+            "ibc": {"userid": "someuser", "password": "s3cret"},
+        }
+    }
+
+
+def test_env_expansion_supports_defaults_and_escapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("THETAGANG_MISSING_SECRET", raising=False)
+    doc = {
+        "a": "${THETAGANG_MISSING_SECRET:-fallback}",
+        "b": "costs $$5",
+        "c": ["${THETAGANG_MISSING_SECRET:-x}", 42, True],
+    }
+    assert expand_env_vars_in_config_doc(doc) == {
+        "a": "fallback",
+        "b": "costs $5",
+        "c": ["x", 42, True],
+    }
+
+
+def test_env_expansion_rejects_unset_without_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("THETAGANG_MISSING_SECRET", raising=False)
+    with pytest.raises(ValueError, match="THETAGANG_MISSING_SECRET"):
+        expand_env_vars_in_config_doc({"password": "${THETAGANG_MISSING_SECRET}"})
+
+
+def test_env_expansion_leaves_plain_values_untouched() -> None:
+    doc = {"number": "DU1234567", "port": 7497, "enabled": True, "tags": ["a", "b"]}
+    assert expand_env_vars_in_config_doc(doc) == {
+        "number": "DU1234567",
+        "port": 7497,
+        "enabled": True,
+        "tags": ["a", "b"],
+    }

--- a/thetagang.toml
+++ b/thetagang.toml
@@ -181,6 +181,11 @@ tradingMode = 'paper'
 RaiseRequestErrors = false
 password           = 'demo'
 userid             = 'demo'
+# Secrets can be loaded from the environment instead of hardcoding them here.
+# Any config string supports `$VAR`, `${VAR}`, and `${VAR:-default}` (use
+# `$$` for a literal `$`), e.g. `password = "${IBKR_PASSWORD}"`. Unset
+# variables without a default fail fast at startup. This also works for
+# `runtime.account.number` and `runtime.database.url`.
 # Change this to point to your config.ini for IBC
 ibcIni = '/etc/thetagang/config.ini'
 # Change or unset this to use something other than the Docker bundled OpenJDK.

--- a/thetagang/config.py
+++ b/thetagang/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+import os
+import re
 from collections import defaultdict
 from collections.abc import Mapping
 from enum import Enum
@@ -1084,3 +1086,68 @@ def config_deprecation_warnings(config_doc: Mapping[str, Any]) -> list[str]:
     if "shares_only" not in regime_rebalance:
         return []
     return [SHARES_ONLY_DEPRECATION_MESSAGE]
+
+
+_ENV_VAR_PATTERN = re.compile(r"\$\$|\$(\w+)|\$\{([^}]+)\}")
+
+
+def _expand_env_vars_in_string(value: str, path: str) -> str:
+    """Expand `$VAR`, `${VAR}`, and `${VAR:-default}` references in one value."""
+
+    def replace(match: re.Match[str]) -> str:
+        if match.group(0) == "$$":
+            return "$"
+        name = match.group(1)
+        default = ""
+        has_default = False
+        braced = match.group(2)
+        if braced is not None:
+            name, sep, default = braced.partition(":-")
+            name = name.strip()
+            has_default = bool(sep)
+            if not name:
+                raise ValueError(
+                    f"Config value at '{path}' has an empty environment "
+                    "variable reference"
+                )
+            if has_default and not default:
+                raise ValueError(
+                    f"Config value at '{path}' has an empty default for "
+                    f"environment variable '{name}'"
+                )
+        if name in os.environ:
+            return os.environ[name]
+        if has_default:
+            return default
+        raise ValueError(
+            f"Config value at '{path}' references unset environment "
+            f"variable '{name}' (no default provided)"
+        )
+
+    return _ENV_VAR_PATTERN.sub(replace, value)
+
+
+def expand_env_vars_in_config_doc(config_doc: dict[str, Any]) -> dict[str, Any]:
+    """Expand env var references in every string in a parsed config document.
+
+    Supports `$VAR`, `${VAR}`, and `${VAR:-default}`; `$$` is a literal `$`.
+    Unset variables without a default raise `ValueError` naming the variable,
+    so misconfigured secrets fail fast instead of authenticating as `"${...}"`.
+    The document is mutated in place and returned for call-site convenience.
+    """
+
+    def walk(node: Any, path: str) -> Any:
+        if isinstance(node, str):
+            return _expand_env_vars_in_string(node, path or "<root>")
+        if isinstance(node, dict):
+            for key, child in node.items():
+                node[key] = walk(child, f"{path}.{key}" if path else str(key))
+            return node
+        if isinstance(node, list):
+            for index, child in enumerate(node):
+                node[index] = walk(child, f"{path}[{index}]")
+            return node
+        return node
+
+    walk(config_doc, "")
+    return config_doc

--- a/thetagang/thetagang.py
+++ b/thetagang/thetagang.py
@@ -13,6 +13,7 @@ from thetagang.config import (
     Config,
     config_deprecation_warnings,
     enabled_stage_ids_from_run,
+    expand_env_vars_in_config_doc,
     stage_enabled_map,
 )
 from thetagang.config_migration.startup_migration import (
@@ -77,11 +78,10 @@ def start(
                 "Config already uses schema v2. Exiting because --migrate-config was set."
             )
         return
-
     config_doc = tomlkit.parse(raw_config).unwrap()
     for warning in config_deprecation_warnings(config_doc):
         log.warning(warning)
-    config = Config(**config_doc)
+    config = Config(**expand_env_vars_in_config_doc(config_doc))
     run_stage_flags = stage_enabled_map(config)
     run_stage_order = enabled_stage_ids_from_run(config.run)
 


### PR DESCRIPTION
## Summary

Config strings now support environment variable references (`$VAR`, `${VAR}`, `${VAR:-default}`, with `$$` as a literal `$`), so secrets like `runtime.ibc.userid`, `runtime.ibc.password`, and `runtime.account.number` no longer need to live in `thetagang.toml`. Expansion runs on the parsed config document at startup, before pydantic validation; unset variables without a default fail fast with a `ValueError` naming the variable and config path.

## User Impact

Operators can keep credentials out of the config file, which is convenient for Docker/cron deployments:

```toml
password = "${IBKR_PASSWORD}"
```

Previously the only option was hardcoding secrets in TOML.

## Root Cause

N/A (new feature). Design notes: expansion applies to the parsed document, never the raw TOML text, so `Run.config_text` in the database keeps `${VAR}` placeholders rather than resolved secrets. Migration preview redaction (`startup_migration.py`) already covers the secret paths and is unaffected.

## Fix

- `thetagang/config.py`: new `expand_env_vars_in_config_doc()` (+ helper), single-pass walk over dicts/lists/strings.
- `thetagang/thetagang.py`: `start()` expands the parsed doc before `Config(**doc)`.
- `thetagang.toml` / `README.md`: document the syntax.
- `.gitignore`: ignore stray root-level `thetagang.db`.
- `tests/test_config_new.py`: 4 tests (resolution, defaults/escapes/lists, unset rejection, plain-value no-op).

## Validation

- `uv run pytest`: 787 passed.
- `uv run ruff check .`, `uv run ruff format --check .` (94 files), `uv run ty check`: all clean.
- End-to-end smoke through `tomlkit.parse → expand → Config(**doc)`, including a `$` inside a secret value (preserved verbatim).
